### PR TITLE
Cite add ability to inject custom trusted cacerts

### DIFF
--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.0.0

--- a/charts/cite/charts/cite-api/templates/deployment.yaml
+++ b/charts/cite/charts/cite-api/templates/deployment.yaml
@@ -60,12 +60,21 @@ spec:
           volumeMounts:
             - mountPath: /app/conf
               name: {{ include "cite-api.name" . }}-conf
+            {{ if .Values.certificateMap }}
+            - mountPath: /usr/local/share/ca-certificates
+              name: certificates
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: {{ include "cite-api.name" . }}-conf
           configMap:
             name: {{ include "cite-api.fullname" . }}
+        {{ if .Values.certificateMap }}
+        - name: certificates
+          configMap:
+            name: {{ .Values.certificateMap }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cite/charts/cite-api/templates/deployment.yaml
+++ b/charts/cite/charts/cite-api/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           volumeMounts:
             - mountPath: /app/conf
               name: {{ include "cite-api.name" . }}-conf
-            {{ if .Values.certificateMap }}
+            {{- if .Values.certificateMap }}
             - mountPath: /usr/local/share/ca-certificates
               name: certificates
             {{- end }}
@@ -70,7 +70,7 @@ spec:
         - name: {{ include "cite-api.name" . }}-conf
           configMap:
             name: {{ include "cite-api.fullname" . }}
-        {{ if .Values.certificateMap }}
+        {{- if .Values.certificateMap }}
         - name: certificates
           configMap:
             name: {{ .Values.certificateMap }}

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -78,6 +78,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# If this deployment needs to trust non-public certificates,
+# create a configMap with the needed certifcates and specify
+# the configMap name here
+certificateMap: ''
+
 command: ['bash', '-c', 'update-ca-certificates && dotnet Cite.Api.dll']
 
 nodeSelector: {}

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -27,6 +27,12 @@ cite-api:
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certifcates and specify
+  # the configMap name here
+  certificateMap: ''
+
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/alloy.api/Alloy.Api/appsettings.json


### PR DESCRIPTION
The PR adds the ability to add trusted cacerts to the cite-api pod container as other crucible apps do via the certificateMap value.