### PR TITLE
Correct bug with volume names and add options for pvc prefix and cacert secrets

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/_helpers.tpl
+++ b/charts/mkdocs-material/templates/_helpers.tpl
@@ -60,3 +60,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Subpath prefix value to use for pvc mount points
+*/}}
+{{- define "mkdocs-material.subpathPrefix" -}}
+{{- $path := default (include "mkdocs-material.fullname" .) .Values.storage.overrideSubpathPrefix -}}
+{{- ternary ($path | printf "%s/" ) "" .Values.storage.existingSubpathPrefix -}}
+{{- end }}

--- a/charts/mkdocs-material/templates/configmap-cacerts.yaml
+++ b/charts/mkdocs-material/templates/configmap-cacerts.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.cacert }}
+  {{- if .Values.certificateMap }}
+  {{- fail "Must specify only one of certificateMap or cacert" }}
+  {{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mkdocs-material.fullname" . }}-cacerts
+  labels:
+    {{- include "mkdocs-material.labels" . | nindent 4 }}
+
+data:
+  cacert.crt: |-
+{{ .Values.cacert | indent 4 }}
+{{- end }}

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -10,14 +10,6 @@ data:
   git-pull.sh: |-
     #!/bin/sh
 
-    {{- if .Values.cacert }}
-    # update CA trust
-    cat << EOF > /usr/local/share/ca-certificates/cacert.crt
-    {{ .Values.cacert | indent 4 | trim }}
-    EOF
-    update-ca-certificates
-    {{- end }}
-
     giturl={{ .Values.giturl }}
     branch={{ .Values.gitbranch }}
 

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -67,44 +67,54 @@ data:
     if [ -f "/docs/.dirty" ]; then
         echo "Building docs..."
 
-        old_docs=`readlink /docs/site`
-        new_docs=`mktemp -d -p /docs`
-
-        echo "Old docs: $old_docs"
-        echo "New docs: $new_docs"
-
-        cd /git
-        mkdocs build -d "$new_docs"
-        if [ "$?" -eq "0" ]; then
-            echo "Mkdocs build succeeded."
-
-            cd /docs
-            tmp_path=`basename "$new_docs"`
-            chmod 775 "$tmp_path"
-            
-            ## Delete the previous symbolic link
-            rm "site"
-
-            ## Relink or link the symbolic link
-            ln -s "$tmp_path" "site"
-
-            if [ -n "$old_docs" ]; then
-                echo "Removing old docs: $old_docs"
-                rm -Rf "$old_docs"
-            else 
-                echo "No old docs to remove"
-            fi
-
-            new_docs_link=`ls -alF /docs/site`
-            echo "$new_docs_link" | grep "$tmp_path" > /dev/null 2>&1
-            if [ "$?" -eq "0" ]; then
-                echo "New link: $new_docs_link"
-                rm "/docs/.dirty"
-            else
-                echo "Unexpected link result: $new_docs_link"
-            fi
+        if [ -n "$DOCS_GIT_PATH" ]; then
+            docs_dir="/git/${DOCS_GIT_PATH}"
         else
-            echo "Mkdocs build failed."
+            docs_dir="/git"
+        fi
+
+        if [ -d "$docs_dir" ]; then
+            old_docs=`readlink /docs/site`
+            new_docs=`mktemp -d -p /docs`
+
+            echo "Old docs: $old_docs"
+            echo "New docs: $new_docs"
+
+            cd "$docs_dir"
+            mkdocs build -d "$new_docs"
+            if [ "$?" -eq "0" ]; then
+                echo "Mkdocs build succeeded."
+
+                cd /docs
+                tmp_path=`basename "$new_docs"`
+                chmod 775 "$tmp_path"
+                
+                ## Delete the previous symbolic link
+                rm "site"
+
+                ## Relink or link the symbolic link
+                ln -s "$tmp_path" "site"
+
+                if [ -n "$old_docs" ]; then
+                    echo "Removing old docs: $old_docs"
+                    rm -Rf "$old_docs"
+                else 
+                    echo "No old docs to remove"
+                fi
+
+                new_docs_link=`ls -alF /docs/site`
+                echo "$new_docs_link" | grep "$tmp_path" > /dev/null 2>&1
+                if [ "$?" -eq "0" ]; then
+                    echo "New link: $new_docs_link"
+                    rm "/docs/.dirty"
+                else
+                    echo "Unexpected link result: $new_docs_link"
+                fi
+            else
+                echo "Mkdocs build failed."
+            fi
+        else 
+          echo "Docs directory not found: ${docs_dir}"    
         fi
     else
         echo "Docs are up-to-date."

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -32,7 +32,7 @@ data:
     git clean -f
     
     if [ -n "$DOCS_GIT_BRANCH" ]; then 
-        gitcheckoutoutput=`git checkout $DOCS_GIT_BRANCH 2>&1`
+        gitcheckoutoutput=`git checkout "$DOCS_GIT_BRANCH" 2>&1`
         echo "$gitcheckoutoutput" | grep "Switch*" > /dev/null 2>&1
         if [ "$?" -eq "0" ]; then
             echo "Branch changed - docs should be updated."

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -12,7 +12,7 @@ data:
 
     update-ca-certificates
 
-    while openssl x509 -noout -text; do :; done < ca-certificates.crt
+    while openssl x509 -noout -text; do :; done < /etc/ssl/certs/ca-certificates.crt
 
     giturl={{ .Values.giturl }}
     branch={{ .Values.gitbranch }}

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -85,7 +85,7 @@ data:
             echo "Old docs: $old_docs"
             echo "New docs: $new_docs"
 
-            echo "Docs direcrtory is: ${docs_dir}"
+            echo "Docs directory is: ${docs_dir}"
             cd "$docs_dir"
             mkdocs build -d "$new_docs"
             if [ "$?" -eq "0" ]; then

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -12,14 +12,9 @@ data:
 
     update-ca-certificates
 
-    while openssl x509 -noout -text; do :; done < /etc/ssl/certs/ca-certificates.crt
-
-    giturl={{ .Values.giturl }}
-    branch={{ .Values.gitbranch }}
-
-    {{- if .Values.gitCredentialsSecret }}
-    git config --global credential.helper "store --file=/git-credentials/{{ .Values.gitCredentialsSecretKey | default ".git-credentials" }}"
-    {{- end }}
+    if [ -n $DOCS_GIT_CRED_FILE ]; then
+        git config --global credential.helper "store --file=/git-credentials/${DOCS_GIT_CRED_FILE}"
+    fi
 
     # Keep track of whether docs need to be built
     dirty=0
@@ -30,14 +25,14 @@ data:
         echo "Clearing and cloning git repo..."
         dirty=1
         rm -rf *
-        git clone "$giturl" .
+        git clone "$DOCS_GIT_URL" .
     fi
 
     git reset --hard
     git clean -f
     
-    if [ -n "$branch" ]; then 
-        gitcheckoutoutput=`git checkout $branch 2>&1`
+    if [ -n "$DOCS_GIT_BRANCH" ]; then 
+        gitcheckoutoutput=`git checkout $DOCS_GIT_BRANCH 2>&1`
         echo "$gitcheckoutoutput" | grep "Switch*" > /dev/null 2>&1
         if [ "$?" -eq "0" ]; then
             echo "Branch changed - docs should be updated."
@@ -56,15 +51,15 @@ data:
     if [ "$dirty" -eq "1" ]; then
         touch "/docs/.dirty"
     fi
-    
-    {{- if .Values.mkdocs.site_url }}
-    sed -i -r -e 's#^(site_url: )(.*)#\1{{ .Values.mkdocs.site_url }}#' mkdocs.yml
-    found_url=`grep -c 'site_url:' mkdocs.yml`
-    if [ $found_url = 0 ]; then 
-      echo 'site_url: {{ .Values.mkdocs.site_url }}' | cat - mkdocs.yml > tmp.yml
-      mv tmp.yml mkdocs.yml
-    fi
-    {{ end }}
+
+    if [ -n "$DOCS_SITE_URL" ]; then
+        sed -i -r -e 's#^(site_url: )(.*)#\1${DOCS_SITE_URL}#' mkdocs.yml
+        found_url=`grep -c 'site_url:' mkdocs.yml`
+        if [ $found_url = 0 ]; then 
+        echo 'site_url: ${DOCS_SITE_URL}' | cat - mkdocs.yml > tmp.yml
+        mv tmp.yml mkdocs.yml
+        fi
+    fi 
 
   mkdocs-build.sh: |-
     #!/bin/sh

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -53,10 +53,10 @@ data:
     fi
 
     if [ -n "$DOCS_SITE_URL" ]; then
-        sed -i -r -e 's#^(site_url: )(.*)#\1${DOCS_SITE_URL}#' mkdocs.yml
+        sed -i -r -e "s#^(site_url: )(.*)#\1${DOCS_SITE_URL}#" mkdocs.yml
         found_url=`grep -c 'site_url:' mkdocs.yml`
         if [ $found_url = 0 ]; then 
-        echo 'site_url: ${DOCS_SITE_URL}' | cat - mkdocs.yml > tmp.yml
+        echo "site_url: ${DOCS_SITE_URL}" | cat - mkdocs.yml > tmp.yml
         mv tmp.yml mkdocs.yml
         fi
     fi 

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -53,6 +53,11 @@ data:
     fi
 
     if [ -n "$DOCS_SITE_URL" ]; then
+        if [ -n "$DOCS_GIT_PATH" ]; then
+            echo "Docs path is: ${DOCS_GIT_PATH}"
+            cd "${DOCS_GIT_PATH}"
+        fi
+
         sed -i -r -e "s#^(site_url: )(.*)#\1${DOCS_SITE_URL}#" mkdocs.yml
         found_url=`grep -c 'site_url:' mkdocs.yml`
         if [ $found_url = 0 ]; then 
@@ -80,6 +85,7 @@ data:
             echo "Old docs: $old_docs"
             echo "New docs: $new_docs"
 
+            echo "Docs direcrtory is: ${docs_dir}"
             cd "$docs_dir"
             mkdocs build -d "$new_docs"
             if [ "$?" -eq "0" ]; then

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -10,6 +10,8 @@ data:
   git-pull.sh: |-
     #!/bin/sh
 
+    update-ca-certificates
+
     giturl={{ .Values.giturl }}
     branch={{ .Values.gitbranch }}
 

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -12,6 +12,8 @@ data:
 
     update-ca-certificates
 
+    while openssl x509 -noout -text; do :; done < ca-certificates.crt
+
     giturl={{ .Values.giturl }}
     branch={{ .Values.gitbranch }}
 

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -89,6 +89,10 @@ spec:
                 secretName: {{ .Values.gitCredentialsSecret }}
                 defaultMode: 0600
             {{- end }}
+            {{- if .Values.gitPath }}
+            - name: DOCS_GIT_PATH
+              value: {{ .Values.gitPath | trimPrefix "/" }}
+            {{- end }}
             {{- if .Values.certificateMap }}
             - name: certificates
               configMap:

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -64,6 +64,11 @@ spec:
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
               command: ["/entry.d/mkdocs-build.sh"]
+              {{- if .Values.gitPath }}
+              env:
+                - name: DOCS_GIT_PATH
+                  value: {{ .Values.gitPath | trimPrefix "/" }}
+              {{- end }}
               volumeMounts:
                 - mountPath: /entry.d
                   name: {{ include "mkdocs-material.fullname" . }}-entry

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -25,6 +25,19 @@ spec:
             - name: git-pull
               image: "bitnami/git"
               command: ["/entry.d/git-pull.sh"]
+              env:
+                - name: DOCS_GIT_URL
+                  value: {{ .Values.giturl }}
+                - name: DOCS_GIT_BRANCH
+                  value: {{ .Values.gitbranch }}
+                {{- if .Values.gitCredentialsSecret }}
+                - name: DOCS_GIT_CRED_FILE
+                  value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
+                {{- end }}
+                {{- if .Values.mkdocs.site_url }}
+                - name: DOCS_SITE_URL
+                  value: {{ .Values.mkdocs.site_url }}
+                {{- end }}
               volumeMounts:
                 - mountPath: /entry.d
                   name: {{ include "mkdocs-material.fullname" . }}-entry

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           initContainers:
             {{- if or .Values.certificateMap .Values.cacert }}
             - name: ca-installer
-              image: "alpine:3.19"
+              image: "bitnami/git"
               command: ['bash', '-c', 'update-ca-certificates']
               volumeMounts:
                 - mountPath: /usr/local/share/ca-certificates

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -93,10 +93,6 @@ spec:
                 secretName: {{ .Values.gitCredentialsSecret }}
                 defaultMode: 0600
             {{- end }}
-            {{- if .Values.gitPath }}
-            - name: DOCS_GIT_PATH
-              value: {{ .Values.gitPath | trimPrefix "/" }}
-            {{- end }}
             {{- if .Values.certificateMap }}
             - name: certificates
               configMap:

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -22,6 +22,14 @@ spec:
         spec:
           restartPolicy: Never
           initContainers:
+            {{- if or .Values.certificateMap .Values.cacert }}
+            - name: ca-installer
+              image: "alpine:3.19"
+              command: ['bash', '-c', 'update-ca-certificates']
+              volumeMounts:
+                - mountPath: /usr/local/share/ca-certificates
+                  name: certificates
+            {{- end }}
             - name: git-pull
               image: "bitnami/git"
               command: ["/entry.d/git-pull.sh"]
@@ -71,6 +79,16 @@ spec:
               secret:
                 secretName: {{ .Values.gitCredentialsSecret }}
                 defaultMode: 0600
+            {{- end }}
+            {{- if .Values.certificateMap }}
+            - name: certificates
+              configMap:
+                name: {{ .Values.certificateMap }}
+            {{- end }}
+            {{- if .Values.cacert }}
+            - name: certificates
+              configMap:
+                name: {{ include "mkdocs-material.fullname" . }}-cacerts
             {{- end }}
 
 {{- end }}

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -34,6 +34,10 @@ spec:
                 - name: DOCS_GIT_CRED_FILE
                   value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
                 {{- end }}
+                {{- if .Values.gitPath }}
+                - name: DOCS_GIT_PATH
+                  value: {{ .Values.gitPath | trimPrefix "/" }}
+                {{- end }}
                 {{- if .Values.mkdocs.site_url }}
                 - name: DOCS_SITE_URL
                   value: {{ .Values.mkdocs.site_url }}

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -30,10 +30,10 @@ spec:
                   name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
                   name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}/docs
+                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
                 - mountPath: /git
                   name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}/git
