### PR TITLE
Add ability to specify k8s secrets as extra environment variables for selected crucible apps

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 3.0.0

--- a/charts/alloy/charts/alloy-api/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-api/templates/deployment.yaml
@@ -34,9 +34,17 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "alloy-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "alloy-api.fullname" . }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -87,6 +87,10 @@ affinity: {}
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Alloy.Api.dll']
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # env is pod env vars
 env:
   # http_proxy:

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -28,6 +28,10 @@ alloy-api:
   # the configMap name here
   certificateMap: ''
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/alloy.api/Alloy.Api/appsettings.json

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 1.0.0

--- a/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
@@ -32,9 +32,17 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "blueprint-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "blueprint-api.fullname" . }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{- toYaml .Values.command | nindent 10 }}
           ports:

--- a/charts/blueprint/charts/blueprint-api/values.yaml
+++ b/charts/blueprint/charts/blueprint-api/values.yaml
@@ -88,6 +88,10 @@ certificateMap: ''
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Blueprint.Api.dll']
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # env is pod env vars
 env:
   # http_proxy: ""

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -80,6 +80,10 @@ blueprint-ui:
 
   extraVolumeMounts: ""
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   env:
   # Config app settings with a JSON file.
   # These values correspond to an OpenID connect client and

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -22,6 +22,10 @@ blueprint-api:
         hosts:
           - example.com
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   env:
     # CORS policy settings.
     # The first entry should be the URL to Blueprint
@@ -79,10 +83,6 @@ blueprint-ui:
   extraVolumes: ""
 
   extraVolumeMounts: ""
-
-  ## existingSecret references a secret already in k8s. 
-  ## The key/value pairs in the secret are added as environment variables.
-  existingSecret: ""
 
   env:
   # Config app settings with a JSON file.

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
+version: 1.5.0
 appVersion: 3.3.0

--- a/charts/caster/charts/caster-api/templates/deployment.yaml
+++ b/charts/caster/charts/caster-api/templates/deployment.yaml
@@ -34,9 +34,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "caster-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "caster-api.fullname" . }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -120,6 +120,10 @@ terraformrc:
           }
       }
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 env:
   # http_proxy:
   # https_proxy:

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -58,6 +58,10 @@ caster-api:
   # Replace TOKEN with an access token created in Gitlab, and update the Gitlab URL
   gitcredentials: 'https://git-access-token:TOKEN@gitlab.example.com'
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/caster.api/src/Caster.Api/appsettings.json

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 1.0.0

--- a/charts/cite/charts/cite-api/templates/deployment.yaml
+++ b/charts/cite/charts/cite-api/templates/deployment.yaml
@@ -33,9 +33,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "cite-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "cite-api.fullname" . }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -86,6 +86,10 @@ tolerations: []
 
 affinity: {}
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 env:
   # http_proxy:
   # https_proxy:

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -23,6 +23,10 @@ cite-api:
         hosts:
           - example.com
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/alloy.api/Alloy.Api/appsettings.json

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.5.0
 appVersion: 1.0.0

--- a/charts/gallery/charts/gallery-api/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-api/templates/deployment.yaml
@@ -32,9 +32,17 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "gallery-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gallery-api.fullname" . }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{- toYaml .Values.command | nindent 10 }}
           ports:

--- a/charts/gallery/charts/gallery-api/values.yaml
+++ b/charts/gallery/charts/gallery-api/values.yaml
@@ -88,6 +88,10 @@ certificateMap: ''
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Gallery.Api.dll']
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # env is pod env vars
 env:
   # http_proxy: ""

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -22,6 +22,10 @@ gallery-api:
         hosts:
           - example.com
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   env:
     # CORS policy settings.
     # The first entry should be the URL to Gallery

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.5
+version: 1.5.0
 appVersion: 3.2.2

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -33,9 +33,17 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "player-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "player-api.fullname" . }}
+          {{- end }}
           command: {{- toYaml .Values.command | nindent 10 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -124,6 +124,10 @@ storage:
   mode: ReadWriteOnce
   class: default
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # env is pod env vars
 env:
   # http_proxy: ""

--- a/charts/player/charts/vm-api/templates/deployment.yaml
+++ b/charts/player/charts/vm-api/templates/deployment.yaml
@@ -32,9 +32,17 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "vm-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "vm-api.fullname" . }}
+          {{- end }}
           command: {{- toYaml .Values.command | nindent 10 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -114,6 +114,10 @@ affinity: {}
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Player.Vm.Api.dll']
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # env is pod env vars
 env:
   # http_proxy: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -64,6 +64,10 @@ player-api:
     mode: ReadWriteOnce
     class: default
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/player.api/S3.Player.Api/appsettings.json
@@ -247,6 +251,10 @@ vm-api:
   # create a configMap with the needed certifcates and specify
   # the configMap name here
   certificateMap: ""
+
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.2
+version: 1.5.0
 appVersion: 3.7.2

--- a/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
@@ -33,9 +33,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "steamfitter-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "steamfitter-api.fullname" . }}
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -91,6 +91,10 @@ affinity: {}
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Steamfitter.Api.dll']
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 env:
   # http_proxy: ""
   # https_proxy: ""

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -29,6 +29,10 @@ steamfitter-api:
   # the configMap name here
   certificateMap: ""
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/steamfitter.api/Steamfitter.Api/appsettings.json


### PR DESCRIPTION
This PR adds the ability to specify additional environment variables to be added via existing k8s secrets the following crucible apps:

- Caster api
- Alloy api
- BP api
- Cite api
- Steamfitter api
- Gallery api
- Player api
- VM api

Here is an example of what the values file would look like for blueprint api to do this:

```
blueprint-api:
  image:
    tag: "1.4.3"

  existingSecret: "bp-secret"

```
The corresponding secret in the cluster might look like this:

```
apiVersion: v1
kind: Secret
metadata:
  name: bp-secret
type: Opaque
stringData:
  ConnectionStrings__PostgreSQL: 'Server=postgres;Port=5432;Database=blueprint_db;Username=blueprint_dbo;Password=foo;SSL Mode=Prefer;Trust Server Certificate=true;'
  ResourceOwnerAuthorization__Password: 'bar'

```
