### PR TITLE
Add settingsYaml: value to topomojo-ui chart

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.6
+appVersion: 2.3.10

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.6
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.6
+appVersion: 2.3.10

--- a/charts/topomojo/charts/topomojo-ui/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7
+version: 0.4.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.7
+appVersion: 2.3.9

--- a/charts/topomojo/charts/topomojo-ui/templates/configmap.yaml
+++ b/charts/topomojo/charts/topomojo-ui/templates/configmap.yaml
@@ -7,7 +7,11 @@ metadata:
 
 data:
   settings.json: |-
+{{- if .Values.settingsYaml }}
+{{ .Values.settingsYaml | toJson | indent 4 }}
+{{- else }}
 {{ .Values.settings | indent 4 }}
+{{- end }}
 
   customize.sh: |
     src=/var/www

--- a/charts/topomojo/charts/topomojo-ui/values.yaml
+++ b/charts/topomojo/charts/topomojo-ui/values.yaml
@@ -97,19 +97,19 @@ basehref: ""
 # faviconsUrl: "https://some.url/favs.tgz"
 
 ## settings is stringified json that gets included as assets/settings.json
-settings: |
-  {
-    appname: 'TopoMojo',
-    oidc: {
-      client_id: 'clientid',
-      authority: 'https://your.identity.authority',
-      redirect_uri: 'https://this.site/oidc',
-      silent_redirect_uri: 'https://this.site/oidc-silent.html',
-      response_type: 'code',
-      scope: 'openid profile topomojo-api',
-      monitorSession: false,
-      loadUserInfo: true,
-      automaticSilentRenew: true,
-      useLocalStorage: true
-    }
-  }
+settings: ""
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  appname: TopoMojo
+  oidc:
+    client_id: clientid
+    authority: https://your.identity.authority
+    redirect_uri: https://this.site/oidc
+    silent_redirect_uri: https://this.site/oidc-silent.html
+    response_type: code
+    scope: openid profile topomojo-api
+    monitorSession: false
+    loadUserInfo: true
+    automaticSilentRenew: true
+    useLocalStorage: true

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -77,13 +77,13 @@ topomojo-api:
   # - TLS and Host URLs need configured, but the snippet should be left alone
   #
   # Topomojo is hardcoded to pass the vmware host using a query parameter named "vmhost".
-  # nginx supports a syntax to resolve variables of the form $arg_name to a query 
+  # nginx supports a syntax to resolve variables of the form $arg_name to a query
   # parameter with key "name" in the request line.
   # That parameter is "vmhost" for this case.
-  # 
+  #
   # nginx resolves $1 to the value of the first capture group of the regex for location:
   # /console/ticket/(.*)
-  # so this means we expect the ticket number to be whatever value is after 
+  # so this means we expect the ticket number to be whatever value is after
   # /console/ticket/ in the request path.
   #
   # An example websocket request that would match this rule is:
@@ -96,11 +96,11 @@ topomojo-api:
   #    allow-snippet-annotations: true
   #    annotations-risk-level: critical  # Became necessary as of ingress-nginx helm chart v4.12
   consoleIngress:
-    deployConsoleProxy: false  
+    deployConsoleProxy: false
     className: ""
     name: vm-consoles
-    namespace: 
-    annotations: 
+    namespace:
+    annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/server-snippet: |
         # Adding proxy configuration for consoles
@@ -355,19 +355,19 @@ topomojo-ui:
   # faviconsUrl: "https://some.url/favs.tgz"
 
   ## settings is stringified json that gets included as assets/settings.json
-  settings: |
-    {
-      appname: 'TopoMojo',
-      oidc: {
-        client_id: 'clientid',
-        authority: 'https://your.identity.authority',
-        redirect_uri: 'https://this.site/oidc',
-        silent_redirect_uri: 'https://this.site/oidc-silent.html',
-        response_type: 'code',
-        scope: 'openid profile topomojo-api',
-        monitorSession: false,
-        loadUserInfo: true,
-        automaticSilentRenew: true,
-        useLocalStorage: true
-      }
-    }
+  settings: ""
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    appname: TopoMojo
+    oidc:
+      client_id: clientid
+      authority: https://your.identity.authority
+      redirect_uri: https://this.site/oidc
+      silent_redirect_uri: https://this.site/oidc-silent.html
+      response_type: code
+      scope: openid profile topomojo-api
+      monitorSession: false
+      loadUserInfo: true
+      automaticSilentRenew: true
+      useLocalStorage: true


### PR DESCRIPTION
Overriding config values with the current topomojo-ui chart is cumbersome, since they are stored as a json string. This PR adds a `settingsYaml:` to this chart to make individual config values easier to override.

The `settings:` value remains to keep the chart backwards-compatible.

Looking for feedback before proceeding with the other Angular charts.