### PR TITLE
Remove appVersion field from parent charts

### DIFF
--- a/charts/authhoc/Chart.yaml
+++ b/charts/authhoc/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.0.0

--- a/charts/buckets/Chart.yaml
+++ b/charts/buckets/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.8.0

--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.5.1
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.32.1

--- a/charts/groups/Chart.yaml
+++ b/charts/groups/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.8.0

--- a/charts/identity/Chart.yaml
+++ b/charts/identity/Chart.yaml
@@ -3,4 +3,3 @@ name: identity
 description: A Helm chart for Kubernetes
 type: application
 version: 0.2.2
-appVersion: 1.4.7

--- a/charts/learninglocker/Chart.yaml
+++ b/charts/learninglocker/Chart.yaml
@@ -3,7 +3,6 @@ name: learninglocker
 description: A Helm chart for Kubernetes
 type: application
 version: 0.2.0
-appVersion: 1.0.0
 
 dependencies:
 - name: learninglocker-api

--- a/charts/market/Chart.yaml
+++ b/charts/market/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.8.0

--- a/charts/statesman/Chart.yaml
+++ b/charts/statesman/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.3
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.1.0

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -16,8 +16,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.5.2
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.10

--- a/charts/webmail/Chart.yaml
+++ b/charts/webmail/Chart.yaml
@@ -14,8 +14,3 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "0.1.0"


### PR DESCRIPTION
Removes the Chart.yaml `appVersion:` field in parent charts that do not deploy a single application. This field is optional in the Helm spec and is confusing for parent charts:

https://helm.sh/docs/topics/charts/#the-chartyaml-file