### PR TITLE
Update Gamebrain to use public Docker image

### DIFF
--- a/charts/gamebrain/Chart.yaml
+++ b/charts/gamebrain/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "1.0.0"

--- a/charts/gamebrain/values.yaml
+++ b/charts/gamebrain/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cmu-sei/gamebrain
+  repository: cmusei/gamebrain
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Points Gamebrain chart to use newly released Docker Hub image:

https://hub.docker.com/r/cmusei/gamebrain