### PR TITLE
[gameboard] Add cacertSecret value

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.5.3

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-api/templates/configmap.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/configmap.yaml
@@ -5,9 +5,14 @@ metadata:
   labels:
     {{- include "gameboard-api.labels" . | nindent 4 }}
 data:
-{{- if .Values.cacert }}
+{{- if or .Values.cacert .Values.cacertSecret }}
   ca-cert.crt: |
+{{- if .Values.cacert }}
 {{ .Values.cacert | indent 4 }}
+{{- else }}
+{{- $cacertSecret := lookup "v1" "Secret" .Release.Namespace (tpl .Values.cacertSecret .) }}
+{{ index $cacertSecret.data .Values.cacertSecretKey | b64dec | indent 4 }}
+{{- end }}
   start.sh: |
     #!/bin/sh
 

--- a/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
+++ b/charts/gameboard/charts/gameboard-api/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.cacert }}
+          {{- if or .Values.cacert .Values.cacertSecret }}
           command: ["/bin/sh"]
           args: ["/start/start.sh"]
           {{- end }}
@@ -74,7 +74,7 @@ spec:
           #     path: /api/version
           #     port: http
           volumeMounts:
-          {{- if .Values.cacert }}
+          {{- if or .Values.cacert .Values.cacertSecret }}
             - mountPath: /start
               name: {{ include "gameboard-api.name" . }}-conf
           {{- end }}

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -126,6 +126,18 @@ migrations:
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 
+# cacert - add custom CA certificate in-line
+# cacert: |-
+#   -----BEGIN CERTIFICATE-----
+#   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
+#   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
+#   …
+#   -----END CERTIFICATE-----
+
+# cacertSecret - Trust a custom CA certificate in an existing Secret
+cacertSecret: ""
+cacertSecretKey: ca.crt
+
 # Config app settings with environment vars.
 # Those most likely needing values are listed. For others,
 # see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -127,6 +127,18 @@ gameboard-api:
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
 
+  # cacert - add custom CA certificate in-line
+  # cacert: |-
+  #   -----BEGIN CERTIFICATE-----
+  #   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
+  #   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
+  #   …
+  #   -----END CERTIFICATE-----
+
+  # cacertSecret - Trust a custom CA certificate in an existing Secret
+  cacertSecret: ""
+  cacertSecretKey: ca.crt
+
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf


### PR DESCRIPTION
Allows for an existing secret to be used for Gameboard when trusting a custom CA. Useful when paired with cert-manager to generate a custom CA in the Foundry Appliance.