### PR TITLE
[crucible apps] Feature/ingress-updates

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: alloy
-description: A Helm chart for Kubernetes
+description: A component for joining together Crucible cyber simulation framework modules
 type: application
-version: 1.4.1
-appVersion: 3.0.0
+version: 1.5.0
+appVersion: "3.0.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/alloy
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: alloy-api
-description: A Helm chart for Kubernetes
+description: RESTful API for Alloy
 type: application
-version: 1.2.0
-appVersion: latest
+version: 1.3.0
+appVersion: "3.4.3"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/alloy/charts/alloy-api
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/alloy/charts/alloy-api/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "alloy-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "alloy-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: alloy-ui
-description: A Helm chart for Kubernetes
+description: Front-end for Alloy
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 3.2.6
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/alloy/charts/alloy-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/alloy/charts/alloy-ui/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "alloy-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "alloy-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: blueprint
-description: A Helm chart for Kubernetes
+description: A MSEL builder with integrations to the Crucible cyber simulation framework
 type: application
-version: 1.4.1
-appVersion: 1.0.0
+version: 1.5.0
+appVersion: "1.0.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/blueprint
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: blueprint-api
-description: RESTful API for Blueprints
+description: RESTful API for Blueprint
 type: application
-version: 1.4.0
+version: 1.3.0
 appVersion: "0.3.10"
 home: https://cmu-sei.github.io/crucible
 sources:

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: blueprint-api
-description: A Helm chart for Kubernetes
+description: RESTful API for Blueprints
 type: application
-version: 1.2.0
-appVersion: 1.0.0
+version: 1.4.0
+appVersion: "0.3.10"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/blueprint/charts/blueprint-api
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "blueprint-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "blueprint-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -1,6 +1,12 @@
 apiVersion: v2
 name: blueprint-ui
-description: A Helm chart for Kubernetes
+description: Front-end component of Blueprint
 type: application
-version: 1.2.1
-appVersion: 1.0.0
+version: 1.3.0
+appVersion: "0.3.12"
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/blueprint/charts/blueprint-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "blueprint-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "blueprint-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: caster
-description: A Helm chart for Kubernetes
+description: The primary deployment component of the Crucible cyber simulation framework.
 type: application
-version: 1.4.3
-appVersion: 3.3.0
+version: 1.5.0
+appVersion: "3.3.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/caster/charts/caster-ui
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -1,6 +1,14 @@
 apiVersion: v2
 name: caster-api
-description: A Helm chart for Kubernetes
+description: API component for Caster deployments.
 type: application
-version: 1.4.2
-appVersion: latest
+version: 1.5.0
+appVersion: 3.3.0
+home: https://cmu-sei.github.io/crucible/
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/feature/ingress-updates/charts/caster/charts/caster-api
+dependencies:
+- name: crucible-common
+  version: "0.1.0"
+  repository: "file://../crucible-common"
+

--- a/charts/caster/charts/caster-api/templates/ingress.yaml
+++ b/charts/caster/charts/caster-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "caster-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "caster-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: caster-ui
-description: A Helm chart for Kubernetes
+description: UI component for Caster deployments.
 type: application
-version: 1.4.3
-appVersion: latest
+version: 1.5.0
+appVersion: "3.3.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/caster/charts/caster-ui
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/caster/charts/caster-ui/templates/ingress.yaml
+++ b/charts/caster/charts/caster-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "caster-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "caster-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: cite
-description: A Helm chart for Kubernetes
+description: Application to evaluate, score, and comment on cyber incidents in Crucible cyber simulation framework
 type: application
-version: 1.4.1
-appVersion: 1.0.0
+version: 1.5.0
+appVersion: "1.0.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/cite
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/cite/charts/cite-api/Chart.yaml
+++ b/charts/cite/charts/cite-api/Chart.yaml
@@ -1,6 +1,14 @@
 apiVersion: v2
-name: cite-api
-description: A Helm chart for Kubernetes
+name: cite-ui
+description: REST API for CITE incident evalutation tool
 type: application
-version: 1.2.0
-appVersion: latest
+version: 1.3.0
+appVersion: "1.3.1"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/cite/charts/cite-api
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts
+~                                                  

