### PR TITLE
Added additional support for git documentation sources

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -21,6 +21,10 @@ data:
     giturl={{ .Values.giturl }}
     branch={{ .Values.gitbranch }}
 
+    {{- if .Values.gitCredentialsSecret }}
+    git config --global credential.helper "store --file=/git-credentials/{{ .Values.gitCredentialsSecretKey | default ".git-credentials" }}"
+    {{- end }}
+
     ## pull updates (and clone on first attempt)
     cd /docs
     if [ ! -d .git ]; then
@@ -35,6 +39,11 @@ data:
 
     {{- if .Values.mkdocs.site_url }}
     sed -i -r -e 's#^(site_url: )(.*)#\1{{ .Values.mkdocs.site_url }}#' mkdocs.yml
-    if [ $(grep -c 'site_url:' mkdocs.yml) == 0 ]; then echo 'site_url: {{ .Values.mkdocs.site_url }}' | cat - mkdocs.yml > tmp.yml; mv tmp.yml mkdocs.yml; fi
-    {{- end }}
+    found_url=`grep -c 'site_url:' mkdocs.yml`
+    if [ $found_url = 0 ]; then 
+      echo 'site_url: {{ .Values.mkdocs.site_url }}' | cat - mkdocs.yml > tmp.yml
+      mv tmp.yml mkdocs.yml
+    fi
+    {{ end }}
+
 {{- end }}

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -32,4 +32,9 @@ data:
     fi
     git pull
     git reset --hard
+
+    {{- if .Values.mkdocs.site_url }}
+    sed -i -r -e 's#^(site_url: )(.*)#\1{{ .Values.mkdocs.site_url }}#' mkdocs.yml
+    if [ $(grep -c 'site_url:' mkdocs.yml) == 0 ]; then echo 'site_url: {{ .Values.mkdocs.site_url }}' | cat - mkdocs.yml > tmp.yml; mv tmp.yml mkdocs.yml; fi
+    {{- end }}
 {{- end }}

--- a/charts/mkdocs-material/templates/configmap.yaml
+++ b/charts/mkdocs-material/templates/configmap.yaml
@@ -18,7 +18,12 @@ data:
         server_name  localhost;
     
         location / {
+            {{- if not .Values.giturl }}
             root   /mkdocs/site;
+            {{- else }}
+            root   /mkdocs/
+            {{- .Values.mkdocs.site_dir | default "site" | trim }};
+            {{- end }}
             index  index.html index.htm;
         }
     

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -31,6 +31,10 @@ spec:
                 - mountPath: /docs
                   name: {{ include "mkdocs-material.name" . }}-vol
                   subPath: {{ include "mkdocs-material.fullname" . }}
+                {{- if .Values.gitCredentialsSecret }}
+                - mountPath: /git-credentials
+                  name: {{ include "mkdocs-material.fullname" . }}-git-creds
+                {{- end }}
           containers:
             - name: mkdocs-build
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -54,5 +58,12 @@ spec:
               persistentVolumeClaim:
                 claimName: {{ include "mkdocs-material.fullname" . }}
             {{- end }}
+            {{- if .Values.gitCredentialsSecret }}
+            - name: {{ include "mkdocs-material.name" . }}-git-creds
+              secret:
+                secretName: {{ .Values.gitCredentialsSecret }}
+                defaultMode: 0600
+            {{- end }}
+
 {{- end }}
     

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -45,8 +45,14 @@ spec:
               configMap:
                 name: {{ include "mkdocs-material.fullname" . }}-entry
                 defaultMode: 0775
+            {{- if .Values.storage.existing }}
+            - name: {{ include "mkdocs-material.name" . }}-vol
+              persistentVolumeClaim:
+                claimName: {{ .Values.storage.existing }}
+            {{- else }}    
             - name: {{ include "mkdocs-material.name" . }}-vol
               persistentVolumeClaim:
                 claimName: {{ include "mkdocs-material.fullname" . }}
+            {{- end }}
 {{- end }}
     

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - mountPath: /docs
               name: {{ include "mkdocs-material.name" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}
+            {{- if .Values.gitCredentialsSecret }}
+            - mountPath: /git-credentials
+              name: {{ include "mkdocs-material.fullname" . }}-git-creds
+            {{- end }}
         {{- end }}
         - name: mkdocs-build
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -93,6 +97,12 @@ spec:
         configMap:
           name: {{ include "mkdocs-material.fullname" . }}-entry
           defaultMode: 0775
+      {{- if .Values.gitCredentialsSecret }}
+      - name: {{ include "mkdocs-material.name" . }}-git-creds
+        secret:
+          secretName: {{ .Values.gitCredentialsSecret }}
+          defaultMode: 0600
+      {{- end }}
       {{- else }}
       - name: {{ include "mkdocs-material.name" . }}-files
         configMap:

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -98,6 +98,14 @@ giturl: ""
 ## gitbranch sets which repo branch to publish
 gitbranch: ""
 
+## Secret that stores the values of a git credential store helper file
+## See https://git-scm.com/docs/git-credential-store
+gitCredentialsSecret: ""
+
+## Key in the gitCredentialsSecret with the credentials file: 
+## The default value is ".git-credentials"
+gitCredentialsSecretKey: ""
+
 ## pollInterval sets minutes between git pull
 pollInterval: 5
 
@@ -114,6 +122,12 @@ pollInterval: 5
 ######################
 
 ## mkdocs YAML configuration
+## This can be used to create an mkdocs.yml file if no giturl is provided
+## It can also be used to modify the effect of the following fields when a giturl
+## is provided and an mkdocs.yml file is included in the git repo
+##   site_url: The value provided here will override the value in the git repo
+##   site_dir: The value provided here will be used to set the mapping in the nginx container to this path
+##             instead of the default value of "site". You should set this to the value that is in your mkdocs.yml file
 mkdocs: {}
   # site_name: My Site
   # theme:


### PR DESCRIPTION
This PR adds some improvements for the handling of mkdocs materials when using git as a source for the docs. The changes are summarized as follows:

1. Allows the use of the existing persistent volume claim for both the cronjob and the init containers of the deployment when running using git
2. Supports overriding the site_url of the mkdocs.yml file when the deployment is served at a different host than the git repo specifies in the site_url field
3. Supports overriding the path that nginx uses to redirect traffic to the static website to match the value specified in site_dir rather than the default value of "site"
4. Supports providing git credentials as a secret in the format used by the git store credential helper

Note:
Because this PR configures git to use the store git credential helper, but the config file is read-only, we see this error in the init container logs every time git tries to write the creds:

fatal: unable to get credential storage lock in 1000 ms: Read-only file system

This error does not impact the functionality because the credentials did not actually change and the read of the credentials works properly. This could be fixed by using a custom git credential helper, but that would require some additional development. Is it ok to leave the current implementation given that error in the logs or should we fix it?

