### PR TITLE
Update Cubespace charts to use Docker Hub images

### DIFF
--- a/charts/cubespace-client/Chart.yaml
+++ b/charts/cubespace-client/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "1.0.1"

--- a/charts/cubespace-client/values.yaml
+++ b/charts/cubespace-client/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cmu-sei/cubespace-client
+  repository: cmusei/cubespace-client
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/cubespace-server/Chart.yaml
+++ b/charts/cubespace-server/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cubespace-server
-description: Cubespace headless server
+description: Cubespace dedicated server
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "1.0.1"

--- a/charts/cubespace-server/values.yaml
+++ b/charts/cubespace-server/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cmu-sei/cubespace-server
+  repository: cmusei/cubespace-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Updates `cubespace-[client|server]` to use publicly-available container images on Docker Hub.