### PR TITLE
[gameboard/mkdocs-material/topomojo] Template ingress annotations and tls secrets

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-api/templates/ingress.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "gameboard-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ (tpl . $) | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ (tpl .secretName $) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-ui/templates/ingress.yaml
+++ b/charts/gameboard/charts/gameboard-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "gameboard-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ (tpl . $) | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ (tpl .secretName $) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/ingress.yaml
+++ b/charts/mkdocs-material/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "mkdocs-material.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ (tpl . $) | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ (tpl .secretName $) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/templates/ingress.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "topomojo-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ (tpl . $) | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ (tpl .secretName $) }}
     {{- end }}
   {{- end }}
   rules:

--- a/charts/topomojo/charts/topomojo-ui/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-ui/templates/ingress.yaml
+++ b/charts/topomojo/charts/topomojo-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "topomojo-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ (tpl . $) | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ (tpl .secretName $) }}
     {{- end }}
   {{- end }}
   rules:


### PR DESCRIPTION
Update appliance charts to template `annotations` and TLS `secretName` fields. Provides better support for cert-manager in an umbrella chart.