### PR TITLE
Gameboard 3.1.0 update

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.0.4
+appVersion: 3.1.0

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.0.4
+appVersion: 3.1.0

--- a/charts/gameboard/charts/gameboard-api/templates/configmap.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "gameboard-api.labels" . | nindent 4 }}
 data:
+{{- if .Values.cacert }}
   ca-cert.crt: |
 {{ .Values.cacert | indent 4 }}
   start.sh: |
@@ -14,7 +15,7 @@ data:
     update-ca-certificates
     cd /app
     dotnet Gameboard.Api.dll
-
+{{- end }}
   job.sh: |-
     #!/bin/sh
 

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.0.4
+appVersion: 3.1.0


### PR DESCRIPTION
- Bump chart versions for `gameboard-api` and `-ui`.
- Fix gameboard-api configmap when `cacert:` value is not present.