### PR TITLE
clean migrations

### DIFF
--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: identity
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: 1.4.6

--- a/charts/identity/charts/identity-api/Chart.yaml
+++ b/charts/identity/charts/identity-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: identity-api
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: 1.4.6

--- a/charts/identity/charts/identity-api/templates/deployment.yaml
+++ b/charts/identity/charts/identity-api/templates/deployment.yaml
@@ -59,7 +59,9 @@ spec:
             - mountPath: /app/data
               name: {{ include "identity-api.name" . }}-vol
               subPath: {{ include "identity-api.fullname" . }}/data
+          {{- if .Values.health }}
           {{- toYaml .Values.health | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/identity/charts/identity-api/templates/deployment.yaml
+++ b/charts/identity/charts/identity-api/templates/deployment.yaml
@@ -29,12 +29,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        - name: "{{ .Chart.Name }}-init"
-          image: "groundnuty/k8s-wait-for:1.3"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args:
-            - "job"
-            - "{{ include "identity-api.fullname" . }}-{{ .Release.Revision}}"
+      {{- if .Values.migrations.enabled }}
+      - name: "{{ .Chart.Name }}-init"
+        image: "groundnuty/k8s-wait-for:v1.4"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - "job"
+        - "{{ include "identity-api.fullname" . }}-{{ .Release.Revision}}"
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -57,16 +59,7 @@ spec:
             - mountPath: /app/data
               name: {{ include "identity-api.name" . }}-vol
               subPath: {{ include "identity-api.fullname" . }}/data
-          # livenessProbe:
-          #   initialDelaySeconds: 30
-          #   httpGet:
-          #     path: /api/version
-          #     port: http
-          # readinessProbe:
-          #   initialDelaySeconds: 30
-          #   httpGet:
-          #     path: /api/version
-          #     port: http
+          {{- toYaml .Values.health | nindent 10 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/identity/charts/identity-api/templates/deployment.yaml
+++ b/charts/identity/charts/identity-api/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
       serviceAccountName: {{ include "identity-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: "{{ .Chart.Name }}-init"
+          image: "groundnuty/k8s-wait-for:1.3"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "job"
+            - "{{ include "identity-api.fullname" . }}-{{ .Release.Revision}}"
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/identity/charts/identity-api/templates/job.yaml
+++ b/charts/identity/charts/identity-api/templates/job.yaml
@@ -17,9 +17,9 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: DBONLY
-            value: migrateAndExit
+            value: "true"
           - name: APP_DBONLY
-            value: migrateAndExit
+            value: "true"
           - name: Database__ConnectionString
             value: {{ .Values.migrations.Database__ConnectionString | default .Values.env.Database__ConnectionString }}
           {{ range $k, $v := .Values.migrations.env }}

--- a/charts/identity/charts/identity-api/templates/job.yaml
+++ b/charts/identity/charts/identity-api/templates/job.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.migrations.enabled -}}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,3 +31,4 @@ spec:
             value: {{ $v | quote }}
           {{- end }}
       restartPolicy: {{ .Values.migrations.restartPolicy }}
+{{- end }}

--- a/charts/identity/charts/identity-api/templates/job.yaml
+++ b/charts/identity/charts/identity-api/templates/job.yaml
@@ -20,6 +20,8 @@ spec:
             value: "true"
           - name: APP_DBONLY
             value: "true"
+          - name: Database__Provider
+            value: {{ .Values.migrations.Database__Provider | default .Values.env.Database__Provider }}
           - name: Database__ConnectionString
             value: {{ .Values.migrations.Database__ConnectionString | default .Values.env.Database__ConnectionString }}
           {{ range $k, $v := .Values.migrations.env }}

--- a/charts/identity/charts/identity-api/templates/job.yaml
+++ b/charts/identity/charts/identity-api/templates/job.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "identity-api.fullname" . }}-{{ .Release.Revision }}
+  labels:
+    {{- include "identity-api.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        {{- include "identity-api.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        env:
+          - name: DBONLY
+            value: migrateAndExit
+          - name: APP_DBONLY
+            value: migrateAndExit
+          - name: Database__ConnectionString
+            value: {{ .Values.migrations.Database__ConnectionString | default .Values.env.Database__ConnectionString }}
+          {{ range $k, $v := .Values.migrations.env }}
+          - name: {{ $k | quote }}
+            value: {{ $v | quote }}
+          {{- end }}
+      restartPolicy: {{ .Values.migrations.restartPolicy }}

--- a/charts/identity/charts/identity-api/templates/serviceaccount.yaml
+++ b/charts/identity/charts/identity-api/templates/serviceaccount.yaml
@@ -9,4 +9,36 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "identity-api.serviceAccountName" . }}
+  labels:
+    {{- include "identity-api.labels" . | nindent 4 }}
+  
+rules:
+  - apiGroups:
+      - 'batch'
+    resources:
+      - jobs
+    verbs:
+      - get
+  
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "identity-api.serviceAccountName" . }}
+  labels:
+    {{- include "identity-api.labels" . | nindent 4 }}
+  
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "identity-api.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "identity-api.serviceAccountName" . }}
 {{- end }}

--- a/charts/identity/charts/identity-api/values.yaml
+++ b/charts/identity/charts/identity-api/values.yaml
@@ -121,3 +121,8 @@ conf:
   trouble: ""
   seed: ""
   signer: ""
