### PR TITLE
Add Yet Analytics SQL LRS helm chart

### DIFF
--- a/charts/lrsql/.helmignore
+++ b/charts/lrsql/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/lrsql/Chart.yaml
+++ b/charts/lrsql/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: lrsql
+description: A helm chart to install the Yet Analytics SQL LRS (see https://github.com/yetanalytics/lrsql)
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.8.4"

--- a/charts/lrsql/examples/crucible-lrs.values.yaml
+++ b/charts/lrsql/examples/crucible-lrs.values.yaml
@@ -1,0 +1,40 @@
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '86400'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '86400'
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    external-dns.alpha.kubernetes.io/alias: "true"
+  hosts:
+    - host: lrsql.crucible-site.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls:
+    - secretName: lrsql-tls
+      hosts:
+        - lrsql.crucible-site.org
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 32Mi
+  limits:
+    cpu: 50m
+    memory: 2Gi
+
+existingSecret: "lrsql-secret"
+
+env:
+  LRSQL_DB_HOST: postgres
+  LRSQL_HTTP_PORT: "80"
+  LRSQL_SSL_PORT: "443"
+  LRSQL_LOG_LEVEL: INFO
+  LRSQL_AUTHORITY_URL: https://lrsql.crucible-site.org
+  LRSQL_ALLOWED_ORIGINS: "https://lrsql.crucible-site.org,https://keycloak.crucible-site.org"
+  LRSQL_OIDC_ISSUER: "https://keycloak.crucible-site.org/realms/master"
+  LRSQL_OIDC_CLIENT_ID: lrsql-admin
+  LRSQL_OIDC_AUDIENCE: https://lrsql.crucible-site.org
+  LRSQL_OIDC_SCOPE_PREFIX: "lrs:"

--- a/charts/lrsql/examples/crucible-lrs.values.yaml
+++ b/charts/lrsql/examples/crucible-lrs.values.yaml
@@ -28,7 +28,6 @@ resources:
 existingSecret: "lrsql-secret"
 
 env:
-  LRSQL_DB_HOST: postgres
   LRSQL_HTTP_PORT: "80"
   LRSQL_SSL_PORT: "443"
   LRSQL_LOG_LEVEL: INFO
@@ -38,3 +37,8 @@ env:
   LRSQL_OIDC_CLIENT_ID: lrsql-admin
   LRSQL_OIDC_AUDIENCE: https://lrsql.crucible-site.org
   LRSQL_OIDC_SCOPE_PREFIX: "lrs:"
+  LRSQL_DB_HOST: postgres
+  ## Consider using secrets to populate the following values via .Values.existingSecret
+  LRSQL_DB_NAME: lrsql_db
+  LRSQL_DB_USER: lrsql_dbo
+  LRSQL_DB_PASSWORD: "secret-password"

--- a/charts/lrsql/templates/NOTES.txt
+++ b/charts/lrsql/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "lrsql.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "lrsql.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "lrsql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "lrsql.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/lrsql/templates/_helpers.tpl
+++ b/charts/lrsql/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "lrsql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "lrsql.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "lrsql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "lrsql.labels" -}}
+helm.sh/chart: {{ include "lrsql.chart" . }}
+{{ include "lrsql.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "lrsql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "lrsql.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "lrsql.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "lrsql.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Subpath prefix value to use for pvc mount points
+*/}}
+{{- define "lrsql.subpathPrefix" -}}
+{{- $path := default (printf "%s-%s" (include "lrsql.fullname" .) "config") .Values.storage.overrideSubpathPrefix -}}
+{{- ternary ($path | printf "%s/" ) "" .Values.storage.existingSubpathPrefix -}}
+{{- end }}
+
+{{/*
+SQL LRS Command to execute based on value of .Values.dbMode */}}
+{{- define "lrsql.containerCommand" -}}
+{{- $dbmode := default "SQLite" .Values.dbMode -}}
+{{- if eq "SQLite" $dbmode -}}
+/lrsql/bin/run_sqlite.sh
+{{- else if eq "Postgres" $dbmode -}}
+/lrsql/bin/run_postgres.sh
+{{- else if eq "SQLite-In-Memory" $dbmode -}}
+/lrsql/bin/run_sqlite_ephemeral.sh
+{{- else -}}
+{{- fail "The value for .Values.dbMode must be one of Postgres, SQLite, SQLite-In-Memory." }}
+{{- end -}}
+{{- end }}

--- a/charts/lrsql/templates/configmap-env.yaml
+++ b/charts/lrsql/templates/configmap-env.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lrsql.fullname" . }}-env
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+data:
+{{- range $key, $val := .Values.env }}
+{{- if $val }}
+  {{ $key }}: {{ (tpl ($val | toString) $) | quote }}
+{{- end }}
+{{- end }}
+{{- if .Values.selmerTemplates }}
+{{- if .Values.selmerTemplates.authorityTemplate }}
+  LRSQL_AUTHORITY_TEMPLATE: /lrsql/config/authorityTemplate.json
+{{- end }}
+{{- if .Values.selmerTemplates.oidcAuthorityTemplate }}
+  LRSQL_OIDC_AUTHORITY_TEMPLATE: /lrsql/config/oidcAuthorityTemplate.json
+{{- end }}
+{{- if .Values.selmerTemplates.oidcClientTemplate }}
+{{- $oidClientTemplate := toYaml .Values.selmerTemplates.oidcClientTemplate }}
+  LRSQL_OIDC_CLIENT_TEMPLATE: {{ $oidClientTemplate | fromYaml | toJson | quote }}
+{{- end }}
+{{- end }}

--- a/charts/lrsql/templates/configmap-templates.yaml
+++ b/charts/lrsql/templates/configmap-templates.yaml
@@ -1,0 +1,24 @@
+{{ if .Values.selmerTemplates }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lrsql.fullname" . }}-templates
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+data:
+{{- if .Values.selmerTemplates.authorityTemplate }}
+  authorityTemplate.json: |-
+
+{{- $authTemplate := toYaml .Values.selmerTemplates.authorityTemplate }}
+{{ $authTemplate | fromYaml | toPrettyJson | indent 4 }}
+{{- end }}
+
+{{- if .Values.selmerTemplates.oidcAuthorityTemplate }}
+  oidcAuthorityTemplate.json: |-
+
+{{- $oidAuthTemplate := toYaml .Values.selmerTemplates.oidcAuthorityTemplate }}
+{{ $oidAuthTemplate | fromYaml | toPrettyJson | indent 4 }}
+{{- end }}
+
+{{- end }}
+

--- a/charts/lrsql/templates/deployment.yaml
+++ b/charts/lrsql/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lrsql.fullname" . }}
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "lrsql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "lrsql.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "lrsql.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - {{ include "lrsql.containerCommand" . }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /lrsql/config
+              name: {{ include "lrsql.fullname" . }}-config
+            {{- if eq "SQLite" .Values.dbMode }}
+            - mountPath: /lrsql/db
+              name: {{ include "lrsql.fullname" . }}-db
+              {{- if include "lrsql.subpathPrefix" . }}
+              subPath: {{ include "lrsql.subpathPrefix" . | trimSuffix "/" }}
+              {{- end }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "lrsql.fullname" . }}-env
+            {{- if .Values.existingSecret }}
+            - secretRef:
+                name: {{ (tpl .Values.existingSecret .) }}
+            {{- end }}
+      volumes:
+      - name: {{ include "lrsql.fullname" . }}-config
+      {{- if .Values.selmerTemplates }}
+        configMap:
+          name: {{ include "lrsql.fullname" . }}-templates
+      {{- else }}
+        emptyDir: {}
+      {{- end }}
+      {{- if eq "SQLite" .Values.dbMode }}
+      - name: {{ include "lrsql.fullname" . }}-db
+      {{- if .Values.storage.existing }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.storage.existing }}
+      {{- else if .Values.storage.size }}
+        persistentVolumeClaim:
+          claimName: {{ include "lrsql.fullname" . }}
+      {{- else }}
+      {{- fail "SQLite mode requires a pvc" }}
+      {{- end }}
+      {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/lrsql/templates/ingress.yaml
+++ b/charts/lrsql/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "lrsql.fullname" . }}
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "lrsql.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/lrsql/templates/pvc.yaml
+++ b/charts/lrsql/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.storage.size (eq "SQLite" .Values.dbMode) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "lrsql.fullname" . }}
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+spec:
+  accessModes:
+  - {{ .Values.storage.mode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.storage.size | quote }}
+  storageClassName: {{ .Values.storage.class }}
+{{- end -}}

