### PR TITLE
Simplify gameboard ingress with subdirectory basehref

### DIFF
--- a/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard-ui/templates/configmap.yaml
+++ b/charts/gameboard-ui/templates/configmap.yaml
@@ -11,10 +11,14 @@ data:
 
   customize.sh: |
     #!/bin/sh
-    index=/var/www/index.html
+    set -e
+    src=/var/www
 {{- if .Values.basehref }}
-    basehref={{ .Values.basehref }}
-    sed -i "s,base\ href=\"/\",base\ href=\"$basehref\"," $index
+    basehref=`echo {{ .Values.basehref }} | sed -e s,^/,, -e s,/$,,`
+    sed -i "s,base\ href=\"/\",base\ href=\"/$basehref/\"," $src/index.html
+    dst=$src/$basehref
+    mkdir -p `dirname $dst`
+    ln -s $src $dst
 {{- end}}
 
 {{- if .Values.openGraph }}

--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -27,5 +27,5 @@ dependencies:
   version: "0.1.1"
   repository: https://helm.cyberforce.site/charts
 - name: gameboard-ui
-  version: "0.1.1"
+  version: "0.1.2"
   repository: https://helm.cyberforce.site/charts


### PR DESCRIPTION
When running Gameboard out of a subdirectory, `use-regex` was required on the UI ingress. This fix removes that requirement.