### PR TITLE
Add ability to specify k8s secrets as extra environment variables for Gameboard

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7
+version: 0.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7
+version: 0.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
@@ -46,6 +46,17 @@ spec:
           command: ["/bin/sh"]
           args: ["/start/start.sh"]
           {{- end }}
+          {{- if .Values.existingSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gameboard-api.fullname" . }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gameboard-api.fullname" . }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "gameboard-api.fullname" . }}

--- a/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
@@ -57,9 +57,6 @@ spec:
             - secretRef:
                 name: {{ include "gameboard-api.fullname" . }}
           {{- end }}
-          envFrom:
-            - secretRef:
-                name: {{ include "gameboard-api.fullname" . }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -122,6 +122,10 @@ migrations:
   Database__ConnectionString: ""
   env: {}
 
+## existingSecret references a secret already in k8s. 
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
 # Config app settings with environment vars.
 # Those most likely needing values are listed. For others,
 # see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -123,6 +123,10 @@ gameboard-api:
     Database__ConnectionString: ""
     env: {}
 
+  ## existingSecret references a secret already in k8s. 
+  ## The key/value pairs in the secret are added as environment variables.
+  existingSecret: ""
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf


### PR DESCRIPTION
This PR adds the ability to specify additional environment variables to be added via existing k8s secrets to gameboard. It follows the same approach that was used in [a previous merge request](https://github.com/cmu-sei/helm-charts/pull/75)

Here is an example of what the values file would look like:

``` 
gameboard-api:
  existingSecret: "gameboard-secret"

```

The corresponding secret in the cluster might look like this:

```
apiVersion: v1
kind: Secret
metadata:
  name: gameboard-secret
type: Opaque
stringData:
  ConnectionStrings__PostgreSQL: 'Server=postgres;Port=5432;Database=gameboard_db;Username=gameboard_dbo;Password=foo;SSL Mode=Prefer;Trust Server Certificate=true;'
  ResourceOwnerAuthorization__Password: 'bar'

```