--- a/charts/lrsql/templates/service.yaml
+++ b/charts/lrsql/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lrsql.fullname" . }}
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "lrsql.selectorLabels" . | nindent 4 }}

--- a/charts/lrsql/templates/serviceaccount.yaml
+++ b/charts/lrsql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "lrsql.serviceAccountName" . }}
+  labels:
+    {{- include "lrsql.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/lrsql/values.yaml
+++ b/charts/lrsql/values.yaml
@@ -1,0 +1,195 @@
+# Default values for lrsql.
+# This is a YAML-formatted file.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: yetanalytics/lrsql
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+## SQL LRS Can use one of three database configurations specified by the dbMode property. The allowable values are:
+# Postgres - connect to and use an external postgres DB
+# SQLite - Run with a SQLite database on the filesystem
+# SQLite-In-Memory - In-memory SQLite db mostly used for development. This will not save your data after a restart.
+dbMode: Postgres
+
+# storage - either an existing pvc or the size for a new pvc
+# This is only used if the dbMode is set to SQLite
+storage:
+  existing: ""
+  existingSubpathPrefix: true  # If true, then volume mounts will use lrsql.fullname as a subpath prefix.
+  overrideSubpathPrefix: # If set then this is the value used for the subpath prefix if above property is true
+  size: ""
+  mode: ReadWriteOnce
+  class: default
+
+## existingSecret references a secret already in k8s.
+## The key/value pairs in the secret are added as environment variables.
+existingSecret: ""
+
+# These are the environment variables that will be passed to lrsql
+env:
+  LRSQL_DB_HOST: # Hostname of postgres DB when using Postgres Mode
+  LRSQL_DB_PORT: 5432 # The port that the database will run on. Not supported by SQLite.
+  LRSQL_DB_NAME: # Database name of postgres DB when using Postgres Mode
+  LRSQL_DB_USER: # Database user of postgres DB when using Postgres Mode
+  LRSQL_DB_PASSWORD: # Database user of postgres DB when using Postgres Mode
+  ## The ADMIN USER is only needed if you do not want to use oidc auth or if you want both local and oidc-based accounts
+  LRSQL_ADMIN_USER_DEFAULT: # The username of the account that seeds the account table, ie. added to the table upon initialization.
+  LRSQL_ADMIN_PASS_DEFAULT: # The password of the account that seeds the account table
+
+  LRSQL_HTTP_PORT: "80" # The HTTP port that the container webserver will be open on.
+  LRSQL_SSL_PORT: "443" # The HTTPS port that the container webserver will be open on.
+
+  LRSQL_AUTHORITY_URL: "http://example.org" # Custom domain in order to uniquely identify Statements inserted into your LRS.
+
+  LRSQL_ALLOW_ALL_ORIGINS: # "true" # Determines whether to enable CORS. When false, it will not allow all origins, it will only allow either LRSQL_HTTP_HOST (for both HTTPS and HTTP ports) or if LRSQL_ALLOWED_ORIGINS is set that will override.
+  LRSQL_ALLOWED_ORIGINS: # This is a list of allowed origins which overrides the defaults. This should include your oidc provider when using oidc. As an ENV it should be written as a comma separated list with no spaces.
+  LRSQL_LOG_LEVEL: INFO # The logging level to use. Can be ALL, TRACE, DEBUG, INFO, WARN, ERROR or OFF
+
+  LRSQL_OIDC_ISSUER: # OIDC Issuer address used for discovery. Will enable OIDC if present. This MUST be the URL from which the path "/.well-known/openid-configuration" path resolves.
+  # LRSQL_OIDC_AUDIENCE MUST equal the base URL of the SQL LRS app for admin UI acccess to work
+  # For keycloak, it is also necessary to setup a custom Audience mapper in the dedicated scope for the admin client
+  # and the value for this must match the value for LRSQL_OIDC_AUDIENCE. This means you must LEAVE the Included Client Audience
+  # field blank rather than set the value to the name of the client. You must ONLY use the Included Custom Audience field
+  LRSQL_OIDC_AUDIENCE: "http://example.org" # This audience MUST equal the base URL of the SQL LRS app for admin UI acccess to work
+  LRSQL_OIDC_CLIENT_ID: # An optional OIDC client ID for the SQL LRS Admin SPA. If provided, along with the LRSQL_OIDC_ISSUER and LRSQL_OIDC_AUDIENCE variables, will enable OIDC access to the Admin UI.
+  # SQL LRS Defines the following scopes, the names of which will be prefixed by the value of LRSQL_OIDC_SCOPE_PREFIX below.
+  # Scope	               Capability
+
+  # all    	             Full read/write access to all xAPI resources.
+  # all/read	           Read-only access to all xAPI resources.
+  # state	               Read/write access to xAPI State Documents.
+  # activities_profile	 Read/write access to xAPI Activity Profile Documents.
+  # agents_profile	     Read/write access to xAPI Agent Profile Documents.
+  # statements/read	     Read-only access to all xAPI Statements (but not non-Statement resources).
+  # statements/read/mine Read-only access to xAPI Statements whose authority value matches the authority of the current user.
+  # statements/write	   Write-only access to xAPI Statements.
+  # admin                Admin API resources share a single scope admin that represents full administrative control over SQL LRS.
+
+  LRSQL_OIDC_SCOPE_PREFIX: "lrs:" # Used as a prefix for all lrsql scopes
+
+# SQL LRS uses Selmer templates for configuring the following optional properties. Examples can be found here:
+# https://github.com/yetanalytics/lrsql/tree/7129a40edb87ef459704964a75bcd2985b628138/resources/lrsql/config
+#
+# See https://github.com/yogthos/Selmer#templates for syntax.
+selmerTemplates:
+  # # Statement authority template, which describes how authorities are constructed during statement insertion.
+  # authorityTemplate:
+  #   account:
+  #     homePage: "{{authority-url}}"
+  #     name: "{{cred-id}}"
+  #   objectType: Agent
+  # # Like authorityTemplate, but only used when forming an authority from an OIDC access token
+  # oidcAuthorityTemplate:
+  #   objectType: Group
+  #   member:
+  #     - account:
+  #         homePage: "{{iss}}"
+  #         name: "{{lrsql/resolved-client-id}}"
+  #     - account:
+  #         homePage: "{{iss}}"
+  #         name: "{{sub}}"
+  # # An optional template to modify LRS Admin UI client OIDC configuration.
+  # oidcClientTemplate:
+  #   authority: "{{oidc-issuer}}"
+  #   client_id: "{{oidc-client-id}}"
+  #   response_type: code
+  #   scope: openid profile {{oidc-scope-prefix}}admin
+  #   automaticSilentRenew: true
+  #   monitorSession: false
+  #   filterProtocolClaims: false
+  #   extraQueryParams:
+  #     audience: "{{oidc-audience}}"
+
+


### PR DESCRIPTION
This PR adds a helm chart for the [Yet Analytics SQL LRS](https://github.com/yetanalytics/lrsql) using the hosted docker container for that open source tool. The chart supports all of the features that are available via the current version of the docker container, currently v0.8.4, and uses [environment variables](https://github.com/yetanalytics/lrsql/blob/main/doc/env_vars.md) for configuration as opposed to a [config file](https://github.com/yetanalytics/lrsql/blob/main/resources/lrsql/config/lrsql.json.example).

I tested this by using a [local chart](https://gitlab.imcite.net/imcite/imcite/-/blob/phlprod-start/argocd/charts/lrsql/Chart.yaml?ref_type=heads) in both phlstaging and phlprod. 