### PR TITLE
Add giturl tpl call to mkdocs-material CronJob

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.6
+version: 0.2.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -27,7 +27,7 @@ spec:
               command: ["/entry.d/git-pull.sh"]
               env:
                 - name: DOCS_GIT_URL
-                  value: {{ .Values.giturl }}
+                  value: {{ (tpl .Values.giturl .) }}
                 - name: DOCS_GIT_BRANCH
                   value: {{ .Values.gitbranch }}
                 {{- if .Values.gitCredentialsSecret }}


### PR DESCRIPTION
Adds a missing `tpl` function call to the giturl value in the mkdocs-material CronJob.