### PR TITLE
[mkdocs-material] Add values templating

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.4
+version: 0.2.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "9.6.12"
+appVersion: "9.6.14"

--- a/charts/mkdocs-material/templates/configmap.yaml
+++ b/charts/mkdocs-material/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   {{- if not .Values.giturl }}
   mkdocs.yml: |-
-{{ .Values.mkdocs | toYaml | indent 4 }}
+    {{- tpl (toYaml .Values.mkdocs) . | nindent 4 }}
   {{- end }}
 
   nginx.conf: |-
@@ -16,12 +16,12 @@ data:
         listen       80;
         listen  [::]:80;
         server_name  localhost;
-    
+
         location / {
             root   /mkdocs/docs/site;
             index  index.html index.htm;
         }
-    
+
         error_page   500 502 503 504  /50x.html;
         location = /50x.html {
             root   /usr/share/nginx/html;

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           command: ["/entry.d/git-pull.sh"]
           env:
             - name: DOCS_GIT_URL
-              value: {{ .Values.giturl }}
+              value: {{ (tpl .Values.giturl .) }}
             - name: DOCS_GIT_BRANCH
               value: {{ .Values.gitbranch }}
             {{- if .Values.gitCredentialsSecret }}

--- a/charts/mkdocs-material/templates/ingress.yaml
+++ b/charts/mkdocs-material/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}


### PR DESCRIPTION
Similar to #87 and #88, this PR adds value templating via `tpl` to the mkdocs-material chart. This makes it easier template values like domain names, Helm releases, and namespaces.