### PR TITLE
Update Cubespace Server with additional args

### DIFF
--- a/charts/cubespace-server/Chart.yaml
+++ b/charts/cubespace-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/cubespace-server/templates/deployment.yaml
+++ b/charts/cubespace-server/templates/deployment.yaml
@@ -36,6 +36,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - "./StandaloneLinux64"
+            {{- if .Values.settings -}}
             {{- if .Values.settings.identityUri }}
             - "-identityURI"
             - "{{ .Values.settings.identityUri }}"
@@ -55,6 +56,13 @@ spec:
             {{- if .Values.settings.clientSecret }}
             - "-clientSecret"
             - "{{ .Values.settings.clientSecret }}"
+            {{- end }}
+            {{- if .Values.settings.debug }}
+            - "-debug"
+            {{- end }}
+            {{- if .Values.settings.dev }}
+            - "-dev"
+            {{- end }}
             {{- end }}
           ports:
             - name: http

--- a/charts/cubespace-server/values.yaml
+++ b/charts/cubespace-server/values.yaml
@@ -81,9 +81,11 @@ tolerations: []
 
 affinity: {}
 
-settings:
-  identityUri: https://chart-example.local/id/
-  gamebrainUri: https://chart-example.local/gamebrain/
-  uriBase: https://chart-example.local/id/
-  clientID: game-server
-  clientSecret: 01234567890abcdef123456789abcdef
+settings: {}
+  # identityUri: https://chart-example.local/id/
+  # gamebrainUri: https://chart-example.local/gamebrain/
+  # uriBase: https://chart-example.local/id/
+  # clientID: game-server
+  # clientSecret: 01234567890abcdef123456789abcdef
+  # debug: false
+  # dev: false


### PR DESCRIPTION
Adds `-debug` and `-dev` boolean arguments.

`settings:` values now commented instead of providing defaults via command line arguments.