### PR TITLE
Add templating support to crucible charts for certain values that are often different between environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 3.0.0
+version: 1.6.0
+appVersion: 3.5.1

--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -3,4 +3,3 @@ name: alloy
 description: A Helm chart for Kubernetes
 type: application
 version: 1.6.0
-appVersion: 3.5.1

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -3,4 +3,4 @@ name: alloy-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.3.0
-appVersion: latest
+appVersion: 3.5.1

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
+version: 1.3.0
 appVersion: latest

--- a/charts/alloy/charts/alloy-api/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-api/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - secretRef:
                 name: {{ include "alloy-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/alloy/charts/alloy-api/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/alloy/charts/alloy-api/templates/secret.yaml
+++ b/charts/alloy/charts/alloy-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/alloy/charts/alloy-api/templates/secret.yaml
+++ b/charts/alloy/charts/alloy-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.3.0
 appVersion: 3.3.1

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
+version: 1.3.1
 appVersion: latest

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -3,4 +3,4 @@ name: alloy-ui
 description: A Helm chart for Kubernetes
 type: application
 version: 1.3.1
-appVersion: latest
+appVersion: 3.3.1

--- a/charts/alloy/charts/alloy-ui/templates/configmap.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "alloy-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/alloy/charts/alloy-ui/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -106,8 +106,26 @@ env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "http://localhost:4402",
+#   "OIDCSettings": {
+#     "authority": "http://localhost:5000/",
+#     "client_id": "alloy.ui",
+#     "redirect_uri": "http://localhost:4403/auth-callback",
+#     "post_logout_redirect_uri": "http://localhost:4403",
+#     "response_type": "code",
+#     "scope": "openid profile s3 s3-vm alloy-api caster-api steamfitter-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "http://localhost:4403/auth-callback"
+#   },
+#   "AppTitle": "Alloy",
+#   "AppTopBarText": "Alloy",
+#   "AppTopBarHexColor": "#0c918d",
+#   "PlayerUIAddress": "http://localhost:4301",
+#   "PollingIntervalMS": "3500",
+#   "UseLocalAuthStorage": true
+# }'
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml: {}

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -102,30 +102,12 @@ extraVolumeMounts: ""
 extraVolumes: ""
 
 # env is pod env vars
-env: 
+env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as appsettings.Production.json
-# settings: '{
-#   "ApiUrl": "http://localhost:4402",
-#   "OIDCSettings": {
-#     "authority": "http://localhost:5000/",
-#     "client_id": "alloy.ui",
-#     "redirect_uri": "http://localhost:4403/auth-callback",
-#     "post_logout_redirect_uri": "http://localhost:4403",
-#     "response_type": "code",
-#     "scope": "openid profile s3 s3-vm alloy-api caster-api steamfitter-api",
-#     "automaticSilentRenew": true,
-#     "silent_redirect_uri": "http://localhost:4403/auth-callback"
-#   },
-#   "AppTitle": "Alloy",
-#   "AppTopBarText": "Alloy",
-#   "AppTopBarHexColor": "#0c918d",
-#   "PlayerUIAddress": "http://localhost:4301",
-#   "PollingIntervalMS": "3500",
-#   "UseLocalAuthStorage": true
-# }'
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml: {}

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -126,3 +126,6 @@ env:
 #   "PollingIntervalMS": "3500",
 #   "UseLocalAuthStorage": true
 # }'
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml: {}

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -121,25 +121,24 @@ alloy-ui:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and
-  # some basic configuration
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   # NOTE:  PlayerUIAddress is the URL to the Crucible - Player application
-  settings: '{
-    "ApiUrl": "https://alloy.example.com",
-    "OIDCSettings": {
-    "authority": "https://identity.example.com/",
-    "client_id": "alloy-ui",
-    "redirect_uri": "https://alloy.example.com/auth-callback",
-    "post_logout_redirect_uri": "https://alloy.example.com",
-    "response_type": "code",
-    "scope": "openid profile alloy-api player-api caster-api steamfitter-api vm-api",
-    "automaticSilentRenew": true,
-    "silent_redirect_uri": "https://alloy.example.com/auth-callback-silent"
-    },
-    "AppTitle": "Alloy",
-    "AppTopBarText": "Alloy",
-    "AppTopBarHexColor": "#b00",
-    "PlayerUIAddress": "https://player.example.com",
-    "UseLocalAuthStorage": true
-    }'
+  settingsYaml:
+    ApiUrl: https://alloy.example.com
+    OIDCSettings:
+      authority: https://identity.example.com/
+      client_id: alloy-ui
+      redirect_uri: https://alloy.example.com/auth-callback
+      post_logout_redirect_uri: https://alloy.example.com
+      response_type: code
+      scope: openid profile alloy-api player-api caster-api steamfitter-api vm-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://alloy.example.com/auth-callback-silent
+    AppTitle: Alloy
+    AppTopBarText: Alloy
+    AppTopBarHexColor: "#b00"
+    PlayerUIAddress: https://player.example.com
+    UseLocalAuthStorage: true

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -127,18 +127,18 @@ alloy-ui:
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   # NOTE:  PlayerUIAddress is the URL to the Crucible - Player application
   settingsYaml:
-    ApiUrl: https://alloy.example.com
-    OIDCSettings:
-      authority: https://identity.example.com/
-      client_id: alloy-ui
-      redirect_uri: https://alloy.example.com/auth-callback
-      post_logout_redirect_uri: https://alloy.example.com
-      response_type: code
-      scope: openid profile alloy-api player-api caster-api steamfitter-api vm-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://alloy.example.com/auth-callback-silent
-    AppTitle: Alloy
-    AppTopBarText: Alloy
-    AppTopBarHexColor: "#b00"
-    PlayerUIAddress: https://player.example.com
-    UseLocalAuthStorage: true
+    # ApiUrl: https://alloy.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com/
+    #   client_id: alloy-ui
+    #   redirect_uri: https://alloy.example.com/auth-callback
+    #   post_logout_redirect_uri: https://alloy.example.com
+    #   response_type: code
+    #   scope: openid profile alloy-api player-api caster-api steamfitter-api vm-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://alloy.example.com/auth-callback-silent
+    # AppTitle: Alloy
+    # AppTopBarText: Alloy
+    # AppTopBarHexColor: "#b00"
+    # PlayerUIAddress: https://player.example.com
+    # UseLocalAuthStorage: true

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: blueprint
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 1.0.0
+version: 1.6.0

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
-appVersion: 1.0.0
+version: 1.3.0
+appVersion: 1.4.7

--- a/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - secretRef:
                 name: {{ include "blueprint-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/blueprint/charts/blueprint-api/templates/secret.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/blueprint/charts/blueprint-api/templates/secret.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -3,4 +3,4 @@ name: blueprint-ui
 description: A Helm chart for Kubernetes
 type: application
 version: 1.2.1
-appVersion: 1.0.0
+appVersion: 1.4.8

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: 1.4.8

--- a/charts/blueprint/charts/blueprint-ui/templates/configmap.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "blueprint-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -100,4 +100,8 @@ extraVolumes: ""
 
 extraVolumeMounts: ""
 
-settings: '{}'
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml: {}

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -85,25 +85,24 @@ blueprint-ui:
   extraVolumeMounts: ""
 
   env:
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and
-  # some basic configuration
-  settings: '{
-    "ApiUrl": "https://blueprint.example.com",
-    "OIDCSettings": {
-      "authority": "https://identity.example.com/",
-      "client_id": "blueprint-ui",
-      "redirect_uri": "https://blueprint.example.com/auth-callback",
-      "post_logout_redirect_uri": "https://blueprint.example.com",
-      "response_type": "code",
-      "scope": "openid profile blueprint",
-      "automaticSilentRenew": true,
-      "silent_redirect_uri": "https://blueprint.example.com/auth-callback-silent"
-    },
-    "AppTitle": "Blueprint",
-    "AppTopBarHexColor": "#2d69b4",
-    "AppTopBarHexTextColor": "#FFFFFF",
-    "AppTopBarText": "Blueprint  -  Exercise Planning",
-    "AppTopBarImage": "/assets/img/monitor-dashboard-white.png",
-    "UseLocalAuthStorage": true
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://blueprint.example.com
+    OIDCSettings:
+      authority: https://identity.example.com/
+      client_id: blueprint-ui
+      redirect_uri: https://blueprint.example.com/auth-callback
+      post_logout_redirect_uri: https://blueprint.example.com
+      response_type: code
+      scope: openid profile blueprint
+      automaticSilentRenew: true
+      silent_redirect_uri: https://blueprint.example.com/auth-callback-silent
+    AppTitle: Blueprint
+    AppTopBarHexColor: "#2d69b4"
+    AppTopBarHexTextColor: "#FFFFFF"
+    AppTopBarText: Blueprint  -  Exercise Planning
+    AppTopBarImage: /assets/img/monitor-dashboard-white.png
+    UseLocalAuthStorage: true

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -90,19 +90,19 @@ blueprint-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://blueprint.example.com
-    OIDCSettings:
-      authority: https://identity.example.com/
-      client_id: blueprint-ui
-      redirect_uri: https://blueprint.example.com/auth-callback
-      post_logout_redirect_uri: https://blueprint.example.com
-      response_type: code
-      scope: openid profile blueprint
-      automaticSilentRenew: true
-      silent_redirect_uri: https://blueprint.example.com/auth-callback-silent
-    AppTitle: Blueprint
-    AppTopBarHexColor: "#2d69b4"
-    AppTopBarHexTextColor: "#FFFFFF"
-    AppTopBarText: Blueprint  -  Exercise Planning
-    AppTopBarImage: /assets/img/monitor-dashboard-white.png
-    UseLocalAuthStorage: true
+    # ApiUrl: https://blueprint.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com/
+    #   client_id: blueprint-ui
+    #   redirect_uri: https://blueprint.example.com/auth-callback
+    #   post_logout_redirect_uri: https://blueprint.example.com
+    #   response_type: code
+    #   scope: openid profile blueprint
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://blueprint.example.com/auth-callback-silent
+    # AppTitle: Blueprint
+    # AppTopBarHexColor: "#2d69b4"
+    # AppTopBarHexTextColor: "#FFFFFF"
+    # AppTopBarText: Blueprint  -  Exercise Planning
+    # AppTopBarImage: /assets/img/monitor-dashboard-white.png
+    # UseLocalAuthStorage: true

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: caster
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 3.3.0
+version: 1.6.0

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.2
-appVersion: latest
+version: 1.5.0
+appVersion: 3.4.2

--- a/charts/caster/charts/caster-api/templates/deployment.yaml
+++ b/charts/caster/charts/caster-api/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - secretRef:
                 name: {{ include "caster-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/caster/charts/caster-api/templates/ingress.yaml
+++ b/charts/caster/charts/caster-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/caster/charts/caster-api/templates/secret.yaml
+++ b/charts/caster/charts/caster-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/caster/charts/caster-api/templates/secret.yaml
+++ b/charts/caster/charts/caster-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/caster/charts/caster-api/templates/statefulset.yaml
+++ b/charts/caster/charts/caster-api/templates/statefulset.yaml
@@ -35,9 +35,17 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
+          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "caster-api.fullname" . }}
+            - secretRef:
+                name: {{ (tpl .Values.existingSecret .) }}
+          {{- else }}
+          envFrom:
+            - secretRef:
+                name: {{ include "caster-api.fullname" . }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -120,7 +120,7 @@ terraformrc:
           }
       }
 
-## existingSecret references a secret already in k8s. 
+## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 
@@ -190,7 +190,7 @@ env:
 
   Authorization__Authority:
   Authorization__AuthorizationUrl:
-  Authorization__TokenUrl: 
+  Authorization__TokenUrl:
   Authorization__AuthorizationScope: 'caster-api'
   Authorization__ClientId: caster-api-dev
   Authorization__ClientName: 'Caster API'

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
-appVersion: latest
+version: 1.5.0
+appVersion: 3.4.1

--- a/charts/caster/charts/caster-ui/templates/configmap.yaml
+++ b/charts/caster/charts/caster-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "caster-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/caster/charts/caster-ui/templates/ingress.yaml
+++ b/charts/caster/charts/caster-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -104,18 +104,19 @@ env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-# settings: '{
-#   "ApiUrl": "",
-#   "OIDCSettings": {
-#     "authority": "",
-#     "client_id": "caster-ui-dev",
-#     "redirect_uri": "",
-#     "post_logout_redirect_uri": "",
-#     "response_type": "code",
-#     "scope": "openid profile email caster-api",
-#     "automaticSilentRenew": true,
-#     "silent_redirect_uri": ""
-#   },
-#   "UseLocalAuthStorage": true
-# }'
-settings: ""
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  # ApiUrl: ""
+  # OIDCSettings:
+  #   authority: ""
+  #   client_id: caster-ui-dev
+  #   redirect_uri: ""
+  #   post_logout_redirect_uri: ""
+  #   response_type: code
+  #   scope: openid profile email caster-api
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: ""
+  # UseLocalAuthStorage: true

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -250,15 +250,15 @@ caster-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://caster.example.com
-    OIDCSettings:
-      authority: https://identity.example.com/
-      client_id: caster-ui-dev
-      redirect_uri: https://caster.example.com/auth-callback/
-      post_logout_redirect_uri: https://caster.example.com/
-      response_type: code
-      scope: openid profile email caster-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://caster.example.com/auth-callback-silent/
-    UseLocalAuthStorage: true
+    # ApiUrl: https://caster.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com/
+    #   client_id: caster-ui-dev
+    #   redirect_uri: https://caster.example.com/auth-callback/
+    #   post_logout_redirect_uri: https://caster.example.com/
+    #   response_type: code
+    #   scope: openid profile email caster-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://caster.example.com/auth-callback-silent/
+    # UseLocalAuthStorage: true
 

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -240,25 +240,25 @@ caster-ui:
   extraVolumes: ""
 
   extraVolumeMounts: ""
-  
-  env: 
+
+  env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client
-  settings: |-
-    '{
-      "ApiUrl": "https://caster.example.com",
-      "OIDCSettings": {
-        "authority": "https://identity.example.com/",
-        "client_id": "caster-ui-dev",
-        "redirect_uri": "https://caster.example.com/auth-callback/",
-        "post_logout_redirect_uri": "https://caster.example.com/",
-        "response_type": "code",
-        "scope": "openid profile email caster-api",
-        "automaticSilentRenew": true,
-        "silent_redirect_uri": "https://caster.example.com/auth-callback-silent/"
-      },
-      "UseLocalAuthStorage": true
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://caster.example.com
+    OIDCSettings:
+      authority: https://identity.example.com/
+      client_id: caster-ui-dev
+      redirect_uri: https://caster.example.com/auth-callback/
+      post_logout_redirect_uri: https://caster.example.com/
+      response_type: code
+      scope: openid profile email caster-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://caster.example.com/auth-callback-silent/
+    UseLocalAuthStorage: true
+

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.1
-appVersion: 1.0.0
+version: 1.6.0

--- a/charts/cite/charts/cite-api/Chart.yaml
+++ b/charts/cite/charts/cite-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
-appVersion: latest
+version: 1.3.0
+appVersion: 1.8.1

--- a/charts/cite/charts/cite-api/templates/deployment.yaml
+++ b/charts/cite/charts/cite-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - secretRef:
                 name: {{ include "cite-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/cite/charts/cite-api/templates/ingress.yaml
+++ b/charts/cite/charts/cite-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/cite/charts/cite-api/templates/secret.yaml
+++ b/charts/cite/charts/cite-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/cite/charts/cite-api/templates/secret.yaml
+++ b/charts/cite/charts/cite-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -91,7 +91,7 @@ tolerations: []
 
 affinity: {}
 
-## existingSecret references a secret already in k8s. 
+## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 1.8.2

--- a/charts/cite/charts/cite-ui/templates/configmap.yaml
+++ b/charts/cite/charts/cite-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "cite-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/cite/charts/cite-ui/templates/ingress.yaml
+++ b/charts/cite/charts/cite-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -104,26 +104,28 @@ env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as appsettings.Production.json
-# {
-#     "ApiUrl": "http://localhost:4720",
-#     "OIDCSettings": {
-#         "authority": "http://localhost:5000/",
-#         "client_id": "cite.ui",
-#         "redirect_uri": "http://localhost:4721/auth-callback",
-#         "post_logout_redirect_uri": "http://localhost:4721",
-#         "response_type": "code",
-#         "scope": "openid profile player player-vm cite",
-#         "automaticSilentRenew": true,
-#         "silent_redirect_uri": "http://localhost:4721/auth-callback-silent"
-#     },
-#     "AppTitle": "CITE",
-#     "AppTopBarHexColor": "#2d69b4",
-#     "AppTopBarHexTextColor": "#FFFFFF",
-#     "AppTopBarText": "CITE  -  Financial Incident Threat Evaluator",
-#     "UseLocalAuthStorage": true,
-#     "DefaultScoringModelId": "",
-#     "DefaultEvaluationId": "",
-#     "DefaultTeamId": ""
-# }
-settings: ""
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  # ApiUrl: http://localhost:4720
+  # OIDCSettings:
+  #   authority: http://localhost:5000/
+  #   client_id: cite.ui
+  #   redirect_uri: http://localhost:4721/auth-callback
+  #   post_logout_redirect_uri: http://localhost:4721
+  #   response_type: code
+  #   scope: openid profile player player-vm cite
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: http://localhost:4721/auth-callback-silent
+  # AppTitle: CITE
+  # AppTopBarHexColor: "#2d69b4"
+  # AppTopBarHexTextColor: "#FFFFFF"
+  # AppTopBarText: CITE  -  Financial Incident Threat Evaluator
+  # UseLocalAuthStorage: true
+  # DefaultScoringModelId: ""
+  # DefaultEvaluationId: ""
+  # DefaultTeamId: ""
+
+

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -118,23 +118,23 @@ cite-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://cite.example.com
-    OIDCSettings:
-      authority: https://identity.example.com/
-      client_id: cite-ui
-      redirect_uri: https://cite.example.com/auth-callback
-      post_logout_redirect_uri: https://cite.example.com
-      response_type: code
-      scope: openid profile alloy-api player-api vm-api cite-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://cite.example.com/auth-callback-silent
-    AppTitle: CITE
-    AppTopBarHexColor: "#2d69b4"
-    AppTopBarHexTextColor: "#FFFFFF"
-    AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
-    UseLocalAuthStorage: true
-    DefaultScoringModelId: ""
-    DefaultEvaluationId: ""
-    DefaultTeamId: ""
+    # ApiUrl: https://cite.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com/
+    #   client_id: cite-ui
+    #   redirect_uri: https://cite.example.com/auth-callback
+    #   post_logout_redirect_uri: https://cite.example.com
+    #   response_type: code
+    #   scope: openid profile alloy-api player-api vm-api cite-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://cite.example.com/auth-callback-silent
+    # AppTitle: CITE
+    # AppTopBarHexColor: "#2d69b4"
+    # AppTopBarHexTextColor: "#FFFFFF"
+    # AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
+    # UseLocalAuthStorage: true
+    # DefaultScoringModelId: ""
+    # DefaultEvaluationId: ""
+    # DefaultTeamId: ""
 
 

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -113,27 +113,28 @@ cite-ui:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and
-  # some basic configuration
-  settings: '{
-    "ApiUrl": "https://cite.example.com",
-    "OIDCSettings": {
-    "authority": "https://identity.example.com/",
-    "client_id": "cite-ui",
-    "redirect_uri": "https://cite.example.com/auth-callback",
-    "post_logout_redirect_uri": "https://cite.example.com",
-    "response_type": "code",
-    "scope": "openid profile alloy-api player-api vm-api cite-api",
-    "automaticSilentRenew": true,
-    "silent_redirect_uri": "https://cite.example.com/auth-callback-silent"
-    },
-    "AppTitle": "CITE",
-    "AppTopBarHexColor": "#2d69b4",
-    "AppTopBarHexTextColor": "#FFFFFF",
-    "AppTopBarText": "CITE  -  Collaborative Incident Threat Evaluator",
-    "UseLocalAuthStorage": true,
-    "DefaultScoringModelId": "",
-    "DefaultEvaluationId": "",
-    "DefaultTeamId": ""
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://cite.example.com
+    OIDCSettings:
+      authority: https://identity.example.com/
+      client_id: cite-ui
+      redirect_uri: https://cite.example.com/auth-callback
+      post_logout_redirect_uri: https://cite.example.com
+      response_type: code
+      scope: openid profile alloy-api player-api vm-api cite-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://cite.example.com/auth-callback-silent
+    AppTitle: CITE
+    AppTopBarHexColor: "#2d69b4"
+    AppTopBarHexTextColor: "#FFFFFF"
+    AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
+    UseLocalAuthStorage: true
+    DefaultScoringModelId: ""
+    DefaultEvaluationId: ""
+    DefaultTeamId: ""
+
+

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: gallery
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 1.0.0
+version: 1.6.0

--- a/charts/gallery/charts/gallery-api/Chart.yaml
+++ b/charts/gallery/charts/gallery-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
-appVersion: 1.0.0
+version: 1.3.0
+appVersion: 1.7.4

--- a/charts/gallery/charts/gallery-api/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - secretRef:
                 name: {{ include "gallery-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/gallery/charts/gallery-api/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/gallery/charts/gallery-api/templates/secret.yaml
+++ b/charts/gallery/charts/gallery-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ $(tpl $val $) | quote }}
 {{- end }}

--- a/charts/gallery/charts/gallery-api/templates/secret.yaml
+++ b/charts/gallery/charts/gallery-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $(tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
-appVersion: 1.0.0
+version: 1.3.0
+appVersion: 1.7.4

--- a/charts/gallery/charts/gallery-ui/templates/configmap.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "gallery-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/gallery/charts/gallery-ui/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -100,4 +100,8 @@ extraVolumes: ""
 
 extraVolumeMounts: ""
 
-settings: '{}'
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml: {}

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -91,20 +91,20 @@ gallery-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://gallery.example.com
-    OIDCSettings:
-      authority: https://identity.example.com/
-      client_id: gallery-ui
-      redirect_uri: https://gallery.example.com/auth-callback
-      post_logout_redirect_uri: https://gallery.example.com
-      response_type: code
-      scope: openid profile gallery
-      automaticSilentRenew: true
-      silent_redirect_uri: https://gallery.example.com/auth-callback-silent
-    AppTitle: Gallery
-    AppTopBarHexColor: "#2d69b4"
-    AppTopBarHexTextColor: "#FFFFFF"
-    AppTopBarText: Gallery  -  Exercise Information Sharing
-    AppTopBarImage: /assets/img/monitor-dashboard-white.png
-    UseLocalAuthStorage: true
+    # ApiUrl: https://gallery.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com/
+    #   client_id: gallery-ui
+    #   redirect_uri: https://gallery.example.com/auth-callback
+    #   post_logout_redirect_uri: https://gallery.example.com
+    #   response_type: code
+    #   scope: openid profile gallery
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://gallery.example.com/auth-callback-silent
+    # AppTitle: Gallery
+    # AppTopBarHexColor: "#2d69b4"
+    # AppTopBarHexTextColor: "#FFFFFF"
+    # AppTopBarText: Gallery  -  Exercise Information Sharing
+    # AppTopBarImage: /assets/img/monitor-dashboard-white.png
+    # UseLocalAuthStorage: true
 

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -84,26 +84,27 @@ gallery-ui:
 
   extraVolumeMounts: ""
 
-  env: 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and
-  # some basic configuration
-  settings: '{
-    "ApiUrl": "https://gallery.example.com",
-    "OIDCSettings": {
-      "authority": "https://identity.example.com/",
-      "client_id": "gallery-ui",
-      "redirect_uri": "https://gallery.example.com/auth-callback",
-      "post_logout_redirect_uri": "https://gallery.example.com",
-      "response_type": "code",
-      "scope": "openid profile gallery",
-      "automaticSilentRenew": true,
-      "silent_redirect_uri": "https://gallery.example.com/auth-callback-silent"
-    },
-    "AppTitle": "Gallery",
-    "AppTopBarHexColor": "#2d69b4",
-    "AppTopBarHexTextColor": "#FFFFFF",
-    "AppTopBarText": "Gallery  -  Exercise Information Sharing",
-    "AppTopBarImage": "/assets/img/monitor-dashboard-white.png",
-    "UseLocalAuthStorage": true
-    }'
+  env:
+
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://gallery.example.com
+    OIDCSettings:
+      authority: https://identity.example.com/
+      client_id: gallery-ui
+      redirect_uri: https://gallery.example.com/auth-callback
+      post_logout_redirect_uri: https://gallery.example.com
+      response_type: code
+      scope: openid profile gallery
+      automaticSilentRenew: true
+      silent_redirect_uri: https://gallery.example.com/auth-callback-silent
+    AppTitle: Gallery
+    AppTopBarHexColor: "#2d69b4"
+    AppTopBarHexTextColor: "#FFFFFF"
+    AppTopBarText: Gallery  -  Exercise Information Sharing
+    AppTopBarImage: /assets/img/monitor-dashboard-white.png
+    UseLocalAuthStorage: true
+

--- a/charts/gameboard/charts/gameboard-api/templates/secret.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -122,7 +122,7 @@ migrations:
   Database__ConnectionString: ""
   env: {}
 
-## existingSecret references a secret already in k8s. 
+## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 3.2.2
+version: 1.6.0

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: console-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 3.3.0

--- a/charts/player/charts/console-ui/templates/configmap.yaml
+++ b/charts/player/charts/console-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "console-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/player/charts/console-ui/templates/ingress.yaml
+++ b/charts/player/charts/console-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -100,44 +100,62 @@ extraVolumes: ""
 
 extraVolumeMounts: ""
 
-env: 
+env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-settings: |-
-  {
-    "ConsoleApiUrl": "https://example.com/vm/api",
-    "OIDCSettings": {
-      "authority": "https://example.com/identity",
-      "client_id": "vm-console-ui",
-      "redirect_uri": "https://example.com/console/auth-callback",
-      "post_logout_redirect_uri": "https://example.com/console",
-      "response_type": "code",
-      "scope": "openid profile player-api vm-api",
-      "automaticSilentRenew": true,
-      "silent_redirect_uri": "https://example.com/console/auth-callback-silent"
-    },
-    "UseLocalAuthStorage": true,
-    "VmResolutionOptions": [
-      { "width": 2560, "height": 1600 },
-      { "width": 1920, "height": 1440 },
-      { "width": 1920, "height": 1200 },
-      { "width": 1600, "height": 1200 },
-      { "width": 1400, "height": 1050 },
-      { "width": 1280, "height": 1024 },
-      { "width": 1440, "height": 900 },
-      { "width": 1280, "height": 960 },
-      { "width": 1366, "height": 768 },
-      { "width": 1280, "height": 800 },
-      { "width": 1280, "height": 720 },
-      { "width": 1024, "height": 768 },
-      { "width": 800, "height": 600 }
-    ],
-    "PasteSpeeds": [
-      { "name": "Fastest", "value": 10 },
-      { "name": "Fast", "value": 30 },
-      { "name": "Normal", "value": 60 },
-      { "name": "Slow", "value": 100 },
-      { "name": "Slowest", "value": 500 }
-    ]
-  }
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  ConsoleApiUrl: https://example.com/vm/api
+  OIDCSettings:
+    authority: https://example.com/identity
+    client_id: vm-console-ui
+    redirect_uri: https://example.com/console/auth-callback
+    post_logout_redirect_uri: https://example.com/console
+    response_type: code
+    scope: openid profile player-api vm-api
+    automaticSilentRenew: true
+    silent_redirect_uri: https://example.com/console/auth-callback-silent
+  UseLocalAuthStorage: true
+  VmResolutionOptions:
+    - width: 2560
+      height: 1600
+    - width: 1920
+      height: 1440
+    - width: 1920
+      height: 1200
+    - width: 1600
+      height: 1200
+    - width: 1400
+      height: 1050
+    - width: 1280
+      height: 1024
+    - width: 1440
+      height: 900
+    - width: 1280
+      height: 960
+    - width: 1366
+      height: 768
+    - width: 1280
+      height: 800
+    - width: 1280
+      height: 720
+    - width: 1024
+      height: 768
+    - width: 800
+      height: 600
+  PasteSpeeds:
+    - name: Fastest
+      value: 10
+    - name: Fast
+      value: 30
+    - name: Normal
+      value: 60
+    - name: Slow
+      value: 100
+    - name: Slowest
+      value: 500
+

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -109,53 +109,53 @@ settings: "{}"
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  ConsoleApiUrl: https://example.com/vm/api
-  OIDCSettings:
-    authority: https://example.com/identity
-    client_id: vm-console-ui
-    redirect_uri: https://example.com/console/auth-callback
-    post_logout_redirect_uri: https://example.com/console
-    response_type: code
-    scope: openid profile player-api vm-api
-    automaticSilentRenew: true
-    silent_redirect_uri: https://example.com/console/auth-callback-silent
-  UseLocalAuthStorage: true
-  VmResolutionOptions:
-    - width: 2560
-      height: 1600
-    - width: 1920
-      height: 1440
-    - width: 1920
-      height: 1200
-    - width: 1600
-      height: 1200
-    - width: 1400
-      height: 1050
-    - width: 1280
-      height: 1024
-    - width: 1440
-      height: 900
-    - width: 1280
-      height: 960
-    - width: 1366
-      height: 768
-    - width: 1280
-      height: 800
-    - width: 1280
-      height: 720
-    - width: 1024
-      height: 768
-    - width: 800
-      height: 600
-  PasteSpeeds:
-    - name: Fastest
-      value: 10
-    - name: Fast
-      value: 30
-    - name: Normal
-      value: 60
-    - name: Slow
-      value: 100
-    - name: Slowest
-      value: 500
+  # ConsoleApiUrl: https://example.com/vm/api
+  # OIDCSettings:
+  #   authority: https://example.com/identity
+  #   client_id: vm-console-ui
+  #   redirect_uri: https://example.com/console/auth-callback
+  #   post_logout_redirect_uri: https://example.com/console
+  #   response_type: code
+  #   scope: openid profile player-api vm-api
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: https://example.com/console/auth-callback-silent
+  # UseLocalAuthStorage: true
+  # VmResolutionOptions:
+  #   - width: 2560
+  #     height: 1600
+  #   - width: 1920
+  #     height: 1440
+  #   - width: 1920
+  #     height: 1200
+  #   - width: 1600
+  #     height: 1200
+  #   - width: 1400
+  #     height: 1050
+  #   - width: 1280
+  #     height: 1024
+  #   - width: 1440
+  #     height: 900
+  #   - width: 1280
+  #     height: 960
+  #   - width: 1366
+  #     height: 768
+  #   - width: 1280
+  #     height: 800
+  #   - width: 1280
+  #     height: 720
+  #   - width: 1024
+  #     height: 768
+  #   - width: 800
+  #     height: 600
+  # PasteSpeeds:
+  #   - name: Fastest
+  #     value: 10
+  #   - name: Fast
+  #     value: 30
+  #   - name: Normal
+  #     value: 60
+  #   - name: Slow
+  #     value: 100
+  #   - name: Slowest
+  #     value: 500
 

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: latest
+version: 1.6.0
+appVersion: 3.3.4

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - secretRef:
                 name: {{ include "player-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/player/charts/player-api/templates/ingress.yaml
+++ b/charts/player/charts/player-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/player-api/templates/secret.yaml
+++ b/charts/player/charts/player-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/player/charts/player-api/templates/secret.yaml
+++ b/charts/player/charts/player-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.4
-appVersion: latest
+version: 1.5.0
+appVersion: 3.3.1

--- a/charts/player/charts/player-ui/templates/configmap.yaml
+++ b/charts/player/charts/player-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "player-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/player/charts/player-ui/templates/ingress.yaml
+++ b/charts/player/charts/player-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -109,22 +109,22 @@ settings: "{}"
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  ApiUrl: https://example.com/player
-  OIDCSettings:
-    authority: https://example.com/identity
-    client_id: player-ui
-    redirect_uri: https://example.com/player/auth-callback
-    post_logout_redirect_uri: https://example.com/player
-    response_type: code
-    scope: openid profile player-api
-    automaticSilentRenew: true
-    silent_redirect_uri: https://example.com/player/auth-callback-silent
-  NotificationsSettings:
-    url: https://example.com/player/hubs
-    number_to_display: 4
-  AppTitle: Crucible
-  AppTopBarText: Crucible
-  AppTopBarHexColor: "#b00"
-  AppTopBarHexTextColor: "#FFFFFF"
-  UseLocalAuthStorage: true
+  # ApiUrl: https://example.com/player
+  # OIDCSettings:
+  #   authority: https://example.com/identity
+  #   client_id: player-ui
+  #   redirect_uri: https://example.com/player/auth-callback
+  #   post_logout_redirect_uri: https://example.com/player
+  #   response_type: code
+  #   scope: openid profile player-api
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: https://example.com/player/auth-callback-silent
+  # NotificationsSettings:
+  #   url: https://example.com/player/hubs
+  #   number_to_display: 4
+  # AppTitle: Crucible
+  # AppTopBarText: Crucible
+  # AppTopBarHexColor: "#b00"
+  # AppTopBarHexTextColor: "#FFFFFF"
+  # UseLocalAuthStorage: true
 

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -100,30 +100,31 @@ extraVolumes: ""
 
 extraVolumeMounts: ""
 
-env: 
+env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-settings: |-
-  {
-    "ApiUrl": "https://example.com/player",
-    "OIDCSettings": {
-      "authority": "https://example.com/identity",
-      "client_id": "player-ui",
-      "redirect_uri": "https://example.com/player/auth-callback",
-      "post_logout_redirect_uri": "https://example.com/player",
-      "response_type": "code",
-      "scope": "openid profile player-api",
-      "automaticSilentRenew": true,
-      "silent_redirect_uri": "https://example.com/player/auth-callback-silent"
-    },
-    "NotificationsSettings": {
-      "url": "https://example.com/player/hubs",
-      "number_to_display": 4
-    },
-    "AppTitle": "Crucible",
-    "AppTopBarText": "Crucible",
-    "AppTopBarHexColor": "#b00",
-    "AppTopBarHexTextColor": "#FFFFFF",
-    "UseLocalAuthStorage": true
-  }
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  ApiUrl: https://example.com/player
+  OIDCSettings:
+    authority: https://example.com/identity
+    client_id: player-ui
+    redirect_uri: https://example.com/player/auth-callback
+    post_logout_redirect_uri: https://example.com/player
+    response_type: code
+    scope: openid profile player-api
+    automaticSilentRenew: true
+    silent_redirect_uri: https://example.com/player/auth-callback-silent
+  NotificationsSettings:
+    url: https://example.com/player/hubs
+    number_to_display: 4
+  AppTitle: Crucible
+  AppTopBarText: Crucible
+  AppTopBarHexColor: "#b00"
+  AppTopBarHexTextColor: "#FFFFFF"
+  UseLocalAuthStorage: true
+

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.3
-appVersion: latest
+version: 1.5.0
+appVersion: 3.7.0

--- a/charts/player/charts/vm-api/templates/console-ingress.yaml
+++ b/charts/player/charts/vm-api/templates/console-ingress.yaml
@@ -29,14 +29,14 @@ spec:
     {{- range .Values.consoleIngress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.consoleIngress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/vm-api/templates/deployment.yaml
+++ b/charts/player/charts/vm-api/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - secretRef:
                 name: {{ include "vm-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/player/charts/vm-api/templates/ingress.yaml
+++ b/charts/player/charts/vm-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/vm-api/templates/pv-iso.yaml
+++ b/charts/player/charts/vm-api/templates/pv-iso.yaml
@@ -14,4 +14,4 @@ spec:
     path: {{ .Values.iso.path }}
     readOnly: false
   storageClassName: "nfs"
-{{- end }}   
+{{- end }}

--- a/charts/player/charts/vm-api/templates/secret.yaml
+++ b/charts/player/charts/vm-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/player/charts/vm-api/templates/secret.yaml
+++ b/charts/player/charts/vm-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.1
-appVersion: latest
+version: 1.3.0
+appVersion: 3.5.0

--- a/charts/player/charts/vm-ui/templates/configmap.yaml
+++ b/charts/player/charts/vm-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "vm-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/player/charts/vm-ui/templates/ingress.yaml
+++ b/charts/player/charts/vm-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -102,27 +102,28 @@ extraVolumeMounts: ""
 
 additionalVolumes: []
 
-env: 
+env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-# settings: |-
-#   {
-#     "ApiUrl": "https://example.com/vm/api",
-#     "DeployApiUrl": "",
-#     "ApiPlayerUrl": "https://example.com/player/api",
-#     "WelderUrl": "",
-#     "UserFollowUrl": "https://example.com/vm/console/user/{userId}/view/{viewId}/console",
-#     "OIDCSettings": {
-#       "authority": "https://example.com/identity",
-#       "client_id": "vm-ui",
-#       "redirect_uri": "https://example.com/vm/auth-callback",
-#       "post_logout_redirect_uri": "https://example.com/vm",
-#       "response_type": "code",
-#       "scope": "openid profile player-api vm-api",
-#       "automaticSilentRenew": true,
-#       "silent_redirect_uri": "https://example.com/vm/auth-callback-silent"
-#     },
-#     "UseLocalAuthStorage": true
-#   }
-settings: ""
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  # ApiUrl: https://example.com/vm/api
+  # DeployApiUrl: ""
+  # ApiPlayerUrl: https://example.com/player/api
+  # WelderUrl: ""
+  # UserFollowUrl: https://example.com/vm/console/user/{userId}/view/{viewId}/console
+  # OIDCSettings:
+  #   authority: https://example.com/identity
+  #   client_id: vm-ui
+  #   redirect_uri: https://example.com/vm/auth-callback
+  #   post_logout_redirect_uri: https://example.com/vm
+  #   response_type: code
+  #   scope: openid profile player-api vm-api
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: https://example.com/vm/auth-callback-silent
+  # UseLocalAuthStorage: true
+

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -1,8 +1,5 @@
 player-api:
   kind: "Deployment"
-  # Docker image release version
-  image:
-    tag: "3.2.3"
 
   probes:
     livenessProbe:
@@ -28,7 +25,7 @@ player-api:
       timeoutSeconds: 1
       failureThreshold: 15
       successThreshold: 1
-  
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
@@ -54,7 +51,7 @@ player-api:
   # the configMap name here
   certificateMap: ""
 
-  
+
 
   # storage - either an existing pvc, the size for a new pvc, or emptyDir
   # this is used to store uploaded files
@@ -64,7 +61,7 @@ player-api:
     mode: ReadWriteOnce
     class: default
 
-  ## existingSecret references a secret already in k8s. 
+  ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
@@ -107,10 +104,10 @@ player-api:
     # TODO - Document Seed Data
     # This is a placeholder and needs to be updated for a new install.
     # Upgrades should keep administrators from the previous install.
-    
+
     # SeedData__Permissions__0__Name: "Demo Permission"
     # SeedData__Permissions__0__Description: "This is a demo permission"
-    
+
     # SeedData__Roles__0__Name: "Demo Role"
     # SeedData__Roles__0__AllPermissions: false
     # SeedData__Roles__0__Permissions__0: "Demo Permission"
@@ -129,14 +126,10 @@ player-api:
 
 player-ui:
 
-  # Docker image release version
-  image:
-    tag: "3.1.8"
-
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
-    enabled: true    
+    enabled: true
     className: ""
     annotations:
       kubernetes.io/ingress.class: nginx
@@ -169,42 +162,35 @@ player-ui:
 
   extraVolumeMounts: ""
 
-  env: 
+  env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and
-  # some basic configuration
-  settings: | 
-    '{
-      "ApiUrl": "https://player.example.com",
-      "OIDCSettings": {
-        "authority": "https://identity.example.com",
-        "client_id": "player-ui-dev",
-        "redirect_uri": "https://player.example.com/auth-callback/",
-        "post_logout_redirect_uri": "https://player.example.com",
-        "response_type": "code",
-        "scope": "openid profile player-api",
-        "automaticSilentRenew": true,
-        "silent_redirect_uri": "https://player.example.com/auth-callback-silent/"
-      },
-      "NotificationsSettings": {
-        "url": "https://player.example.com/hubs",
-        "number_to_display": 4
-      },
-      "AppTitle": "Crucible",
-      "AppTopBarText": "Crucible",
-      "AppTopBarHexColor": "#b00",
-      "AppTopBarHexTextColor": "#FFFFFF",
-      "UseLocalAuthStorage": true
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://player.example.com
+    OIDCSettings:
+      authority: https://identity.example.com
+      client_id: player-ui-dev
+      redirect_uri: https://player.example.com/auth-callback/
+      post_logout_redirect_uri: https://player.example.com
+      response_type: code
+      scope: openid profile player-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://player.example.com/auth-callback-silent/
+    NotificationsSettings:
+      url: https://player.example.com/hubs
+      number_to_display: 4
+    AppTitle: Crucible
+    AppTopBarText: Crucible
+    AppTopBarHexColor: "#b00"
+    AppTopBarHexTextColor: "#FFFFFF"
+    UseLocalAuthStorage: true
 
 vm-api:
-
-  # Docker image release version
-  image:
-    tag: "3.5.3"
 
   # iso - an NFS volume mount for ISO uploads
   iso:
@@ -212,11 +198,11 @@ vm-api:
     size: ""
     server: ""
     path: ""
-    
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
-    enabled: true  
+    enabled: true
     className: ""
     annotations:
       kubernetes.io/ingress.class: nginx
@@ -243,10 +229,10 @@ vm-api:
   #   connections will go directly from the UI to the vCenter hosts themselves
   # - The host value here corresponds to RewriteHost__RewriteHostUrl below
   consoleIngress:
-    deployConsoleProxy: false  
+    deployConsoleProxy: false
     className: ""
     name: player-connect
-    annotations: 
+    annotations:
       kubernetes.io/ingress.class: nginx
       nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
@@ -272,7 +258,7 @@ vm-api:
   # the configMap name here
   certificateMap: ""
 
-  ## existingSecret references a secret already in k8s. 
+  ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
@@ -313,8 +299,8 @@ vm-api:
     IdentityClient__TokenUrl: https://identity.example.com/connect/token
     IdentityClient__ClientId: "player-vm-admin"
     IdentityClient__Scope: "player-api vm-api"
-    IdentityClient__Username: 
-    IdentityClient__Password: 
+    IdentityClient__Username:
+    IdentityClient__Password:
 
     # Crucible Player URL
     ClientSettings__urls__playerApi: "https://player.example.com"
@@ -330,8 +316,8 @@ vm-api:
     # - BaseFolder is the folder inside the DataStore to use
     Vsphere__Host: "vcenter.example.com"
     Vsphere__Username: "player-account@vsphere.local"
-    Vsphere__Password: 
-    Vsphere__DsName: 
+    Vsphere__Password:
+    Vsphere__DsName:
     Vsphere__BaseFolder: "player"
 
     # Rewrite Host settings
@@ -342,14 +328,10 @@ vm-api:
 
 vm-ui:
 
-  # Docker image release version
-  image:
-    tag: "3.3.3"
-
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
-    enabled: true  
+    enabled: true
     className: ""
     annotations:
       kubernetes.io/ingress.class: nginx
@@ -382,43 +364,37 @@ vm-ui:
 
   extraVolumeMounts: ""
 
-  env: 
+  env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client
-  settings: | 
-    '{
-      "ApiUrl": "https://vm.example.com/api",
-      "DeployApiUrl": "",
-      "ApiPlayerUrl": "https://player.example.com/api",
-      "WelderUrl": "",
-      "UserFollowUrl": "https://console.example.com/user/{userId}/view/{viewId}/console",
-      "OIDCSettings": {
-          "authority": "https://identity.example.com",
-          "client_id": "vm-ui-dev",
-          "redirect_uri": "https://vm.example.com/auth-callback/",
-          "post_logout_redirect_uri": "https://vm.example.com",
-          "response_type": "code",
-          "scope": "openid profile player-api vm-api",
-          "automaticSilentRenew": true,
-          "silent_redirect_uri": "https://vm.example.com/auth-callback-silent/"
-      },
-      "UseLocalAuthStorage": true
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
 
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://vm.example.com/api
+    DeployApiUrl: ""
+    ApiPlayerUrl: https://player.example.com/api
+    WelderUrl: ""
+    UserFollowUrl: https://console.example.com/user/{userId}/view/{viewId}/console
+    OIDCSettings:
+      authority: https://identity.example.com
+      client_id: vm-ui-dev
+      redirect_uri: https://vm.example.com/auth-callback/
+      post_logout_redirect_uri: https://vm.example.com
+      response_type: code
+      scope: openid profile player-api vm-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://vm.example.com/auth-callback-silent/
+    UseLocalAuthStorage: true
 
 console-ui:
-
-  # Docker image release version
-  image:
-    tag: "3.1.1"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
-    enabled: true  
+    enabled: true
     className: ""
     annotations:
       kubernetes.io/ingress.class: nginx
@@ -451,39 +427,51 @@ console-ui:
 
   extraVolumeMounts: ""
 
-  env: 
+  env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client and some basic settings
-  settings: |
-    '{
-      "ConsoleApiUrl": "https://vm.example.com/api/",
-      "OIDCSettings": {
-        "authority": "https://identity.example.com",
-        "client_id": "vm-console-ui-dev",
-        "redirect_uri": "https://console.example.com/auth-callback/",
-        "post_logout_redirect_uri": "https://console.example.com",
-        "response_type": "code",
-        "scope": "openid profile player-api vm-api vm-console-api",
-        "automaticSilentRenew": true,
-        "silent_redirect_uri": "https://console.example.com/auth-callback-silent/"
-      },
-      "UseLocalAuthStorage": true,
-      "VmResolutionOptions": [
-        { "width": 2560, "height": 1600 },
-        { "width": 1920, "height": 1440 },
-        { "width": 1920, "height": 1200 },
-        { "width": 1600, "height": 1200 },
-        { "width": 1400, "height": 1050 },
-        { "width": 1280, "height": 1024 },
-        { "width": 1440, "height": 900 },
-        { "width": 1280, "height": 960 },
-        { "width": 1366, "height": 768 },
-        { "width": 1280, "height": 800 },
-        { "width": 1280, "height": 720 },
-        { "width": 1024, "height": 768 },
-        { "width": 800, "height": 600 }
-      ]
-    }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ConsoleApiUrl: https://vm.example.com/api/
+    OIDCSettings:
+      authority: https://identity.example.com
+      client_id: vm-console-ui-dev
+      redirect_uri: https://console.example.com/auth-callback/
+      post_logout_redirect_uri: https://console.example.com
+      response_type: code
+      scope: openid profile player-api vm-api vm-console-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://console.example.com/auth-callback-silent/
+    UseLocalAuthStorage: true
+    VmResolutionOptions:
+      - width: 2560
+        height: 1600
+      - width: 1920
+        height: 1440
+      - width: 1920
+        height: 1200
+      - width: 1600
+        height: 1200
+      - width: 1400
+        height: 1050
+      - width: 1280
+        height: 1024
+      - width: 1440
+        height: 900
+      - width: 1280
+        height: 960
+      - width: 1366
+        height: 768
+      - width: 1280
+        height: 800
+      - width: 1280
+        height: 720
+      - width: 1024
+        height: 768
+      - width: 800
+        height: 600
+

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -171,24 +171,24 @@ player-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://player.example.com
-    OIDCSettings:
-      authority: https://identity.example.com
-      client_id: player-ui-dev
-      redirect_uri: https://player.example.com/auth-callback/
-      post_logout_redirect_uri: https://player.example.com
-      response_type: code
-      scope: openid profile player-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://player.example.com/auth-callback-silent/
-    NotificationsSettings:
-      url: https://player.example.com/hubs
-      number_to_display: 4
-    AppTitle: Crucible
-    AppTopBarText: Crucible
-    AppTopBarHexColor: "#b00"
-    AppTopBarHexTextColor: "#FFFFFF"
-    UseLocalAuthStorage: true
+    # ApiUrl: https://player.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com
+    #   client_id: player-ui-dev
+    #   redirect_uri: https://player.example.com/auth-callback/
+    #   post_logout_redirect_uri: https://player.example.com
+    #   response_type: code
+    #   scope: openid profile player-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://player.example.com/auth-callback-silent/
+    # NotificationsSettings:
+    #   url: https://player.example.com/hubs
+    #   number_to_display: 4
+    # AppTitle: Crucible
+    # AppTopBarText: Crucible
+    # AppTopBarHexColor: "#b00"
+    # AppTopBarHexTextColor: "#FFFFFF"
+    # UseLocalAuthStorage: true
 
 vm-api:
 
@@ -373,21 +373,21 @@ vm-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://vm.example.com/api
-    DeployApiUrl: ""
-    ApiPlayerUrl: https://player.example.com/api
-    WelderUrl: ""
-    UserFollowUrl: https://console.example.com/user/{userId}/view/{viewId}/console
-    OIDCSettings:
-      authority: https://identity.example.com
-      client_id: vm-ui-dev
-      redirect_uri: https://vm.example.com/auth-callback/
-      post_logout_redirect_uri: https://vm.example.com
-      response_type: code
-      scope: openid profile player-api vm-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://vm.example.com/auth-callback-silent/
-    UseLocalAuthStorage: true
+    # ApiUrl: https://vm.example.com/api
+    # DeployApiUrl: ""
+    # ApiPlayerUrl: https://player.example.com/api
+    # WelderUrl: ""
+    # UserFollowUrl: https://console.example.com/user/{userId}/view/{viewId}/console
+    # OIDCSettings:
+    #   authority: https://identity.example.com
+    #   client_id: vm-ui-dev
+    #   redirect_uri: https://vm.example.com/auth-callback/
+    #   post_logout_redirect_uri: https://vm.example.com
+    #   response_type: code
+    #   scope: openid profile player-api vm-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://vm.example.com/auth-callback-silent/
+    # UseLocalAuthStorage: true
 
 console-ui:
 
@@ -436,42 +436,42 @@ console-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ConsoleApiUrl: https://vm.example.com/api/
-    OIDCSettings:
-      authority: https://identity.example.com
-      client_id: vm-console-ui-dev
-      redirect_uri: https://console.example.com/auth-callback/
-      post_logout_redirect_uri: https://console.example.com
-      response_type: code
-      scope: openid profile player-api vm-api vm-console-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://console.example.com/auth-callback-silent/
-    UseLocalAuthStorage: true
-    VmResolutionOptions:
-      - width: 2560
-        height: 1600
-      - width: 1920
-        height: 1440
-      - width: 1920
-        height: 1200
-      - width: 1600
-        height: 1200
-      - width: 1400
-        height: 1050
-      - width: 1280
-        height: 1024
-      - width: 1440
-        height: 900
-      - width: 1280
-        height: 960
-      - width: 1366
-        height: 768
-      - width: 1280
-        height: 800
-      - width: 1280
-        height: 720
-      - width: 1024
-        height: 768
-      - width: 800
-        height: 600
+    # ConsoleApiUrl: https://vm.example.com/api/
+    # OIDCSettings:
+    #   authority: https://identity.example.com
+    #   client_id: vm-console-ui-dev
+    #   redirect_uri: https://console.example.com/auth-callback/
+    #   post_logout_redirect_uri: https://console.example.com
+    #   response_type: code
+    #   scope: openid profile player-api vm-api vm-console-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://console.example.com/auth-callback-silent/
+    # UseLocalAuthStorage: true
+    # VmResolutionOptions:
+    #   - width: 2560
+    #     height: 1600
+    #   - width: 1920
+    #     height: 1440
+    #   - width: 1920
+    #     height: 1200
+    #   - width: 1600
+    #     height: 1200
+    #   - width: 1400
+    #     height: 1050
+    #   - width: 1280
+    #     height: 1024
+    #   - width: 1440
+    #     height: 900
+    #   - width: 1280
+    #     height: 960
+    #   - width: 1366
+    #     height: 768
+    #   - width: 1280
+    #     height: 800
+    #   - width: 1280
+    #     height: 720
+    #   - width: 1024
+    #     height: 768
+    #   - width: 800
+    #     height: 600
 

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: steamfitter
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
-appVersion: 3.7.2
+version: 1.6.0

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.2.0
-appVersion: latest
+version: 1.3.0
+appVersion: 3.8.0

--- a/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - secretRef:
                 name: {{ include "steamfitter-api.fullname" . }}
             - secretRef:
-                name: {{ .Values.existingSecret }}
+                name: {{ (tpl .Values.existingSecret .) }}
           {{- else }}
           envFrom:
             - secretRef:

--- a/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/steamfitter/charts/steamfitter-api/templates/secret.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ $val | quote }}
+  {{ $key }}: {{ (tpl $val $) | quote }}
 {{- end }}

--- a/charts/steamfitter/charts/steamfitter-api/templates/secret.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -91,7 +91,7 @@ affinity: {}
 
 command: ['bash', '-c', 'update-ca-certificates && dotnet Steamfitter.Api.dll']
 
-## existingSecret references a secret already in k8s. 
+## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.2
-appVersion: latest
+version: 1.5.0
+appVersion: 3.8.0

--- a/charts/steamfitter/charts/steamfitter-ui/templates/configmap.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/configmap.yaml
@@ -5,4 +5,9 @@ metadata:
   name: {{ include "steamfitter-ui.fullname" . }}
 data:
   settings.env.json: |-
-{{ .Values.settings | nindent 4 }}
+{{ if .Values.settingsYaml }}
+{{- $settingsString := toYaml .Values.settingsYaml }}
+{{- (tpl $settingsString .) | fromYaml | toPrettyJson | indent 4 }}
+{{- else }}
+{{- .Values.settings | indent 4 }}
+{{- end }}

--- a/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
@@ -31,14 +31,14 @@ spec:
     {{- range .Values.ingress.tls }}
     - hosts:
         {{- range .hosts }}
-        - {{ . | quote }}
+        - {{ (tpl . $) | quote }}
         {{- end }}
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ (tpl .host $) | quote }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -100,24 +100,26 @@ extraVolumes: ""
 
 extraVolumeMounts: ""
 
-env: 
+env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-# settings: '{
-#     "ApiUrl": "http://host.docker.internal:4400",
-#     "VmApiUrl": "http://host.docker.internal:4302/api",
-#     "ApiPlayerUrl": "http://host.docker.internal:4300",
-#     "OIDCSettings": {
-#         "authority": "http://host.docker.internal:5000/",
-#         "client_id": "steamfitter.web",
-#         "redirect_uri": "http://host.docker.internal:4401/auth-callback",
-#         "post_logout_redirect_uri": "http://host.docker.internal:4401",
-#         "response_type": "code",
-#         "scope": "openid profile s3 s3-vm steamfitter",
-#         "automaticSilentRenew": true,
-#         "silent_redirect_uri": "http://host.docker.internal:4401/auth-callback-silent"
-#     },
-#     "UseLocalAuthStorage": true
-# }'
-settings: ""
+## settings is stringified json that gets included as assets/settings.json
+settings: "{}"
+
+## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+settingsYaml:
+  # ApiUrl: http://host.docker.internal:4400
+  # VmApiUrl: http://host.docker.internal:4302/api
+  # ApiPlayerUrl: http://host.docker.internal:4300
+  # OIDCSettings:
+  #   authority: http://host.docker.internal:5000/
+  #   client_id: steamfitter.web
+  #   redirect_uri: http://host.docker.internal:4401/auth-callback
+  #   post_logout_redirect_uri: http://host.docker.internal:4401
+  #   response_type: code
+  #   scope: openid profile s3 s3-vm steamfitter
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: http://host.docker.internal:4401/auth-callback-silent
+  # UseLocalAuthStorage: true
+

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -1,9 +1,5 @@
 steamfitter-api:
 
-  # Docker image release version
-  image:
-    tag: "3.7.2"
-  
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
@@ -29,7 +25,7 @@ steamfitter-api:
   # the configMap name here
   certificateMap: ""
 
-  ## existingSecret references a secret already in k8s. 
+  ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
@@ -67,8 +63,8 @@ steamfitter-api:
     # OAuth2 Identity Client /w Password
     ResourceOwnerAuthorization__Authority: https://identity.example.com
     ResourceOwnerAuthorization__ClientId: steamfitter-api
-    ResourceOwnerAuthorization__UserName: 
-    ResourceOwnerAuthorization__Password: 
+    ResourceOwnerAuthorization__UserName:
+    ResourceOwnerAuthorization__Password:
     ResourceOwnerAuthorization__Scope: "vm-api"
 
     # Crucible URLs
@@ -79,7 +75,7 @@ steamfitter-api:
     # TODO - Document Stackstorm dependencies
     VmTaskProcessing__ApiType: st2
     VmTaskProcessing__ApiUsername: "st2admin"
-    VmTaskProcessing__ApiPassword: 
+    VmTaskProcessing__ApiPassword:
     VmTaskProcessing__ApiBaseUrl: "https://stackstorm.example.com"
     VmTaskProcessing__ApiParameters__clusters: ""
 
@@ -97,10 +93,6 @@ steamfitter-api:
     # SeedData__UserPermissions__1__PermissionId: ""
 
 steamfitter-ui:
-
-  # Docker image release version
-  image:
-    tag: "3.7.4"
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -136,28 +128,30 @@ steamfitter-ui:
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
   extraVolumes: ""
-  
+
   extraVolumeMounts: ""
-  
-  env: 
+
+  env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  # Config app settings with a JSON file.
-  # These values correspond to an OpenID connect client
-  settings: '{
-      "ApiUrl": "https://steamfitter.example.com",
-      "VmApiUrl": "https://vm.example.com",
-      "ApiPlayerUrl": "https://player.example.com",
-      "OIDCSettings": {
-          "authority": "https://identity.example.com",
-          "client_id": "steamfitter-ui-dev",
-          "redirect_uri": "https://steamfitter.example.com/auth-callback/",
-          "post_logout_redirect_uri": "https://steamfitter.example.com",
-          "response_type": "code",
-          "scope": "openid profile player-api vm-api steamfitter-api",
-          "automaticSilentRenew": true,
-          "silent_redirect_uri": "https://steamfitter.example.com/auth-callback-silent/"
-      },
-      "UseLocalAuthStorage": true
-  }'
+  ## settings is stringified json that gets included as assets/settings.json
+  settings: "{}"
+
+  ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
+  settingsYaml:
+    ApiUrl: https://steamfitter.example.com
+    VmApiUrl: https://vm.example.com
+    ApiPlayerUrl: https://player.example.com
+    OIDCSettings:
+      authority: https://identity.example.com
+      client_id: steamfitter-ui-dev
+      redirect_uri: https://steamfitter.example.com/auth-callback/
+      post_logout_redirect_uri: https://steamfitter.example.com
+      response_type: code
+      scope: openid profile player-api vm-api steamfitter-api
+      automaticSilentRenew: true
+      silent_redirect_uri: https://steamfitter.example.com/auth-callback-silent/
+    UseLocalAuthStorage: true
+
+

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -140,18 +140,18 @@ steamfitter-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    ApiUrl: https://steamfitter.example.com
-    VmApiUrl: https://vm.example.com
-    ApiPlayerUrl: https://player.example.com
-    OIDCSettings:
-      authority: https://identity.example.com
-      client_id: steamfitter-ui-dev
-      redirect_uri: https://steamfitter.example.com/auth-callback/
-      post_logout_redirect_uri: https://steamfitter.example.com
-      response_type: code
-      scope: openid profile player-api vm-api steamfitter-api
-      automaticSilentRenew: true
-      silent_redirect_uri: https://steamfitter.example.com/auth-callback-silent/
-    UseLocalAuthStorage: true
+    # ApiUrl: https://steamfitter.example.com
+    # VmApiUrl: https://vm.example.com
+    # ApiPlayerUrl: https://player.example.com
+    # OIDCSettings:
+    #   authority: https://identity.example.com
+    #   client_id: steamfitter-ui-dev
+    #   redirect_uri: https://steamfitter.example.com/auth-callback/
+    #   post_logout_redirect_uri: https://steamfitter.example.com
+    #   response_type: code
+    #   scope: openid profile player-api vm-api steamfitter-api
+    #   automaticSilentRenew: true
+    #   silent_redirect_uri: https://steamfitter.example.com/auth-callback-silent/
+    # UseLocalAuthStorage: true
 
 

--- a/charts/topomojo/charts/topomojo-api/templates/secret.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
 type: Opaque
 stringData:
 {{- range $key, $val := .Values.env }}
-  {{ $key }}: {{ (tpl $val $) | quote }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
 {{- end }}

--- a/charts/topomojo/charts/topomojo-ui/values.yaml
+++ b/charts/topomojo/charts/topomojo-ui/values.yaml
@@ -101,15 +101,15 @@ settings: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  appname: TopoMojo
-  oidc:
-    client_id: clientid
-    authority: https://your.identity.authority
-    redirect_uri: https://this.site/oidc
-    silent_redirect_uri: https://this.site/oidc-silent.html
-    response_type: code
-    scope: openid profile topomojo-api
-    monitorSession: false
-    loadUserInfo: true
-    automaticSilentRenew: true
-    useLocalStorage: true
+  # appname: TopoMojo
+  # oidc:
+  #   client_id: clientid
+  #   authority: https://your.identity.authority
+  #   redirect_uri: https://this.site/oidc
+  #   silent_redirect_uri: https://this.site/oidc-silent.html
+  #   response_type: code
+  #   scope: openid profile topomojo-api
+  #   monitorSession: false
+  #   loadUserInfo: true
+  #   automaticSilentRenew: true
+  #   useLocalStorage: true

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -359,15 +359,15 @@ topomojo-ui:
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
-    appname: TopoMojo
-    oidc:
-      client_id: clientid
-      authority: https://your.identity.authority
-      redirect_uri: https://this.site/oidc
-      silent_redirect_uri: https://this.site/oidc-silent.html
-      response_type: code
-      scope: openid profile topomojo-api
-      monitorSession: false
-      loadUserInfo: true
-      automaticSilentRenew: true
-      useLocalStorage: true
+    # appname: TopoMojo
+    # oidc:
+    #   client_id: clientid
+    #   authority: https://your.identity.authority
+    #   redirect_uri: https://this.site/oidc
+    #   silent_redirect_uri: https://this.site/oidc-silent.html
+    #   response_type: code
+    #   scope: openid profile topomojo-api
+    #   monitorSession: false
+    #   loadUserInfo: true
+    #   automaticSilentRenew: true
+    #   useLocalStorage: true


### PR DESCRIPTION
This PR adds the same features that were introduced in PR #87 #88 and #89 

This PR adds the ability to use helm templating within certain values that are often different between environments. For example:
- .Values.existingSecret
- .Values.env values within the key/value pairs there
- .Values.ingress.tls.hosts
- .Values.ingress.hosts.host

I also added support for each of the affected UI subcharts to use a new settingsYaml key in addition to the existing settings key to generate angular settings.json files. This new key eliminates the need for stringified json, which is error-prone, and supports effective tempating within the settings contents.

I tested these by exercising each affected chart via the helm template command with typical values files and with examples of the templating support that was added.

Note: I tweaked the support for .Values.env to handle values that are not interpreted as strings, such as boolean values, to avoid Go errors.