+                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
                 {{- if .Values.gitCredentialsSecret }}
                 - mountPath: /git-credentials
                   name: {{ include "mkdocs-material.fullname" . }}-git-creds
@@ -48,10 +48,10 @@ spec:
                   name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
                   name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}/docs
+                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
                 - mountPath: /git
                   name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.fullname" . }}/git
+                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
           volumes:
             - name: {{ include "mkdocs-material.fullname" . }}-entry
               configMap:

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -29,10 +29,10 @@ spec:
                 - mountPath: /entry.d
                   name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
-                  name: {{ include "mkdocs-material.name" . }}-vol
+                  name: {{ include "mkdocs-material.fullname" . }}-vol
                   subPath: {{ include "mkdocs-material.fullname" . }}/docs
                 - mountPath: /git
-                  name: {{ include "mkdocs-material.name" . }}-vol
+                  name: {{ include "mkdocs-material.fullname" . }}-vol
                   subPath: {{ include "mkdocs-material.fullname" . }}/git
                 {{- if .Values.gitCredentialsSecret }}
                 - mountPath: /git-credentials
@@ -47,27 +47,27 @@ spec:
                 - mountPath: /entry.d
                   name: {{ include "mkdocs-material.fullname" . }}-entry
                 - mountPath: /docs
-                  name: {{ include "mkdocs-material.name" . }}-vol
+                  name: {{ include "mkdocs-material.fullname" . }}-vol
                   subPath: {{ include "mkdocs-material.fullname" . }}/docs
                 - mountPath: /git
