### PR TITLE
Feature/player configurable monitors

### DIFF
--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: 3.0.0

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: latest

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -47,11 +47,11 @@ spec:
             httpGet:
               path: /api/health/live
               port: http
-            initialDelaySeconds:  {{ .Values.probes.livenessProbe.initialDelaySeconds }}
-            periodSeconds:        {{ .Values.probes.livenessProbe.periodSeconds }}
-            timeoutSeconds:       {{ .Values.probes.livenessProbe.timeoutSeconds }}
-            failureThreshold:     {{ .Values.probes.livenessProbe.failureThreshold }}
-            successThreshold:     {{ .Values.probes.livenessProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
         {{- end }}
         {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -42,14 +42,28 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds:  {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds:        {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds:       {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold:     {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold:     {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/player/charts/player-api/templates/statefulset.yaml
+++ b/charts/player/charts/player-api/templates/statefulset.yaml
@@ -48,11 +48,11 @@ spec:
             httpGet:
               path: /api/health/live
               port: http
-            initialDelaySeconds:  {{ .Values.probes.livenessProbe.initialDelaySeconds }}
-            periodSeconds:        {{ .Values.probes.livenessProbe.periodSeconds }}
-            timeoutSeconds:       {{ .Values.probes.livenessProbe.timeoutSeconds }}
-            failureThreshold:     {{ .Values.probes.livenessProbe.failureThreshold }}
-            successThreshold:     {{ .Values.probes.livenessProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
         {{- end }}
         {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:

--- a/charts/player/charts/player-api/templates/statefulset.yaml
+++ b/charts/player/charts/player-api/templates/statefulset.yaml
@@ -43,14 +43,28 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds:  {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds:        {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds:       {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold:     {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold:     {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -42,6 +42,24 @@ service:
   type: ClusterIP
   port: 80
 
+# Default liveness and readiness probes
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -2,8 +2,26 @@ player-api:
   kind: "Deployment"
   # Docker image release version
   image:
-    tag: "3.1.0"
-  
+    tag: "3.2.7"
+ 
+  # Configure default liveness and rediness probe settings 
+  probes: 
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:


### PR DESCRIPTION
Add configuration options to player-api liveness and readiness probes. 
New Configuration defaults:

```
player-api:
  probes:
    livenessProbe:
      enabled: true
      initialDelaySeconds: 30
      periodSeconds: 10
      timeoutSeconds: 5
      failureThreshold: 6
      successThreshold: 1
    readinessProbe:
      enabled: true
      initialDelaySeconds: 5
      periodSeconds: 10
      timeoutSeconds: 5
      failureThreshold: 6
      successThreshold: 1
```