--- a/charts/cite/charts/cite-api/templates/ingress.yaml
+++ b/charts/cite/charts/cite-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "cite-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "cite-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: cite-ui
-description: A Helm chart for Kubernetes
+description: Front-end component for CITE incident evalutation tool
 type: application
 version: 1.2.1
-appVersion: latest
+appVersion: "1.3.5"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/cite/charts/cite-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/cite/charts/cite-ui/templates/ingress.yaml
+++ b/charts/cite/charts/cite-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "cite-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "cite-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/crucible-common/.helmignore
+++ b/charts/crucible-common/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/crucible-common/Chart.yaml
+++ b/charts/crucible-common/Chart.yaml
@@ -6,5 +6,8 @@ type: library
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 # Keep same as appVersion
-version: 0.1.0
-appVersion: 0.1.0
+version: 1.0.0
+appVersion: 1.0.0
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/crucible-common

--- a/charts/crucible-common/Chart.yaml
+++ b/charts/crucible-common/Chart.yaml
@@ -8,4 +8,3 @@ type: library
 # Keep same as appVersion
 version: 0.1.0
 appVersion: 0.1.0
-

--- a/charts/crucible-common/Chart.yaml
+++ b/charts/crucible-common/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: crucible-common
+description: Library helm chart for common elements for crucible apps. Cannot be deployed as-is.
+type: library
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+# Keep same as appVersion
+version: 0.1.0
+appVersion: 0.1.0
+