-                  name: {{ include "mkdocs-material.name" . }}-vol
+                  name: {{ include "mkdocs-material.fullname" . }}-vol
                   subPath: {{ include "mkdocs-material.fullname" . }}/git
           volumes:
-            - name: {{ include "mkdocs-material.name" . }}-entry
+            - name: {{ include "mkdocs-material.fullname" . }}-entry
               configMap:
                 name: {{ include "mkdocs-material.fullname" . }}-entry
                 defaultMode: 0775
             {{- if .Values.storage.existing }}
-            - name: {{ include "mkdocs-material.name" . }}-vol
+            - name: {{ include "mkdocs-material.fullname" . }}-vol
               persistentVolumeClaim:
                 claimName: {{ .Values.storage.existing }}
             {{- else }}    
-            - name: {{ include "mkdocs-material.name" . }}-vol
+            - name: {{ include "mkdocs-material.fullname" . }}-vol
               persistentVolumeClaim:
                 claimName: {{ include "mkdocs-material.fullname" . }}
             {{- end }}
             {{- if .Values.gitCredentialsSecret }}
-            - name: {{ include "mkdocs-material.name" . }}-git-creds
+            - name: {{ include "mkdocs-material.fullname" . }}-git-creds
               secret:
                 secretName: {{ .Values.gitCredentialsSecret }}
                 defaultMode: 0600

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -22,14 +22,6 @@ spec:
         spec:
           restartPolicy: Never
           initContainers:
