### PR TITLE
Fix/player api probes

### DIFF
--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.4
+version: 1.4.5
 appVersion: 3.2.2

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.4.4
 appVersion: latest

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -42,20 +42,39 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /api/health/live
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/player/charts/player-api/templates/statefulset.yaml
+++ b/charts/player/charts/player-api/templates/statefulset.yaml
@@ -43,20 +43,39 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /api/health/live
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -42,6 +42,31 @@ service:
   type: ClusterIP
   port: 80
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+      
 ingress:
   enabled: false
   className: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -2,7 +2,32 @@ player-api:
   kind: "Deployment"
   # Docker image release version
   image:
-    tag: "3.2.2"
+    tag: "3.2.3"
+
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
   
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured


### PR DESCRIPTION
Editable probes for player-api.
New setting defaults:
```
player-api:
  probes:
    livenessProbe:
      enabled: true
      initialDelaySeconds: 30
      periodSeconds: 10
      timeoutSeconds: 5
      failureThreshold: 6
      successThreshold: 1

    readinessProbe:
      enabled: true
      initialDelaySeconds: 5
      periodSeconds: 10
      timeoutSeconds: 5
      failureThreshold: 6
      successThreshold: 1

    startupProbe:
      enabled: true
      initialDelaySeconds: 30
      periodSeconds: 10
      timeoutSeconds: 1
      failureThreshold: 15
      successThreshold: 1
   ```