### PR TITLE
Remove '-pvc' from deployment charts

### DIFF
--- a/charts/buckets/charts/api/templates/deployment.yaml
+++ b/charts/buckets/charts/api/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "api.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "api.fullname" . }}-pvc
+          claimName: {{ include "api.fullname" . }}
       {{- else }}
       - name: {{ include "api.name" . }}-vol
         emptyDir: {}

--- a/charts/gameengine/templates/deployment.yaml
+++ b/charts/gameengine/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "gameengine.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "gameengine.fullname" . }}-pvc
+          claimName: {{ include "gameengine.fullname" . }}
       {{- else }}
       - name: {{ include "gameengine.name" . }}-vol
         emptyDir: {}

--- a/charts/identity-api/templates/deployment.yaml
+++ b/charts/identity-api/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "identity-api.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "identity-api.fullname" . }}-pvc
+          claimName: {{ include "identity-api.fullname" . }}
       {{- else }}
       - name: {{ include "identity-api.name" . }}-vol
         emptyDir: {}

--- a/charts/market/charts/orders/templates/deployment.yaml
+++ b/charts/market/charts/orders/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "orders.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "orders.fullname" . }}-pvc
+          claimName: {{ include "orders.fullname" . }}
       {{- else }}
       - name: {{ include "orders.name" . }}-vol
         emptyDir: {}

--- a/charts/staticweb/templates/deployment.yaml
+++ b/charts/staticweb/templates/deployment.yaml
@@ -98,7 +98,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "staticweb.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "staticweb.fullname" . }}-pvc
+          claimName: {{ include "staticweb.fullname" . }}
       {{- else }}
       - name: {{ include "staticweb.name" . }}-vol
         emptyDir: {}

--- a/charts/topomojo-api/templates/deployment.yaml
+++ b/charts/topomojo-api/templates/deployment.yaml
@@ -86,7 +86,7 @@ spec:
       {{- else if .Values.storage.size }}
       - name: {{ include "topomojo-api.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ include "topomojo-api.fullname" . }}-pvc
+          claimName: {{ include "topomojo-api.fullname" . }}
       {{- else }}
       - name: {{ include "topomojo-api.name" . }}-vol
         emptyDir: {}


### PR DESCRIPTION
Fixes mismatch between pvc and deployment resources for a few charts.