--- a/charts/crucible-common/templates/_ingress.tpl
+++ b/charts/crucible-common/templates/_ingress.tpl
@@ -1,0 +1,140 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Generate the proper ingress API
+It expects a dictionary with two entries:
+  - `ingress` which contains ingress settings (.Values.ingress)
+  - `context` the parent context (`.` or `$`)
+
+Usage:
+{{ include "common.ingress.apiVersion "ingress" .Values.ingress "context" $ }}
+*/}}
+
+{{- define "common.ingress.apiVersion" -}}
+{{- if .ingress.apiVersion -}}
+{{- .ingress.apiVersion -}}
+{{- else if .context.Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- else if .context.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "extensions/v1beta1" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns true if the ingressClassname field is supported 
+expects dict with one entry:
+	- `apiVersion` - supported ingress api version (common.ingress.apiVersion)
+Usage:
+{{- include "common.ingress.supportsIngressClassname"  (dict "apiVersion" $apiVersion) }}
+*/}}
+
+{{- define "common.ingress.supportsIngressClassname" -}}
+{{- if eq .apiVersion "networking.k8s.io/v1" -}}
+{{- print "true" -}}
+{{- else -}}
+{{- print "false" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns true if the pathType field is supported 
+expects dict with one entry:
+	- `apiVersion` - supported ingress api version (common.ingress.apiVersion)
+Usage:
+{{- include "common.ingress.supportsPathType"  (dict "apiVersion" $apiVersion) }}
+*/}}
+
+{{- define "common.ingress.supportsPathType" -}}
+{{- if eq .apiVersion "networking.k8s.io/v1" -}}
+{{- print "true" -}}
+{{- else -}}
+{{- print "false" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Formats a backend stanza for ingress based on api availability 
+expects dict with four entries:
+  - `ingress` which contains ingress settings (.Values.ingress)
+	- `apiVersion` - supported ingress api version (common.ingress.apiVersion)
+  - `serviceName`  - service name
+	- `servicePort` - servicePort
+Usage:
+{{- include "common.ingress.formatBackend"  (dict "apiVersion" $apiVersion "ingress" .Values.ingress "svcName" $fullName "svcPort" $svcPort) }}
+*/}}
+
+{{- define "common.ingress.formatBackend" -}}
+{{- if or (eq .apiVersion "extensions/v1beta1") (eq .apiVersion "networking.k8s.io/v1beta1") -}}
+serviceName: {{ .svcName }}
+servicePort: {{ .svcPort }}
+{{- else -}}
+service:
+  name: {{ .svcName }}
+  port:
+    {{- if typeIs "string" .svcPort }}
+    name: {{ .svcPort }}
+    {{- else if or (typeIs "int" .svcPort) (typeIs "float64" .svcPort) }}
+    number: {{ .svcPort | int }}
+		{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Renders a Ingress for the webservice
+
+It expects a dictionary with the entries:
+  - `name` the Ingress name to use
+  - `rootContext` the root context ($)
+  - `localContext` the context of the deployment to render the Ingress for (.)
+  - `ingress` which contains ingress settings (.Values.ingress)
+  - `name` 
+Usage - 
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName  "svcPort" $svcPort) }}
+
+*/}}
+
+{{- define "common.ingress.template" }}
+{{- $global := .rootContext.Values.global }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .ingress "context" .rootContext) }}
+{{- $svcName := .fullName }}
+{{- $svcPort := .svcPort }}
+---
+apiVersion: {{ $apiVersion  }}
+kind: Ingress
+metadata: 
+  name: {{ .fullName }}
+  labels: {{- (include "common.labels.default" .localContext) | nindent 4 }}
+  {{- with .ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:  
+  {{- if and .ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" (dict "apiVersion" $apiVersion))) }}
+  ingressClassName: {{ .ingress.ingressClassName | quote }}
+  {{- end }}
+  rules: 
+    {{- range .ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if include "common.ingress.supportsPathType" (dict "apiVersion" $apiVersion) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.formatBackend"  (dict "apiVersion" $apiVersion "ingress" .ingress "svcName" $svcName "svcPort" $svcPort)  | nindent 14 -}}
+          {{- end }}
+    {{- end }}
+  {{- if .ingress.tls }}
+  tls:
+    {{- range .ingress.tls }}
+    - hosts:
+      {{-  range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end}}

--- a/charts/crucible-common/templates/_ingress.tpl
+++ b/charts/crucible-common/templates/_ingress.tpl
@@ -132,7 +132,7 @@ spec:
     {{- range .ingress.tls }}
   - hosts:
     {{-  range .hosts }}
-      - {{ . | quote }}
+    - {{ . | quote }}
     {{- end }}
     secretName: {{ .secretName }}
   {{- end }}

--- a/charts/crucible-common/templates/_ingress.tpl
+++ b/charts/crucible-common/templates/_ingress.tpl
@@ -116,25 +116,25 @@ spec:
   {{- end }}
   rules: 
     {{- range .ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if include "common.ingress.supportsPathType" (dict "apiVersion" $apiVersion) }}
-            pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
-            backend: {{- include "common.ingress.formatBackend"  (dict "apiVersion" $apiVersion "ingress" .ingress "svcName" $svcName "svcPort" $svcPort)  | nindent 14 -}}
-          {{- end }}
+  - host: {{ .host | quote }}
+    http:
+      paths:
+      {{- range .paths }}
+      - path: {{ .path }}
+        {{- if include "common.ingress.supportsPathType" (dict "apiVersion" $apiVersion) }}
+        pathType: {{ default "ImplementationSpecific" .pathType }}
+        {{- end }}
+        backend: {{- include "common.ingress.formatBackend"  (dict "apiVersion" $apiVersion "ingress" .ingress "svcName" $svcName "svcPort" $svcPort)  | nindent 10 -}}
+      {{- end }}
     {{- end }}
   {{- if .ingress.tls }}
   tls:
     {{- range .ingress.tls }}
-    - hosts:
-      {{-  range .hosts }}
-        - {{ . | quote }}
-      {{- end }}
-      secretName: {{ .secretName }}
+  - hosts:
+    {{-  range .hosts }}
+      - {{ . | quote }}
     {{- end }}
+    secretName: {{ .secretName }}
+  {{- end }}
   {{- end }}
 {{- end}}

--- a/charts/crucible-common/templates/_labels.tpl
+++ b/charts/crucible-common/templates/_labels.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Common labels
+*/}}
+{{- define "common.labels.default" -}}
+helm.sh/chart: {{ include "common.labels.chart" . }}
+{{ include "common.labels.selectorLabels" . }}
+{{- if  .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "common.labels.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "common.names.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label
+*/}}
+{{- define "common.labels.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+

--- a/charts/crucible-common/templates/_names.tpl
+++ b/charts/crucible-common/templates/_names.tpl
@@ -1,0 +1,28 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{- define "common.names.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "common.names.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/crucible-common/values.yaml
+++ b/charts/crucible-common/values.yaml
@@ -1,0 +1,5 @@
+# Default values for crucible-common.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+exampleValue: crucible-common

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: gallery
-description: A Helm chart for Kubernetes
+description: Incident visualization dashboard with integration with the Crucible cyber simulation framework
 type: application
-version: 1.4.1
-appVersion: 1.0.0
+version: 1.5.0
+appVersion: "1.0.0"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/gallery
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/gallery/charts/gallery-api/Chart.yaml
+++ b/charts/gallery/charts/gallery-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: gallery-api
-description: A Helm chart for Kubernetes
+description: REST API component for Gallery
 type: application
-version: 1.2.0
-appVersion: 1.0.0
+version: 1.4.0
+appVersion: "1.5.1"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/gallery/charts/gallery-api
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/gallery/charts/gallery-api/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "gallery-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "gallery-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: gallery-ui
-description: A Helm chart for Kubernetes
+description: Front-end component for Gallery dashboard
 type: application
-version: 1.2.1
-appVersion: 1.0.0
+version: 1.3.0
+appVersion: 1.5.2
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/gallery/charts/gallery-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/gallery/charts/gallery-ui/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "gallery-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "gallery-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: player
-description: A Helm chart for Kubernetes
+description: A centralized participant interface for the Crucible cyber simulation framework
 type: application
-version: 1.4.4
+version: 1.5.0
 appVersion: 3.2.2
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: console-ui
-description: A Helm chart for Kubernetes
+description: UI for interacting with VMWare consoles from Player
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 3.1.1
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player/charts/console-ui
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/console-ui/templates/ingress.yaml
+++ b/charts/player/charts/console-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "console-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "console-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: player-api
-description: A Helm chart for Kubernetes
+description: API for managing Player component of Crucible
 type: application
-version: 1.4.3
-appVersion: latest
+version: 1.5.0
+appVersion: 3.2.2
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player/charts/player-api
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/player-api/templates/ingress.yaml
+++ b/charts/player/charts/player-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "player-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "player-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -2,5 +2,12 @@ apiVersion: v2
 name: player-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.4
-appVersion: latest
+version: 1.5.0
+appVersion: 3.1.8
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player/charts/player-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/player-ui/templates/ingress.yaml
+++ b/charts/player/charts/player-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "player-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "player-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: vm-api
-description: A Helm chart for Kubernetes
+description: A restful API for managing VMs integrated with Player
 type: application
-version: 1.4.3
-appVersion: latest
+version: 1.5.0
+appVersion: 3.5.3
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player/charts/vm-api
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/vm-api/templates/console-ingress.yaml
+++ b/charts/player/charts/vm-api/templates/console-ingress.yaml
@@ -1,59 +1,8 @@
-{{- if .Values.ingress.consoleIngress.deployConsoleProxy -}}
-{{- $fullName := .Values.consoleIngress.name -}}
-{{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  {{- with .Values.consoleIngress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.consoleIngress.tls }}
-  tls:
-    {{- range .Values.consoleIngress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.consoleIngress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- if .Values.consoleIngress.enabled }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.consoleIngress "context" $) }}
+{{/* Not using common.names.fullname for fullName, as that would deploy as the same name/backend target as the vm-api */}}
+{{- $name := default "player-console" .Values.consoleIngress.name }}
+{{- $fullName :=  printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.consoleIngress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/charts/vm-api/templates/ingress.yaml
+++ b/charts/player/charts/vm-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "vm-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "vm-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -66,20 +66,21 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-  consoleIngress:
-    deployConsoleProxy: false   
-    name: ''
-    annotations:
-      {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths: []
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+consoleIngress:
+  enabled: false
+  deployConsoleProxy: false   
+  name: ''
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
 # create a configMap with the needed certifcates and specify

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: vm-ui
-description: A Helm chart for Kubernetes
+description: Frontend application for the VM management component of Player
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 3.3.3
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/player/charts/vm-ui
+dependencies:
+- name: crucible-common
+  version: 1.x.x
+  repository: https://helm.cmusei.dev/charts

--- a/charts/player/charts/vm-ui/templates/ingress.yaml
+++ b/charts/player/charts/vm-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "vm-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "vm-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -194,6 +194,7 @@ vm-api:
   #   connections will go directly from the UI to the vCenter hosts themselves
   # - The host value here corresponds to RewriteHost__RewriteHostUrl below
   consoleIngress:
+    enabled: true
     deployConsoleProxy: false  
     className: ""
     name: player-connect

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: steamfitter
-description: A Helm chart for Kubernetes
+description: Scenario creation tool for Crucible cyber simulation framework
 type: application
-version: 1.4.2
-appVersion: 3.7.2
+version: 1.5.0
+appVersion: "3.7.2"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/steamfitter
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: steamfitter-api
-description: A Helm chart for Kubernetes
+description: REST API for Steamfitter
 type: application
-version: 1.2.0
-appVersion: latest
+version: 1.3.0
+appVersion: "3.7.2"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/steamfitter/charts/steamfitter-api
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "steamfitter-api.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "steamfitter-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -1,6 +1,13 @@
 apiVersion: v2
 name: steamfitter-ui
-description: A Helm chart for Kubernetes
+description: Front-end for Steamfitter
 type: application
-version: 1.4.2
-appVersion: latest
+version: 1.5.0
+appVersion: "3.7.4"
+home: https://cmu-sei.github.io/crucible
+sources:
+  - https://github.com/cmu-sei/helm-charts/tree/main/charts/steamfitter/charts/steamfitter-ui
+dependencies:
+  - name: crucible-common
+    version: 1.x.x
+    repository: https://helm.cmusei.dev/charts

--- a/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
@@ -1,61 +1,7 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "steamfitter-ui.fullname" . -}}
+{{- $fullName := include "common.names.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
-  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
-  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
-  {{- end }}
-{{- end }}
-{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1
-{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
-kind: Ingress
-metadata:
-  name: {{ $fullName }}
-  labels:
-    {{- include "steamfitter-ui.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
-  tls:
-    {{- range .Values.ingress.tls }}
-    - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
-      http:
-        paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
-            pathType: {{ .pathType }}
-            {{- end }}
-            backend:
-              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-              service:
-                name: {{ $fullName }}
-                port:
-                  number: {{ $svcPort }}
-              {{- else }}
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
-              {{- end }}
-          {{- end }}
-    {{- end }}
+{{- $apiVersion := include "common.ingress.apiVersion" (dict "ingress" .Values.ingress "context" $) }}
+{{- $svcPort := .Values.service.port }}
+{{- include "common.ingress.template" (dict "rootContext" $ "localContext" . "ingress" .Values.ingress "fullName" $fullName "svcPort" $svcPort) }}
 {{- end }}


### PR DESCRIPTION

## Description of change
Updates crucible application manifests to use a `crucible-common` library for templating commonly used features.
This first pass introduces the use of the common library for generating kubernetes ingress resources.

In the short term, this change makes the `consoleIngress` deploy work for the `player/vm-api` sub-application.
In the long term, the use of a common library will make maintaining charts easier whenever changes are needed to
common components, as the change will often be able to be made only to the underlying common template elements.

## Features
+ New `crucible-common` library chart
+ Ingress resources now created using shared template

## Maintenance
+ Upgraded chart versions as needed
+ Cleaned up and added missing content to `Chart.yaml` files

## Bugfix
+ `consoleIngress` now deploys from `player/`vm-api`
 
## Testing
To test:
Clone the repository
Choose an app to compare formats
Replace the `dependencies` stanza in charts/\<app\>/Chart.yaml with:
```yaml
dependencies:
  - name: crucible-common
    version: 0.x.x
    repository: "file://../crucible-common"
 ```
 
Run `helm dependency build` in the app folder, this will build the `crucible-common` dependency

Write (or use an existing) values.yaml for the app

run from the root of the charts repo:
```
helm template --name-template=test-deploy --dry-run charts/<app> -f values.yaml --debug -o yaml > common.txt
helm template --name-template=test-deploy --dry-run sei/<app> -f values.yaml --debug -o yaml > old.txt
vimdiff common.txt old.txt
```
Check that everything matches

If it looks good, may then deploy to a development cluster.

## Possible Drawbacks
Requiring a dependency does add another (small) layer of complexity for airgapped/offline installs, but as shown in testing it is possible to replace the dependency source with local files.

