### PR TITLE
Fix secretName attribute for topomojo-api deployment

### DIFF
--- a/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
@@ -137,7 +137,7 @@ spec:
       {{- if .Values.existingSecret }}
       - name: {{ include "topomojo-api.name" . }}-extra
         secret:
-          name: {{ .Values.existingSecret }}
+          secretName: {{ .Values.existingSecret }}
       {{- end }}
       {{- if .Values.storage.existing }}
       - name: {{ include "topomojo-api.name" . }}-vol


### PR DESCRIPTION
The topomojo-api chart uses an incorrect `name:` attribute when referencing a secrets volume in its deployment. This corrects the deployment to use `secretName:` instead.