### PR TITLE
Feature/crucible additional volumes

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 3.0.0

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: latest

--- a/charts/alloy/charts/alloy-ui/templates/_helpers.tpl
+++ b/charts/alloy/charts/alloy-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "alloy-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "alloy-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/alloy/charts/alloy-ui/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "alloy-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "alloy-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "alloy-ui.fullname" . }}-settings
           configMap:
             name: {{ include "alloy-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "alloy-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alloy/charts/alloy-ui/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "alloy-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "alloy-ui.fullname" . }}-settings
           configMap:
             name: {{ include "alloy-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -81,9 +81,25 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/alloy.ico
+#     subPath: alloy.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
 
-additionalVolumes: []
+extraVolumeMounts: ""
+
+extraVolumes: ""
 
 # env is pod env vars
 env: 

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 # env is pod env vars
 env: 
   ## basehref is path to the app

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -94,11 +94,25 @@ alloy-ui:
         hosts:
           - example.com
 
-  # Mount additional volumes in container
-  additionalVolumeMounts: []
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/alloy.ico
+  #     subPath: alloy.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
 
-  additionalVolumes: []
-
+  extraVolumeMounts: ""
+  
   env: 
     ## basehref is path to the app
     APP_BASEHREF: ""

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -1,7 +1,7 @@
 alloy-api:
   # Docker image release version
   image:
-    tag: '2.0.2'
+    tag: '3.4.3'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -75,7 +75,7 @@ alloy-api:
 alloy-ui:
   # Docker image release version
   image:
-    tag: '2.0.1'
+    tag: '3.2.6'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -93,6 +93,11 @@ alloy-ui:
       - secretName: ''
         hosts:
           - example.com
+
+  # Mount additional volumes in container
+  additionalVolumeMounts: []
+
+  additionalVolumes: []
 
   env: 
     ## basehref is path to the app

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.0.0

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.0.0

--- a/charts/blueprint/charts/blueprint-ui/templates/_helpers.tpl
+++ b/charts/blueprint/charts/blueprint-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "blueprint-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "blueprint-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/blueprint/charts/blueprint-ui/templates/deployment.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "blueprint-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "blueprint-ui.fullname" . }}-settings
           configMap:
             name: {{ include "blueprint-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/blueprint/charts/blueprint-ui/templates/deployment.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "blueprint-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "blueprint-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "blueprint-ui.fullname" . }}-settings
           configMap:
             name: {{ include "blueprint-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "blueprint-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -81,4 +81,8 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 settings: '{}'

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -81,8 +81,23 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the white ruler icon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+# 
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/pencil-ruler-white.png
+#     subPath: pencil-ruler-white.png
 
-additionalVolumes: []
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
+
+extraVolumeMounts: ""
 
 settings: '{}'

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -1,6 +1,6 @@
 blueprint-api:
   image:
-    tag: "1.0.0"
+    tag: "0.3.10"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -42,7 +42,7 @@ blueprint-api:
 blueprint-ui:
   # Docker image release version
   image:
-    tag: '1.0.0'
+    tag: '0.3.12'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -60,6 +60,11 @@ blueprint-ui:
       - secretName: ''
         hosts:
           - example.com
+
+  # Mount additional volumes into container
+  additionalVolumeMounts: []
+
+  additionalVolumes: []
 
   env:
   # Config app settings with a JSON file.

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -61,10 +61,24 @@ blueprint-ui:
         hosts:
           - example.com
 
-  # Mount additional volumes into container
-  additionalVolumeMounts: []
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the white ruler icon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/pencil-ruler-white.png
+  #     subPath: pencil-ruler-white.png
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
 
-  additionalVolumes: []
+  extraVolumeMounts: ""
 
   env:
   # Config app settings with a JSON file.

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: 3.3.0

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.2
+version: 1.4.3
 appVersion: latest

--- a/charts/caster/charts/caster-ui/templates/_helpers.tpl
+++ b/charts/caster/charts/caster-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "caster-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "caster-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/caster/charts/caster-ui/templates/deployment.yaml
+++ b/charts/caster/charts/caster-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "caster-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "caster-ui.fullname" . }}-settings
           configMap:
             name: {{ include "caster-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/caster/charts/caster-ui/templates/deployment.yaml
+++ b/charts/caster/charts/caster-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "caster-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "caster-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "caster-ui.fullname" . }}-settings
           configMap:
             name: {{ include "caster-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "caster-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -81,8 +81,24 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
-additionalVolumes: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/alloy.ico
+#     subPath: alloy.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
+
+extraVolumeMounts: ""
 
 env: 
   ## basehref is path to the app
@@ -102,3 +118,4 @@ env:
 #   },
 #   "UseLocalAuthStorage": true
 # }'
+settings: ""

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -81,6 +81,9 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+additionalVolumes: []
+
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -3,7 +3,7 @@ caster-api:
   # Docker image release version
   image:
     # Caster API version
-    tag: "2.1.0"
+    tag: "3.3.0"
   
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -199,7 +199,7 @@ caster-ui:
 
   # Docker image release version
   image:
-    tag: "2.1.0"
+    tag: "3.3.0"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -218,6 +218,11 @@ caster-ui:
         hosts:
          - example.com
 
+  # Mount additional files in container
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
+  
   env: 
     ## basehref is path to the app
     APP_BASEHREF: ""

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -218,10 +218,24 @@ caster-ui:
         hosts:
          - example.com
 
-  # Mount additional files in container
-  additionalVolumeMounts: []
-  
-  additionalVolumes: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/caster.ico
+  #     subPath: caster.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
+
+  extraVolumeMounts: ""
   
   env: 
     ## basehref is path to the app

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.0.0

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: latest

--- a/charts/cite/charts/cite-ui/templates/_helpers.tpl
+++ b/charts/cite/charts/cite-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "cite-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "cite-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/cite/charts/cite-ui/templates/deployment.yaml
+++ b/charts/cite/charts/cite-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "cite-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "cite-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "cite-ui.fullname" . }}-settings
           configMap:
             name: {{ include "cite-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "cite-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cite/charts/cite-ui/templates/deployment.yaml
+++ b/charts/cite/charts/cite-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "cite-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "cite-ui.fullname" . }}-settings
           configMap:
             name: {{ include "cite-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -80,10 +80,25 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+  
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the default dropdown indicator from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/svg-icons/ic_expand_more.svg
+#     subPath: ic_expand_more.svg
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
 
-additionalVolumeMounts: []
-
-additionalVolumes: []
+extraVolumeMounts: ""
 
 env:
   ## basehref is path to the app
@@ -111,3 +126,4 @@ env:
 #     "DefaultEvaluationId": "",
 #     "DefaultTeamId": ""
 # }
+settings: ""

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -80,10 +80,24 @@ cite-ui:
         hosts:
           - example.com
   
-  # Mount additional volumes into container
-  additionalVolumeMounts: []
-  
-  additionalVolumes: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the default dropdown indicator from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/svg-icons/ic_expand_more.svg
+  #     subPath: ic_expand_more.svg
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
+
+  extraVolumeMounts: ""   
 
   env:
     ## basehref is path to the app

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -1,7 +1,7 @@
 cite-api:
   # Docker image release version
   image:
-    tag: '1.0.0'
+    tag: '1.3.1'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -61,7 +61,7 @@ cite-api:
 cite-ui:
   # Docker image release version
   image:
-    tag: '1.0.0'
+    tag: '1.3.5'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -79,6 +79,11 @@ cite-ui:
       - secretName: ''
         hosts:
           - example.com
+  
+  # Mount additional volumes into container
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
 
   env:
     ## basehref is path to the app

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.0.0

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.0.0

--- a/charts/gallery/charts/gallery-ui/templates/_helpers.tpl
+++ b/charts/gallery/charts/gallery-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "gallery-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "gallery-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/gallery/charts/gallery-ui/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "gallery-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "gallery-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "gallery-ui.fullname" . }}-settings
           configMap:
             name: {{ include "gallery-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "gallery-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/gallery/charts/gallery-ui/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "gallery-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "gallery-ui.fullname" . }}-settings
           configMap:
             name: {{ include "gallery-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -81,4 +81,8 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 settings: '{}'

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -81,8 +81,23 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the dropdown indicator from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/svg-icons/ic_expand_more.svg
+#     subPath: ic_expand_more.svg
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
 
-additionalVolumes: []
+extraVolumeMounts: ""
 
 settings: '{}'

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -1,6 +1,6 @@
 gallery-api:
   image:
-    tag: "1.0.0"
+    tag: "1.5.1"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -42,7 +42,7 @@ gallery-api:
 gallery-ui:
   # Docker image release version
   image:
-    tag: '1.0.0'
+    tag: '1.5.2'
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -60,6 +60,11 @@ gallery-ui:
       - secretName: ''
         hosts:
           - example.com
+
+  # Mount additional volumes into container
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
 
   env: 
   # Config app settings with a JSON file.

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -61,10 +61,24 @@ gallery-ui:
         hosts:
           - example.com
 
-  # Mount additional volumes into container
-  additionalVolumeMounts: []
-  
-  additionalVolumes: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the dropdown indicator from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/svg-icons/ic_expand_more.svg
+  #     subPath: ic_expand_more.svg
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
+
+  extraVolumeMounts: ""
 
   env: 
   # Config app settings with a JSON file.

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: 3.2.2

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: console-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: latest

--- a/charts/player/charts/console-ui/templates/_helpers.tpl
+++ b/charts/player/charts/console-ui/templates/_helpers.tpl
@@ -60,3 +60,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+```handlebars
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "console-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "console-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/player/charts/console-ui/templates/deployment.yaml
+++ b/charts/player/charts/console-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "console-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "console-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "console-ui.fullname" . }}-settings
           configMap:
             name: {{ include "console-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "console-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/console-ui/templates/deployment.yaml
+++ b/charts/player/charts/console-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "console-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "console-ui.fullname" . }}-settings
           configMap:
             name: {{ include "console-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -81,9 +81,24 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/player.ico
+#     subPath: player.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
 
-additionalVolumes: []
+extraVolumeMounts: ""
 
 env: 
   ## basehref is path to the app

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: latest

--- a/charts/player/charts/player-ui/templates/_helpers.tpl
+++ b/charts/player/charts/player-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "player-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "player-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/player/charts/player-ui/templates/deployment.yaml
+++ b/charts/player/charts/player-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "player-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "player-ui.fullname" . }}-settings
           configMap:
             name: {{ include "player-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/player-ui/templates/deployment.yaml
+++ b/charts/player/charts/player-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "player-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "player-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "player-ui.fullname" . }}-settings
           configMap:
             name: {{ include "player-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "player-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -81,34 +81,49 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/player.ico
+#     subPath: player.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
 
-additionalVolumes: []
+extraVolumeMounts: ""
 
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-# settings: |-
-#   {
-#     "ApiUrl": "https://example.com/player",
-#     "OIDCSettings": {
-#       "authority": "https://example.com/identity",
-#       "client_id": "player-ui",
-#       "redirect_uri": "https://example.com/player/auth-callback",
-#       "post_logout_redirect_uri": "https://example.com/player",
-#       "response_type": "code",
-#       "scope": "openid profile player-api",
-#       "automaticSilentRenew": true,
-#       "silent_redirect_uri": "https://example.com/player/auth-callback-silent"
-#     },
-#     "NotificationsSettings": {
-#       "url": "https://example.com/player/hubs",
-#       "number_to_display": 4
-#     },
-#     "AppTitle": "Crucible",
-#     "AppTopBarText": "Crucible",
-#     "AppTopBarHexColor": "#b00",
-#     "AppTopBarHexTextColor": "#FFFFFF",
-#     "UseLocalAuthStorage": true
-#   }
+settings: |-
+  {
+    "ApiUrl": "https://example.com/player",
+    "OIDCSettings": {
+      "authority": "https://example.com/identity",
+      "client_id": "player-ui",
+      "redirect_uri": "https://example.com/player/auth-callback",
+      "post_logout_redirect_uri": "https://example.com/player",
+      "response_type": "code",
+      "scope": "openid profile player-api",
+      "automaticSilentRenew": true,
+      "silent_redirect_uri": "https://example.com/player/auth-callback-silent"
+    },
+    "NotificationsSettings": {
+      "url": "https://example.com/player/hubs",
+      "number_to_display": 4
+    },
+    "AppTitle": "Crucible",
+    "AppTopBarText": "Crucible",
+    "AppTopBarHexColor": "#b00",
+    "AppTopBarHexTextColor": "#FFFFFF",
+    "UseLocalAuthStorage": true
+  }

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: latest

--- a/charts/player/charts/vm-ui/templates/_helpers.tpl
+++ b/charts/player/charts/vm-ui/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "vm-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "vm-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/player/charts/vm-ui/templates/deployment.yaml
+++ b/charts/player/charts/vm-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "vm-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "vm-ui.fullname" . }}-settings
           configMap:
             name: {{ include "vm-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/vm-ui/templates/deployment.yaml
+++ b/charts/player/charts/vm-ui/templates/deployment.yaml
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "vm-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "vm-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "vm-ui.fullname" . }}-settings
           configMap:
             name: {{ include "vm-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "vm-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -81,7 +81,24 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/player.ico
+#     subPath: player.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
+
+extraVolumeMounts: ""
 
 additionalVolumes: []
 
@@ -108,3 +125,4 @@ env:
 #     },
 #     "UseLocalAuthStorage": true
 #   }
+settings: ""

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -2,7 +2,7 @@ player-api:
   kind: "Deployment"
   # Docker image release version
   image:
-    tag: "3.1.0"
+    tag: "3.2.2"
   
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -82,7 +82,7 @@ player-ui:
 
   # Docker image release version
   image:
-    tag: "2.0.4"
+    tag: "3.1.8"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -100,6 +100,11 @@ player-ui:
       - secretName: ""
         hosts:
          - example.com
+
+  # Mount additional volumes into container
+  additionalVolumeMounts: []
+
+  additionalVolumes: []
 
   env: 
     ## basehref is path to the app
@@ -136,7 +141,7 @@ vm-api:
 
   # Docker image release version
   image:
-    tag: "2.1.3"
+    tag: "3.5.3"
 
   # iso - an NFS volume mount for ISO uploads
   iso:
@@ -272,7 +277,7 @@ vm-ui:
 
   # Docker image release version
   image:
-    tag: "2.1.2"
+    tag: "3.3.3"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -290,6 +295,10 @@ vm-ui:
       - secretName: ""
         hosts:
          - example.com
+
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
 
   env: 
     ## basehref is path to the app
@@ -322,7 +331,7 @@ console-ui:
 
   # Docker image release version
   image:
-    tag: "2.1.1"
+    tag: "3.1.1"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -340,6 +349,10 @@ console-ui:
       - secretName: ""
         hosts:
          - example.com
+
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
 
   env: 
     ## basehref is path to the app

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -101,10 +101,24 @@ player-ui:
         hosts:
          - example.com
 
-  # Mount additional volumes into container
-  additionalVolumeMounts: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/player.ico
+  #     subPath: player.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
 
-  additionalVolumes: []
+  extraVolumeMounts: ""
 
   env: 
     ## basehref is path to the app
@@ -296,9 +310,24 @@ vm-ui:
         hosts:
          - example.com
 
-  additionalVolumeMounts: []
-  
-  additionalVolumes: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/player.ico
+  #     subPath: player.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
+
+  extraVolumeMounts: ""
 
   env: 
     ## basehref is path to the app
@@ -350,9 +379,24 @@ console-ui:
         hosts:
          - example.com
 
-  additionalVolumeMounts: []
-  
-  additionalVolumes: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/player.ico
+  #     subPath: player.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
+
+  extraVolumeMounts: ""
 
   env: 
     ## basehref is path to the app

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: 3.7.2

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: latest

--- a/charts/steamfitter/charts/steamfitter-ui/templates/_helpers.tpl
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/_helpers.tpl
@@ -60,3 +60,18 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "steamfitter-ui.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "steamfitter-ui.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}
+

--- a/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
@@ -54,10 +54,16 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "steamfitter-ui.fullname" . }}-settings
+            {{- if .Values.additionalVolumeMounts }}
+              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: {{ include "steamfitter-ui.fullname" . }}-settings
           configMap:
             name: {{ include "steamfitter-ui.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+          {{- toYaml .Values.additionalVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "steamfitter-api.fullname" . }}
+                name: {{ include "steamfitter-ui.fullname" . }}
           ports:
             - name: http
               containerPort: 8080
@@ -54,16 +54,12 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "steamfitter-ui.fullname" . }}-settings
-            {{- if .Values.additionalVolumeMounts }}
-              {{- toYaml .Values.additionalVolumeMounts | nindent 12 }}
-            {{- end }}
+            {{- include "steamfitter-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "steamfitter-ui.fullname" . }}-settings
           configMap:
             name: {{ include "steamfitter-ui.fullname" . }}
-        {{- if .Values.additionalVolumes }}
-          {{- toYaml .Values.additionalVolumes | nindent 8 }}
-        {{- end }}
+        {{- include "steamfitter-ui.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -81,6 +81,10 @@ tolerations: []
 
 affinity: {}
 
+additionalVolumeMounts: []
+
+additionalVolumes: []
+
 env: 
   ## basehref is path to the app
   APP_BASEHREF: ""

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -81,9 +81,24 @@ tolerations: []
 
 affinity: {}
 
-additionalVolumeMounts: []
+## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+# Example use to overwrite the favicon from a file in a configMap:
+#
+# extraVolumes: |
+#   - name: "replacement-icon-vol"
+#      configMap:
+#        name: "replacement-icons"
+#
+# extraVolumeMounts: |
+#   - name: "replacement-icon-vol"
+#     mountPath: /usr/share/nginx/html/assets/img/steamfitter.ico
+#     subPath: steamfitter.ico
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumes: ""
 
-additionalVolumes: []
+extraVolumeMounts: ""
 
 env: 
   ## basehref is path to the app
@@ -105,3 +120,4 @@ env:
 #     },
 #     "UseLocalAuthStorage": true
 # }'
+settings: ""

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -116,10 +116,24 @@ steamfitter-ui:
          - example.com
 
 
-  # Mount additional volumes into container
-  additionalVolumeMounts: []
+  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  # Example use to overwrite the favicon from a file in a configMap:
+  #
+  # extraVolumes: |
+  #   - name: "replacement-icon-vol"
+  #      configMap:
+  #        name: "replacement-icons"
+  #
+  # extraVolumeMounts: |
+  #   - name: "replacement-icon-vol"
+  #     mountPath: /usr/share/nginx/html/assets/img/steamfitter.ico
+  #     subPath: steamfitter.ico
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumes: ""
   
-  additionalVolumes: []
+  extraVolumeMounts: ""
   
   env: 
     ## basehref is path to the app

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -2,7 +2,7 @@ steamfitter-api:
 
   # Docker image release version
   image:
-    tag: "2.0.5"
+    tag: "3.7.2"
   
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -96,7 +96,7 @@ steamfitter-ui:
 
   # Docker image release version
   image:
-    tag: "2.0.5"
+    tag: "3.7.4"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -115,6 +115,12 @@ steamfitter-ui:
         hosts:
          - example.com
 
+
+  # Mount additional volumes into container
+  additionalVolumeMounts: []
+  
+  additionalVolumes: []
+  
   env: 
     ## basehref is path to the app
     APP_BASEHREF: ""


### PR DESCRIPTION
Updates crucible app manifests for ui components with `extraVolumes` and `extraVolumeMounts` options for mounting additional files into, or overriding existing files in the deployed container without having to bake new files into the base image.

### Rationale of Feature Addition
This change is to make development easier, as often image or css assets may need to be changed while working on the application, and this allows a quicker path to updating when working with kubernetes deployments. The process could be done for api deployments as well, but ultimately their design doesn't gain much utility allowing for additional files to be mounted into the containers.

### Bugfixes
Replaces incorrect reference to `steamfitter-api.fullname` in steamfitter-ui with `steamfitter-ui.fullname`

### Testing
Changes may  be tested by writing a test.settings.yaml with the following contents:
```yaml
extraVolumes: |
  - emptyDir: {}
    name: test-vol
extraVolumeMounts: |
  - mountPath: /var/run/
    name: test-vol
```

and running

> helm template --dry-run \<app\>/charts/\<app\>-ui -f test.settings.yaml

The new dummy volumes will be rendered in the deployment section of the template. This does require an active Kubernetes context to work, but will not deploy anything to the cluster.

### Maintenance
+ Updated tags in charts to most current recent app versions
+ Updated chart version as per best practices when making updates to a helm chart.