### PR TITLE
Add conditional check for doc build and minimize build impact on doc site.

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -34,9 +34,9 @@ data:
     if [ -n "$branch" ]; then
       git checkout $branch
     fi
-    git pull
     git reset --hard
-
+    git pull
+    
     {{- if .Values.mkdocs.site_url }}
     sed -i -r -e 's#^(site_url: )(.*)#\1{{ .Values.mkdocs.site_url }}#' mkdocs.yml
     found_url=`grep -c 'site_url:' mkdocs.yml`

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -25,17 +25,41 @@ data:
     git config --global credential.helper "store --file=/git-credentials/{{ .Values.gitCredentialsSecretKey | default ".git-credentials" }}"
     {{- end }}
 
+    # Keep track of whether docs need to be built
+    dirty=0
+
     ## pull updates (and clone on first attempt)
-    cd /docs
+    cd /git
     if [ ! -d .git ]; then
-      rm -rf *
-      git clone $giturl .
+        echo "Clearing and cloning git repo..."
+        dirty=1
+        rm -rf *
+        git clone "$giturl" .
     fi
-    if [ -n "$branch" ]; then
-      git checkout $branch
-    fi
+
     git reset --hard
+    git clean -f
+    
+    if [ -n "$branch" ]; then 
+        gitcheckoutoutput=`git checkout $branch 2>&1`
+        echo "$gitcheckoutoutput" | grep "Switch*" > /dev/null 2>&1
+        if [ "$?" -eq "0" ]; then
+            echo "Branch changed - docs should be updated."
+            dirty=1
+        fi
+    fi
+
+    gitfetchoutput=`git fetch --porcelain`
+    if [ -n "$gitfetchoutput" ]; then
+        echo "Changes were made on remote branch - docs should be updated."
+        dirty=1
+    fi
+
     git pull
+
+    if [ "$dirty" -eq "1" ]; then
+        touch "/docs/.dirty"
+    fi
     
     {{- if .Values.mkdocs.site_url }}
     sed -i -r -e 's#^(site_url: )(.*)#\1{{ .Values.mkdocs.site_url }}#' mkdocs.yml
@@ -46,4 +70,52 @@ data:
     fi
     {{ end }}
 
+  mkdocs-build.sh: |-
+    #!/bin/sh
+
+    if [ -f "/docs/.dirty" ]; then
+        echo "Building docs..."
+
+        old_docs=`readlink /docs/site`
+        new_docs=`mktemp -d -p /docs`
+
+        echo "Old docs: $old_docs"
+        echo "New docs: $new_docs"
+
+        cd /git
+        mkdocs build -d "$new_docs"
+        if [ "$?" -eq "0" ]; then
+            echo "Mkdocs build succeeded."
+
+            cd /docs
+            tmp_path=`basename "$new_docs"`
+            chmod 775 "$tmp_path"
+            
+            ## Delete the previous symbolic link
+            rm "site"
+
+            ## Relink or link the symbolic link
+            ln -s "$tmp_path" "site"
+
+            if [ -n "$old_docs" ]; then
+                echo "Removing old docs: $old_docs"
+                rm -Rf "$old_docs"
+            else 
+                echo "No old docs to remove"
+            fi
+
+            new_docs_link=`ls -alF /docs/site`
+            echo "$new_docs_link" | grep "$tmp_path" > /dev/null 2>&1
+            if [ "$?" -eq "0" ]; then
+                echo "New link: $new_docs_link"
+                rm "/docs/.dirty"
+            else
+                echo "Unexpected link result: $new_docs_link"
+            fi
+        else
+            echo "Mkdocs build failed."
+        fi
+    else
+        echo "Docs are up-to-date."
+    fi
 {{- end }}

--- a/charts/mkdocs-material/templates/configmap.yaml
+++ b/charts/mkdocs-material/templates/configmap.yaml
@@ -18,12 +18,7 @@ data:
         server_name  localhost;
     
         location / {
-            {{- if not .Values.giturl }}
-            root   /mkdocs/site;
-            {{- else }}
-            root   /mkdocs/
-            {{- .Values.mkdocs.site_dir | default "site" | trim }};
-            {{- end }}
+            root   /mkdocs/docs/site;
             index  index.html index.htm;
         }
     

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -30,7 +30,10 @@ spec:
                   name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
                   name: {{ include "mkdocs-material.name" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}
+                  subPath: {{ include "mkdocs-material.fullname" . }}/docs
+                - mountPath: /git
+                  name: {{ include "mkdocs-material.name" . }}-vol
+                  subPath: {{ include "mkdocs-material.fullname" . }}/git
                 {{- if .Values.gitCredentialsSecret }}
                 - mountPath: /git-credentials
                   name: {{ include "mkdocs-material.fullname" . }}-git-creds
@@ -39,11 +42,16 @@ spec:
             - name: mkdocs-build
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              args: ["build"]
+              command: ["/entry.d/mkdocs-build.sh"]
               volumeMounts:
+                - mountPath: /entry.d
+                  name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
                   name: {{ include "mkdocs-material.name" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}
+                  subPath: {{ include "mkdocs-material.fullname" . }}/docs
+                - mountPath: /git
+                  name: {{ include "mkdocs-material.name" . }}-vol
+                  subPath: {{ include "mkdocs-material.fullname" . }}/git
           volumes:
             - name: {{ include "mkdocs-material.name" . }}-entry
               configMap:

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -37,7 +37,10 @@ spec:
               name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
               name: {{ include "mkdocs-material.name" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}
+              subPath: {{ include "mkdocs-material.fullname" . }}/docs
+            - mountPath: /git
+              name: {{ include "mkdocs-material.name" . }}-vol
+              subPath: {{ include "mkdocs-material.fullname" . }}/git
             {{- if .Values.gitCredentialsSecret }}
             - mountPath: /git-credentials
               name: {{ include "mkdocs-material.fullname" . }}-git-creds
@@ -46,13 +49,20 @@ spec:
         - name: mkdocs-build
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          args: ["build"]
-          volumeMounts:
             {{- if .Values.giturl }}
+          command: ["/entry.d/mkdocs-build.sh"]
+          volumeMounts:
+            - mountPath: /entry.d
+              name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
               name: {{ include "mkdocs-material.name" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}
+              subPath: {{ include "mkdocs-material.fullname" . }}/docs
+            - mountPath: /git
+              name: {{ include "mkdocs-material.name" . }}-vol
+              subPath: {{ include "mkdocs-material.fullname" . }}/git
             {{- else }}
+          args: ["build"]
+          volumeMounts:
             - mountPath: /docs/mkdocs.yml
               name: {{ include "mkdocs-material.name" . }}
               subPath: mkdocs.yml
@@ -60,7 +70,7 @@ spec:
               name: {{ include "mkdocs-material.name" . }}-files
             - mountPath: /docs/site
               name: {{ include "mkdocs-material.name" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/site
+              subPath: {{ include "mkdocs-material.fullname" . }}/docs/site
             {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
This PR adds a conditional check on the git repo so that mkdocs only builds if something has changed since the last poll. I also changed new builds so that they are done "asynchronously." This is achieved by serving the docs via a symbolic link to a build directory. The link stays in place during a new build and swaps over at the end so that downtime and impact on the doc site are minimized regardless of how long the build takes. Build times of more than one minute had been causing the site to become unresponsive when docs disappeared. 