### PR TITLE
[gameboard] Add settingsYaml: and tpl templating

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.2
+appVersion: 3.32.1

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.8
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.1
+appVersion: 3.32.1

--- a/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             - secretRef:
                 name: {{ include "gameboard-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/gameboard/charts/gameboard-api/templates/ingress.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/gameboard/charts/gameboard-api/templates/secret.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.7
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.4.2
+appVersion: 3.32.1

--- a/charts/gameboard/charts/gameboard-ui/templates/configmap.yaml
+++ b/charts/gameboard/charts/gameboard-ui/templates/configmap.yaml
@@ -7,7 +7,12 @@ metadata:
 
 data:
   settings.json: |-
-{{ .Values.settings | indent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}
 
   customize.sh: |
     src=/var/www

--- a/charts/gameboard/charts/gameboard-ui/templates/ingress.yaml
+++ b/charts/gameboard/charts/gameboard-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/gameboard/charts/gameboard-ui/values.yaml
+++ b/charts/gameboard/charts/gameboard-ui/values.yaml
@@ -98,3 +98,6 @@ basehref: ""
 
 ## settings is stringified json that gets included as assets/settings.json
 settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml: {}

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -123,7 +123,7 @@ gameboard-api:
     Database__ConnectionString: ""
     env: {}
 
-  ## existingSecret references a secret already in k8s. 
+  ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
@@ -257,3 +257,6 @@ gameboard-ui:
 
   ## settings is stringified json that gets included as assets/settings.json
   settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml: {}


### PR DESCRIPTION
Similar to #86 and #87, this PR gives the same treatment to the Gameboard chart. This allows for improved values templating when Gameboard is included in umbrella Helm charts.