-            {{- if or .Values.certificateMap .Values.cacert }}
-            - name: ca-installer
-              image: "bitnami/git"
-              command: ['bash', '-c', 'update-ca-certificates']
-              volumeMounts:
-                - mountPath: /usr/local/share/ca-certificates
-                  name: certificates
-            {{- end }}
             - name: git-pull
               image: "bitnami/git"
               command: ["/entry.d/git-pull.sh"]
@@ -45,6 +37,10 @@ spec:
                 {{- if .Values.gitCredentialsSecret }}
                 - mountPath: /git-credentials
                   name: {{ include "mkdocs-material.fullname" . }}-git-creds
+                {{- end }}
+                {{- if or .Values.certificateMap .Values.cacert }}
+                - mountPath: /usr/local/share/ca-certificates
+                  name: certificates
                 {{- end }}
           containers:
             - name: mkdocs-build

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -28,6 +28,14 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
+        {{- if or .Values.certificateMap .Values.cacert }}
+        - name: ca-installer
+          image: "alpine:3.19"
+          command: ['bash', '-c', 'update-ca-certificates']
+          volumeMounts:
+            - mountPath: /usr/local/share/ca-certificates
+              name: certificates
+        {{- end }}
         {{- if .Values.giturl }}
         - name: git-pull
           image: "bitnami/git"
