### PR TITLE
improve Mattermost chart

### DIFF
--- a/charts/mattermost-team-edition/Chart.yaml
+++ b/charts/mattermost-team-edition/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: Mattermost Team Edition server.
 name: mattermost-team-edition
-version: 3.12.2
-appVersion: 5.24.2
+version: 3.13.0
+appVersion: 5.25.7
 keywords:
 - mattermost
 - communication

--- a/charts/mattermost-team-edition/templates/deployment.yaml
+++ b/charts/mattermost-team-edition/templates/deployment.yaml
@@ -38,6 +38,19 @@ spec:
         imagePullPolicy: {{ .Values.initContainerImage.imagePullPolicy }}
         command: ["sh", "-c", "until curl --max-time 10 http://{{ .Release.Name }}-mysql:3306; do echo waiting for {{ .Release.Name }}-mysql; sleep 5; done;"]
       {{- end }}
+      {{ if .Values.persistence.config.enabled }}
+      - name: "init-config"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        command: ["sh", "-c", "if [ ! -e config/config.json ]; then cp config.json config/; fi"]
+        volumeMounts:
+        - mountPath: /mattermost/config.json
+          name: config-json
+          subPath: config.json
+        - mountPath: /mattermost/config
+          name: mattermost-data
+          subPath: {{ include "mattermost-team-edition.fullname" . }}/config
+      {{- end }}
       {{- if .Values.extraInitContainers }}
       {{- .Values.extraInitContainers | toYaml | nindent 6 }}
       {{- end }}
@@ -74,16 +87,21 @@ spec:
         - mountPath: /mattermost/bin/mattermost-custom-start
           name: config-entry
           subPath: entryscript
-        - mountPath: /mattermost/config/config.json
+        {{ if .Values.persistence.config.enabled }}
+        - mountPath: /mattermost/config
+          name: mattermost-data
+          subPath: {{ include "mattermost-team-edition.fullname" . }}/config
+        {{- else }}
+         - mountPath: /mattermost/config/config.json
           name: config-json
           subPath: config.json
+        {{- end }}
         - mountPath: /mattermost/data
           name: mattermost-data
-          subPath: mattermost
-        # - mountPath: /mattermost/data
-        #   name: mattermost-data
-        # - mountPath: /mattermost/{{ trimPrefix "./" .Values.configJSON.PluginSettings.Directory }}
-        #   name: mattermost-data
+          subPath: {{ include "mattermost-team-edition.fullname" . }}/data
+        - mountPath: /mattermost/{{ trimPrefix "./" .Values.configJSON.PluginSettings.Directory }}
+          name: mattermost-data
+          subPath: {{ include "mattermost-team-edition.fullname" . }}/plugins
         {{- if .Values.extraVolumeMounts -}}
         {{ .Values.extraVolumeMounts | toYaml | nindent 8 }}
         {{- end }}
@@ -107,14 +125,25 @@ spec:
       {{ else }}
         emptyDir: {}
       {{ end }}
-      # - name: mattermost-plugins
-      # {{ if .Values.persistence.plugins.enabled }}
-      #   persistentVolumeClaim:
-      #     {{ if .Values.persistence.plugins.existingClaim }}
-      #     claimName: {{.Values.persistence.plugins.existingClaim }}
-      #     {{ else }}
-      #     claimName: {{ default (include "mattermost-team-edition.fullname" .) }}-plugins
-      #     {{ end }}
-      # {{ else }}
-      #   emptyDir: {}
-      # {{ end }}
+      - name: mattermost-plugins
+      {{ if .Values.persistence.plugins.enabled }}
+        persistentVolumeClaim:
+          {{ if .Values.persistence.plugins.existingClaim }}
+          claimName: {{.Values.persistence.plugins.existingClaim }}
+          {{ else }}
+          claimName: {{ default (include "mattermost-team-edition.fullname" .) }}-plugins
+          {{ end }}
+      {{ else }}
+        emptyDir: {}
+      {{ end }}
+      - name: mattermost-config
+      {{ if .Values.persistence.config.enabled }}
+        persistentVolumeClaim:
+          {{ if .Values.persistence.config.existingClaim }}
+          claimName: {{.Values.persistence.config.existingClaim }}
+          {{ else }}
+          claimName: {{ default (include "mattermost-team-edition.fullname" .) }}-config
+          {{ end }}
+      {{ else }}
+        emptyDir: {}
+      {{ end }}

--- a/charts/mattermost-team-edition/templates/ingress.yaml
+++ b/charts/mattermost-team-edition/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{ $ingress := .Values.ingress }}
 {{ if $ingress.enabled }}
-{{ $serviceName := include "mattermost-team-edition.name" . }}
+{{ $serviceName := include "mattermost-team-edition.fullname" . }}
 {{ $servicePort := .Values.service.externalPort }}
 apiVersion: {{ include "mattermost-team-edition.ingress.apiVersion" . }}
 kind: Ingress

--- a/charts/mattermost-team-edition/templates/service.yaml
+++ b/charts/mattermost-team-edition/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
-  name: {{ include "mattermost-team-edition.name" . }}
+  name: {{ include "mattermost-team-edition.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "mattermost-team-edition.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -41,7 +41,7 @@ persistence:
   # existingClaim: ""
   ## If persist config is enabled, the initial config.json is copied into a 
   config:
-    enabled: true
+    enabled: false
     size: 1Gi
     # storageClass:
     accessMode: ReadWriteOnce

--- a/charts/mattermost-team-edition/values.yaml
+++ b/charts/mattermost-team-edition/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: mattermost/mattermost-team-edition
-  tag: 5.24.2
+  # tag: 5.25.7
   imagePullPolicy: IfNotPresent
 
 initContainerImage:
@@ -39,7 +39,14 @@ persistence:
     # storageClass:
     accessMode: ReadWriteOnce
   # existingClaim: ""
-
+  ## If persist config is enabled, the initial config.json is copied into a 
+  config:
+    enabled: true
+    size: 1Gi
+    # storageClass:
+    accessMode: ReadWriteOnce
+    # existingClaim: ""
+    
 service:
   type: ClusterIP
   externalPort: 8065


### PR DESCRIPTION
Added settings to deploy with persisted config.json.  This mounts a volume to /mattermost/config so admins can change settings from the app dashboard.

Tweaked service and ingress to use full name, so multiple instances can be deployed in the same namespace.