+
+migrations:
+  restartPolicy: Never
+  Database__ConnectionString: ""
+  env: {}

--- a/charts/identity/charts/identity-api/values.yaml
+++ b/charts/identity/charts/identity-api/values.yaml
@@ -124,5 +124,6 @@ conf:
 
 migrations:
   restartPolicy: Never
+  Database__Provider: ""
   Database__ConnectionString: ""
   env: {}

--- a/charts/identity/charts/identity-api/values.yaml
+++ b/charts/identity/charts/identity-api/values.yaml
@@ -16,6 +16,8 @@ fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
+  ## If true, also create a Role to support `migrations` (described below)
+  ## and a RoleBinding for the new serviceAccount
   create: false
   # Annotations to add to the service account
   annotations: {}
@@ -47,11 +49,25 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: ["/api"]
+      paths: ["/"]
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+health: {}
+  # livenessProbe:
+  #   initialDelaySeconds: 10
+  #   httpGet:
+  #     path: /api/version
+  #     port: http
+  # startupProbe:
+  #   initialDelaySeconds: 30
+  #   httpGet:
+  #     path: /api/version
+  #     port: http
+  #   failureThreshold: 9
+  #   periodSeconds: 10
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -84,6 +100,21 @@ storage:
   size: ""
   mode: ReadWriteOnce
   class: default
+
+## migrations sets how data migrations run
+## If enabled, all replicas will wait until a single migration job runs.
+## this is important if running multiple replicas or if you use different
+## connection strings (permissions) for building the database versus using it.
+## If using a single connection string, no need to specify here. It will use values
+## from `env` below.
+## NOTE: the serviceAccount must have permission to `get batch.jobs`.
+## If you create the serviceAccount above, it will get a RoleBinding to a Role with that allowed.
+migrations:
+  enabled: false
+  restartPolicy: Never
+  Database__Provider: ""
+  Database__ConnectionString: ""
+  env: {}
 
 # Config app settings with environment vars.
 # Those most likely needing values are listed. For others,
@@ -121,9 +152,3 @@ conf:
   trouble: ""
   seed: ""
   signer: ""
-
-migrations:
-  restartPolicy: Never
-  Database__Provider: ""
-  Database__ConnectionString: ""
-  env: {}

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -14,6 +14,8 @@ identity-api:
 
   serviceAccount:
     # Specifies whether a service account should be created
+    ## If true, also create a Role to support `migrations` (described below)
+    ## and a RoleBinding for the new serviceAccount
     create: false
     # Annotations to add to the service account
     annotations: {}
@@ -45,11 +47,25 @@ identity-api:
       # kubernetes.io/tls-acme: "true"
     hosts:
       - host: chart-example.local
-        paths: ["/api"]
+        paths: ["/"]
     tls: []
     #  - secretName: chart-example-tls
     #    hosts:
     #      - chart-example.local
+
+  health: {}
+    # livenessProbe:
+    #   initialDelaySeconds: 10
+    #   httpGet:
+    #     path: /api/version
+    #     port: http
+    # startupProbe:
+    #   initialDelaySeconds: 30
+    #   httpGet:
+    #     path: /api/version
+    #     port: http
+    #   failureThreshold: 9
+    #   periodSeconds: 10
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -83,6 +99,21 @@ identity-api:
     mode: ReadWriteOnce
     class: default
 
+  ## migrations sets how data migrations run
+  ## If enabled, all replicas will wait until a single migration job runs.
+  ## this is important if running multiple replicas or if you use different
+  ## connection strings (permissions) for building the database versus using it.
+  ## If using a single connection string, no need to specify here. It will use values
+  ## from `env` below.
+  ## NOTE: the serviceAccount must have permission to `get batch.jobs`.
+  ## If you create the serviceAccount above, it will get a RoleBinding to a Role with that allowed.
+  migrations:
+    enabled: false
+    restartPolicy: Never
+    Database__Provider: ""
+    Database__ConnectionString: ""
+    env: {}
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/Identity/blob/master/src/IdentityServer/appsettings.conf
@@ -110,6 +141,7 @@ identity-api:
     Headers__Cors__Headers__0: ""
     Headers__Cors__AllowCredentials: false
     Headers__Forwarding__TargetHeaders: All
+
 
   conf:
     issuers: ""


### PR DESCRIPTION
Support running migrations when deploying multiple replicas and/or using different connection strings (permissions) for migrations and normal operations.

- The app's Program.cs looks for an `APP_DBONLY` env variable and, if found, exits after running migrations.
- The chart deploys a Job with the app image and that env variable
- The app replicas run an initContainer that waits for the job to complete
- When job completes, app runs normally (including running migrations, but shouldn't find any not already applied)

I was pleased to find that the approach I was considering was already [fleshed out by Andrew Lock](https://andrewlock.net/deploying-asp-net-core-applications-to-kubernetes-part-7-running-database-migrations-using-jobs-and-init-containers/), especially the use of `k8s-wait-for` image in the init container.

This approach requires serviceAccount permissions to `get batch.jobs` so the init container can see when the migrations job is complete.  If one elects in the values.yaml to `serviceAccount.create: true`, an appropriate Role and RoleBinding will be created.  (Which in turn requires the actor running helm has permission to create Roles and RoleBindings.)