@@ -134,4 +142,14 @@ spec:
       {{- else }}
       - name: {{ include "mkdocs-material.fullname" . }}-vol
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.certificateMap }}
+      - name: certificates
+        configMap:
+          name: {{ .Values.certificateMap }}
+      {{- end }}
+      {{- if .Values.cacert }}
+      - name: certificates
+        configMap:
+          name: {{ include "mkdocs-material.fullname" . }}-cacerts
       {{- end }}

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
             - name: DOCS_GIT_CRED_FILE
               value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
             {{- end }}
+            {{- if .Values.gitPath }}
+            - name: DOCS_GIT_PATH
+              value: {{ .Values.gitPath | trimPrefix "/" }}
+            {{- end }}
             {{- if .Values.mkdocs.site_url }}
             - name: DOCS_SITE_URL
               value: {{ .Values.mkdocs.site_url }}

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -37,10 +37,10 @@ spec:
               name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/docs
+              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
             - mountPath: /git
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/git
+              subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
             {{- if .Values.gitCredentialsSecret }}
             - mountPath: /git-credentials
               name: {{ include "mkdocs-material.fullname" . }}-git-creds
@@ -56,10 +56,10 @@ spec:
               name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/docs
+              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
             - mountPath: /git
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/git
+              subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
             {{- else }}
           args: ["build"]
           volumeMounts:
@@ -70,7 +70,7 @@ spec:
               name: {{ include "mkdocs-material.fullname" . }}-files
             - mountPath: /docs/site
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}/docs/site
+              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs/site
             {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -85,7 +85,10 @@ spec:
               subPath: nginx.conf
             - mountPath: /mkdocs
               name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.fullname" . }}
+              {{- if include "mkdocs-material.subpathPrefix" . }}
+              subPath: {{ include "mkdocs-material.subpathPrefix" . | trimSuffix "/" }}
+              {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -72,6 +72,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
             {{- if .Values.giturl }}
           command: ["/entry.d/mkdocs-build.sh"]
+          {{- if .Values.gitPath }}
+          env:
+            - name: DOCS_GIT_PATH
+              value: {{ .Values.gitPath | trimPrefix "/" }}
+          {{- end }}
           volumeMounts:
             - mountPath: /entry.d
               name: {{ include "mkdocs-material.fullname" . }}-entry

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -36,10 +36,10 @@ spec:
             - mountPath: /entry.d
               name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}/docs
             - mountPath: /git
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}/git
             {{- if .Values.gitCredentialsSecret }}
             - mountPath: /git-credentials
@@ -55,21 +55,21 @@ spec:
             - mountPath: /entry.d
               name: {{ include "mkdocs-material.fullname" . }}-entry
             - mountPath: /docs
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}/docs
             - mountPath: /git
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}/git
             {{- else }}
           args: ["build"]
           volumeMounts:
             - mountPath: /docs/mkdocs.yml
-              name: {{ include "mkdocs-material.name" . }}
+              name: {{ include "mkdocs-material.fullname" . }}
               subPath: mkdocs.yml
             - mountPath: /docs/docs
-              name: {{ include "mkdocs-material.name" . }}-files
+              name: {{ include "mkdocs-material.fullname" . }}-files
             - mountPath: /docs/site
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}/docs/site
             {{- end }}
       containers:
@@ -81,10 +81,10 @@ spec:
               protocol: TCP
           volumeMounts:
             - mountPath: /etc/nginx/conf.d/default.conf
-              name: {{ include "mkdocs-material.name" . }}
+              name: {{ include "mkdocs-material.fullname" . }}
               subPath: nginx.conf
             - mountPath: /mkdocs
