### PR TITLE
Add support for env in Gallery and Blueprint UI modules

### DIFF
--- a/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "blueprint-ui.fullname" . }}
+  labels:
+    {{- include "blueprint-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+{{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+{{- end }}

--- a/charts/gallery/charts/gallery-ui/templates/secret.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gallery-ui.fullname" . }}
+  labels:
+    {{- include "gallery-ui.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+{{- range $key, $val := .Values.env }}
+  {{ $key }}: {{ $val | quote }}
+{{- end }}


### PR DESCRIPTION
Gallery.UI and Blueprint.UI both have supposed support for the `APP_BASEHREF` environment variable. This patch imports the env configuration block as a secret to enable this feature as supported by other charts in this repository.

