### PR TITLE
Add vm-consoles ingress option to topomojo

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/templates/console-ingress.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/console-ingress.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.consoleIngress.deployConsoleProxy -}}
+{{- $fullName := .Values.consoleIngress.name -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.consoleIngress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.consoleIngress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.consoleIngress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  {{- if .Values.consoleIngress.namespace }}
+  namespace: {{ .Values.consoleIngress.namespace }}
+  {{- end }}
+  name: {{ $fullName }}
+  {{- with .Values.consoleIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.consoleIngress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.consoleIngress.className }}
+  {{- end }}
+  {{- if .Values.consoleIngress.tls }}
+  tls:
+    {{- range .Values.consoleIngress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.consoleIngress.hosts }}
+    - host: {{ .host | quote }}
+      {{- if .paths }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -70,6 +70,57 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Optional second ingress for topomojo api
+# - This ingress is used as a proxy for getting a websocket
+#   console connection to vCenter hosts.
+# - TLS and Host URLs need configured, but the snippet should be left alone
+#
+# Topomojo is hardcoded to pass the vmware host using a query parameter named "vmhost".
+# nginx supports a syntax to resolve variables of the form $arg_name to a query 
+# parameter with key "name" in the request line.
+# That parameter is "vmhost" for this case.
+# 
+# nginx resolves $1 to the value of the first capture group of the regex for location:
+# /console/ticket/(.*)
+# so this means we expect the ticket number to be whatever value is after 
+# /console/ticket/ in the request path.
+#
+# An example websocket request that would match this rule is:
+# wss://connect.example.com/console/ticket/6e71189b23e5ade2?vmhost=10.4.52.68
+#
+# NOTES:
+# - This is only used if deployConsoleProxy below is true, otherwise
+#   connections will go directly from the UI to the vCenter hosts themselves
+# This ingress requires the following properties to be set on the nginx controller via the ConfigMap
+#    allow-snippet-annotations: true
+#    annotations-risk-level: critical  # Became necessary as of ingress-nginx helm chart v4.12
+consoleIngress:
+  deployConsoleProxy: false  
+  className: ""
+  name: vm-consoles
+  namespace: 
+  annotations: 
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/server-snippet: |
+      # Adding proxy configuration for consoles
+      location ~ /console/ticket/(.*) {
+        proxy_pass https://$arg_vmhost/ticket/$1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_request_buffering off;
+        proxy_buffering off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+        proxy_ssl_session_reuse on;
+      }
+  hosts:
+    - host: connect.example.com
+      paths: []
+  tls:
+    - secretName: ""
+      hosts:
+        - connect.example.com
+
 health: {}
   # livenessProbe:
   #   initialDelaySeconds: 10

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -71,6 +71,57 @@ topomojo-api:
     #    hosts:
     #      - chart-example.local
 
+  # Optional second ingress for topomojo api
+  # - This ingress is used as a proxy for getting a websocket
+  #   console connection to vCenter hosts.
+  # - TLS and Host URLs need configured, but the snippet should be left alone
+  #
+  # Topomojo is hardcoded to pass the vmware host using a query parameter named "vmhost".
+  # nginx supports a syntax to resolve variables of the form $arg_name to a query 
+  # parameter with key "name" in the request line.
+  # That parameter is "vmhost" for this case.
+  # 
+  # nginx resolves $1 to the value of the first capture group of the regex for location:
+  # /console/ticket/(.*)
+  # so this means we expect the ticket number to be whatever value is after 
+  # /console/ticket/ in the request path.
+  #
+  # An example websocket request that would match this rule is:
+  # wss://connect.example.com/console/ticket/6e71189b23e5ade2?vmhost=10.4.52.68
+  #
+  # NOTES:
+  # - This is only used if deployConsoleProxy below is true, otherwise
+  #   connections will go directly from the UI to the vCenter hosts themselves
+  # This ingress requires the following properties to be set on the nginx controller via the ConfigMap
+  #    allow-snippet-annotations: true
+  #    annotations-risk-level: critical  # Became necessary as of ingress-nginx helm chart v4.12
+  consoleIngress:
+    deployConsoleProxy: false  
+    className: ""
+    name: vm-consoles
+    namespace: 
+    annotations: 
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/server-snippet: |
+        # Adding proxy configuration for consoles
+        location ~ /console/ticket/(.*) {
+          proxy_pass https://$arg_vmhost/ticket/$1;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_request_buffering off;
+          proxy_buffering off;
+          proxy_read_timeout 86400s;
+          proxy_send_timeout 86400s;
+          proxy_ssl_session_reuse on;
+        }
+    hosts:
+      - host: connect.example.com
+        paths: []
+    tls:
+      - secretName: ""
+        hosts:
+         - connect.example.com
+
   health: {}
     # livenessProbe:
     #   initialDelaySeconds: 10


### PR DESCRIPTION
The PR adds an optional ingress to topomojo for websocket connections to vmware consoles. It is patterned after a similar capability in the player vm api helm chart.