### PR TITLE
TopoMojo: Adds tpl function to select values for umbrella chart use

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
@@ -139,12 +139,12 @@ spec:
       {{- if .Values.existingSecret }}
       - name: {{ include "topomojo-api.name" . }}-extra
         secret:
-          secretName: {{ .Values.existingSecret }}
+          secretName: {{ (tpl .Values.existingSecret .) }}
       {{- end }}
       {{- if .Values.storage.existing }}
       - name: {{ include "topomojo-api.name" . }}-vol
         persistentVolumeClaim:
-          claimName: {{ .Values.storage.existing }}
+          claimName: {{ (tpl .Values.storage.existing .) }}
       {{- else if .Values.storage.size }}
       - name: {{ include "topomojo-api.name" . }}-vol
         persistentVolumeClaim:

--- a/charts/topomojo/charts/topomojo-api/templates/ingress.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/topomojo/charts/topomojo-api/templates/secret.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -76,13 +76,13 @@ ingress:
 # - TLS and Host URLs need configured, but the snippet should be left alone
 #
 # Topomojo is hardcoded to pass the vmware host using a query parameter named "vmhost".
-# nginx supports a syntax to resolve variables of the form $arg_name to a query 
+# nginx supports a syntax to resolve variables of the form $arg_name to a query
 # parameter with key "name" in the request line.
 # That parameter is "vmhost" for this case.
-# 
+#
 # nginx resolves $1 to the value of the first capture group of the regex for location:
 # /console/ticket/(.*)
-# so this means we expect the ticket number to be whatever value is after 
+# so this means we expect the ticket number to be whatever value is after
 # /console/ticket/ in the request path.
 #
 # An example websocket request that would match this rule is:
@@ -95,11 +95,11 @@ ingress:
 #    allow-snippet-annotations: true
 #    annotations-risk-level: critical  # Became necessary as of ingress-nginx helm chart v4.12
 consoleIngress:
-  deployConsoleProxy: false  
+  deployConsoleProxy: false
   className: ""
   name: vm-consoles
-  namespace: 
-  annotations: 
+  namespace:
+  annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/server-snippet: |
       # Adding proxy configuration for consoles

--- a/charts/topomojo/charts/topomojo-ui/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-ui/templates/configmap.yaml
+++ b/charts/topomojo/charts/topomojo-ui/templates/configmap.yaml
@@ -7,10 +7,11 @@ metadata:
 
 data:
   settings.json: |-
-{{- if .Values.settingsYaml }}
-{{ .Values.settingsYaml | toJson | indent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
 {{- else }}
-{{ .Values.settings | indent 4 }}
+{{- .Values.settings | indent 4 }}
 {{- end }}
 
   customize.sh: |

--- a/charts/topomojo/charts/topomojo-ui/templates/ingress.yaml
+++ b/charts/topomojo/charts/topomojo-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
Uses Helm's `tpl` function (https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) to support templating domain names as well as some Kubernetes resource names (mainly existing Secrets and ConfigMaps).