-              name: {{ include "mkdocs-material.name" . }}-vol
+              name: {{ include "mkdocs-material.fullname" . }}-vol
               subPath: {{ include "mkdocs-material.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -99,36 +99,36 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ include "mkdocs-material.name" . }}
+      - name: {{ include "mkdocs-material.fullname" . }}
         configMap:
           name: {{ include "mkdocs-material.fullname" . }}
       {{- if .Values.giturl }}
-      - name: {{ include "mkdocs-material.name" . }}-entry
+      - name: {{ include "mkdocs-material.fullname" . }}-entry
         configMap:
           name: {{ include "mkdocs-material.fullname" . }}-entry
           defaultMode: 0775
       {{- if .Values.gitCredentialsSecret }}
-      - name: {{ include "mkdocs-material.name" . }}-git-creds
+      - name: {{ include "mkdocs-material.fullname" . }}-git-creds
         secret:
           secretName: {{ .Values.gitCredentialsSecret }}
           defaultMode: 0600
       {{- end }}
       {{- else }}
-      - name: {{ include "mkdocs-material.name" . }}-files
+      - name: {{ include "mkdocs-material.fullname" . }}-files
         configMap:
           name: {{ include "mkdocs-material.fullname" . }}-files
       {{- end }}
       {{- if .Values.storage.existing }}
-      - name: {{ include "mkdocs-material.name" . }}-vol
+      - name: {{ include "mkdocs-material.fullname" . }}-vol
         persistentVolumeClaim:
           claimName: {{ .Values.storage.existing }}
       {{- else if .Values.storage.size }}
-      - name: {{ include "mkdocs-material.name" . }}-vol
+      - name: {{ include "mkdocs-material.fullname" . }}-vol
         persistentVolumeClaim:
           claimName: {{ include "mkdocs-material.fullname" . }}
       {{- else if .Values.giturl }}
       {{- fail "Git deployment mode requires persistent volume" }}
       {{- else }}
-      - name: {{ include "mkdocs-material.name" . }}-vol
+      - name: {{ include "mkdocs-material.fullname" . }}-vol
         emptyDir: {}
       {{- end }}

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -32,6 +32,19 @@ spec:
         - name: git-pull
           image: "bitnami/git"
           command: ["/entry.d/git-pull.sh"]
+          env:
+            - name: DOCS_GIT_URL
+              value: {{ .Values.giturl }}
+            - name: DOCS_GIT_BRANCH
+              value: {{ .Values.gitbranch }}
+            {{- if .Values.gitCredentialsSecret }}
+            - name: DOCS_GIT_CRED_FILE
+              value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
+            {{- end }}
+            {{- if .Values.mkdocs.site_url }}
+            - name: DOCS_SITE_URL
+              value: {{ .Values.mkdocs.site_url }}
+            {{- end }}
           volumeMounts:
             - mountPath: /entry.d
               name: {{ include "mkdocs-material.fullname" . }}-entry

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -30,8 +30,8 @@ spec:
       initContainers:
         {{- if or .Values.certificateMap .Values.cacert }}
         - name: ca-installer
-          image: "alpine:3.19"
-          command: ['sh', '-c', 'update-ca-certificates']
+          image: "bitnami/git"
+          command: ['bash', '-c', 'update-ca-certificates']
           volumeMounts:
             - mountPath: /usr/local/share/ca-certificates
               name: certificates

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         {{- if or .Values.certificateMap .Values.cacert }}
         - name: ca-installer
           image: "alpine:3.19"
-          command: ['bash', '-c', 'update-ca-certificates']
+          command: ['sh', '-c', 'update-ca-certificates']
           volumeMounts:
             - mountPath: /usr/local/share/ca-certificates
               name: certificates

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -28,14 +28,6 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        {{- if or .Values.certificateMap .Values.cacert }}
-        - name: ca-installer
-          image: "bitnami/git"
-          command: ['bash', '-c', 'update-ca-certificates']
-          volumeMounts:
-            - mountPath: /usr/local/share/ca-certificates
-              name: certificates
-        {{- end }}
         {{- if .Values.giturl }}
         - name: git-pull
           image: "bitnami/git"
@@ -52,6 +44,10 @@ spec:
             {{- if .Values.gitCredentialsSecret }}
             - mountPath: /git-credentials
               name: {{ include "mkdocs-material.fullname" . }}-git-creds
+            {{- end }}
+            {{- if or .Values.certificateMap .Values.cacert }}
+            - mountPath: /usr/local/share/ca-certificates
+              name: certificates
             {{- end }}
         {{- end }}
         - name: mkdocs-build

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -119,8 +119,8 @@ pollInterval: 5
 #   …
 #   -----END CERTIFICATE-----
 
-# If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# If this deployment needs to trust custom ca certificates,
+# create a configMap with the needed certificates and specify
 # the configMap name here
 # certificateMap: "ca-map"
 

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -108,6 +108,9 @@ gitCredentialsSecret: ""
 ## The default value is ".git-credentials"
 gitCredentialsSecretKey: ""
 
+## The path relative to the root of the git repo where the docs are located.
+gitPath: ""
+
 ## pollInterval sets minutes between git pull
 pollInterval: 5
 

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -111,13 +111,18 @@ gitCredentialsSecretKey: ""
 ## pollInterval sets minutes between git pull
 pollInterval: 5
 
-# cacert - add custom CA certificate
+# cacert - add custom CA certificate in-line
 # cacert: |-
 #   -----BEGIN CERTIFICATE-----
 #   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
 #   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
 #   …
 #   -----END CERTIFICATE-----
+
+# If this deployment needs to trust non-public certificates,
+# create a configMap with the needed certifcates and specify
+# the configMap name here
+# certificateMap: "ca-map"
 
 ######################
 # Non-Git deployment #

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -71,6 +71,8 @@ resources: {}
 # storage - either an existing pvc, the size for a new pvc, or emptyDir (git requires a pvc)
 storage:
   existing: ""
+  existingSubpathPrefix: true  # If true, then volume mounts will use mkdocs-material.name as a subpath prefix.
+  overrideSubpathPrefix: # If set then this is the value used for the subpath prefix if above property is true
   size: ""
   mode: ReadWriteOnce
   class: default


### PR DESCRIPTION
This PR fixes a bug in the current mkdocs helm chart where the name of the volumeMounts only matched the name of the corresponding volumes if the helm release happened to be named the same as the chart.

In addition to that it adds these features:
- pvc volumes can be used without a suffix subPath or with a custom suffix subPath
- trusted cacerts can be added to the git-pull container using the certificateMap property as in other crucible helm charts
- the git-pull script has been changed to use environment variables for conditional checks rather than using go templating variables within the script