### PR TITLE
Adds rootless container support to crucible exercise apps

### DIFF
--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 3.6.0

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -3,4 +3,4 @@ name: alloy-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.3.0
-appVersion: 3.5.1
+appVersion: 3.6.0

--- a/charts/alloy/charts/alloy-api/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-api/templates/deployment.yaml
@@ -34,20 +34,21 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "alloy-api.fullname" . }}
+          {{- if .Values.existingSecret }}
             - secretRef:
                 name: {{ (tpl .Values.existingSecret .) }}
-          {{- else }}
-          envFrom:
-            - secretRef:
-                name: {{ include "alloy-api.fullname" . }}
+          {{- end }}
+          {{- if .Values.certificateMap }}
+          env:
+            - name: SSL_CERT_DIR
+              value: /usr/local/share/ca-certificates/
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/alloy/charts/alloy-api/templates/service.yaml
+++ b/charts/alloy/charts/alloy-api/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "alloy-api.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ default 80 .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -36,7 +36,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false
@@ -85,9 +85,9 @@ tolerations: []
 
 affinity: {}
 
-command: ['bash', '-c', 'update-ca-certificates && dotnet Alloy.Api.dll']
+command: ["./Alloy.Api"]
 
-## existingSecret references a secret already in k8s. 
+## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
 

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: 3.5.0

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -3,4 +3,4 @@ name: caster-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.5.0
-appVersion: 3.4.2
+appVersion: 3.5.0

--- a/charts/caster/charts/caster-api/templates/_helpers.tpl
+++ b/charts/caster/charts/caster-api/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+  Shared environment configuration for containers
+*/}}
+{{- define "caster-api.env" }}
+envFrom:
+  - secretRef:
+      name: {{ include "caster-api.fullname" . }}
+{{- if .Values.existingSecret }}
+  - secretRef:
+      name: {{ (tpl .Values.existingSecret .) }}
+{{- end }}
+{{- end }}

--- a/charts/caster/charts/caster-api/templates/configmap.yaml
+++ b/charts/caster/charts/caster-api/templates/configmap.yaml
@@ -2,7 +2,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "caster-api.fullname" . }}-terraform-installation
+  name: {{ include "caster-api.fullname" . }}-scripts
 data:
   install-terraform.sh: |-
 {{- include "terraform-installation" . | nindent 4 }}
+  vol-permissions.sh: |-
+{{- include "vol-permissions" . | nindent 4 }}

--- a/charts/caster/charts/caster-api/templates/deployment.yaml
+++ b/charts/caster/charts/caster-api/templates/deployment.yaml
@@ -28,26 +28,48 @@ spec:
       serviceAccountName: {{ include "caster-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: {{ .Chart.Name}}-install-terraform
+          image: debian:bookworm-slim
+          command: ["bash", "-c", "/mnt/scripts/install-terraform.sh"]
+          volumeMounts:
+            - mountPath: /terraform
+              name: {{ include "caster-api.name" . }}-vol
+              subPath: {{ include "caster-api.fullname" . }}/terraform
+            - mountPath: /mnt/scripts/install-terraform.sh
+              name: {{ include "caster-api.fullname" . }}-scripts
+              subPath: install-terraform.sh
+          securityContext:
+            runAsUser: 0
+          {{- include "caster-api.env" . | nindent 10 }}
+        - name: {{ .Chart.Name}}-vol-permissions
+          image: bash
+          command: ["bash", "-c", "/mnt/scripts/vol-permissions.sh /terraform"]
+          volumeMounts:
+            - mountPath: /terraform
+              name: {{ include "caster-api.name" . }}-vol
+              subPath: {{ include "caster-api.fullname" . }}/terraform
+            - mountPath: /mnt/scripts/vol-permissions.sh
+              name: {{ include "caster-api.fullname" . }}-scripts
+              subPath: vol-permissions.sh
+          securityContext:
+            runAsUser: 0
+          {{- include "caster-api.env" . | nindent 10 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
-          {{- if .Values.existingSecret }}
-          envFrom:
-            - secretRef:
-                name: {{ include "caster-api.fullname" . }}
-            - secretRef:
-                name: {{ (tpl .Values.existingSecret .) }}
-          {{- else }}
-          envFrom:
-            - secretRef:
-                name: {{ include "caster-api.fullname" . }}
+          {{- include "caster-api.env" . | nindent 10 }}
+          {{- if .Values.certificateMap }}
+          env:
+            - name: SSL_CERT_DIR
+              value: /usr/local/share/ca-certificates/
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -79,7 +101,7 @@ spec:
               subPath: {{ include "caster-api.fullname" . }}/terraform
             - mountPath: /install-terraform.sh
               subPath: install-terraform.sh
-              name: {{ include "caster-api.fullname" . }}-terraform-installation
+              name: {{ include "caster-api.fullname" . }}-scripts
             {{ if .Values.certificateMap }}
             - mountPath: /usr/local/share/ca-certificates
               name: certificates
@@ -102,9 +124,9 @@ spec:
         - name: {{ include "caster-api.name" . }}-vol
           emptyDir: {}
         {{- end }}
-        - name: {{ include "caster-api.fullname" . }}-terraform-installation
+        - name: {{ include "caster-api.fullname" . }}-scripts
           configMap:
-            name: {{ include "caster-api.fullname" . }}-terraform-installation
+            name: {{ include "caster-api.fullname" . }}-scripts
             defaultMode: 0755
         - name: {{ include "caster-api.fullname" . }}-gitcredentials
           configMap:

--- a/charts/caster/charts/caster-api/templates/scripts/terraform-installation.tpl
+++ b/charts/caster/charts/caster-api/templates/scripts/terraform-installation.tpl
@@ -1,13 +1,15 @@
 {{- define "terraform-installation" }}
-# Skip installation
+#!/bin/bash
+
 if [ "${SKIP_TERRAFORM_INSTALLATION,,}" == "true" ]; then
     exit 0
 fi
 
 if [ ! -d $Terraform__BinaryPath ]; then
+    echo "Installing Terraform."
 
     # Install Unzip
-    apt-get update && apt-get install -y unzip wget
+    apt-get update && apt-get install -y unzip curl jq
 
     # Create Terraform directories
     mkdir -p "$Terraform__RootWorkingDirectory"

--- a/charts/caster/charts/caster-api/templates/scripts/vol-permissions.tpl
+++ b/charts/caster/charts/caster-api/templates/scripts/vol-permissions.tpl
@@ -1,0 +1,21 @@
+{{- define "vol-permissions" }}
+#!/bin/bash
+
+DIR="${1}"
+USER_ID="${2:-1654}"
+GROUP_ID="${3:-1654}"
+
+if [ "${SKIP_VOL_PERMISSIONS,,}" == "true" ]; then
+    echo "Skipping volume permissions check."
+    exit 0
+fi
+
+echo "Checking and updating ownership in: $DIR for UID:GID = $USER_ID:$GROUP_ID"
+
+if find "$DIR" \( \! -user "$USER_ID" -o \! -group "$GROUP_ID" \) -exec chown "$USER_ID:$GROUP_ID" {} +; then
+    echo "Ownership check/update completed successfully."
+else
+    echo "Error: Failed to update file ownership."
+    exit 1
+fi
+{{- end }}

--- a/charts/caster/charts/caster-api/templates/service.yaml
+++ b/charts/caster/charts/caster-api/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "caster-api.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ default 80 .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -40,7 +40,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false
@@ -83,12 +83,7 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
-command:
-  [
-    'bash',
-    '-c',
-    'update-ca-certificates && /install-terraform.sh && dotnet Caster.Api.dll',
-  ]
+command: ["./Caster.Api"]
 
 nodeSelector: {}
 
@@ -136,6 +131,7 @@ env:
   PathBase: ""
 
   SKIP_TERRAFORM_INSTALLATION: false
+  SKIP_VOL_PERMISSIONS: false
 
   VSPHERE_SERVER:
   VSPHERE_USER:
@@ -224,14 +220,3 @@ env:
 
   FileVersions__DaysToSaveAllUntaggedVersions: 7
   FileVersions__DaysToSaveDailyUntaggedVersions: 31
-
-  SeedData__Permissions__0__Id: '00000000-0000-0000-0000-000000000001'
-  SeedData__Permissions__0__Key: 'SystemAdmin'
-  SeedData__Permissions__0__Value: 'true'
-  SeedData__Permissions__0__Description: 'Has Full Rights.  Can do everything.'
-  SeedData__Permissions__0__ReadOnly: true
-  SeedData__Permissions__1__Id: '00000000-0000-0000-0000-000000000002'
-  SeedData__Permissions__1__Key: 'ContentDeveloper'
-  SeedData__Permissions__1__Value: 'true'
-  SeedData__Permissions__1__Description: 'Can create/edit/delete an Exercise/Directory/Workspace/File/Module'
-  SeedData__Permissions__1__ReadOnly: true

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.0
+version: 1.7.0
 appVersion: 3.4.0

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -3,4 +3,4 @@ name: player-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.6.0
-appVersion: 3.3.4
+appVersion: 3.4.0

--- a/charts/player/charts/player-api/templates/_helpers.tpl
+++ b/charts/player/charts/player-api/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+  Shared environment configuration for containers
+*/}}
+{{- define "player-api.env" }}
+envFrom:
+  - secretRef:
+      name: {{ include "player-api.fullname" . }}
+{{- if .Values.existingSecret }}
+  - secretRef:
+      name: {{ (tpl .Values.existingSecret .) }}
+{{- end }}
+{{- end }}

--- a/charts/player/charts/player-api/templates/configmap.yaml
+++ b/charts/player/charts/player-api/templates/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "player-api.fullname" . }}-scripts
+data:
+  vol-permissions.sh: |-
+{{- include "vol-permissions" . | nindent 4 }}

--- a/charts/player/charts/player-api/templates/deployment.yaml
+++ b/charts/player/charts/player-api/templates/deployment.yaml
@@ -28,27 +28,36 @@ spec:
       serviceAccountName: {{ include "player-api.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: {{ .Chart.Name}}-vol-permissions
+          image: bash
+          command: ["bash", "-c", "/mnt/scripts/vol-permissions.sh /fileupload"]
+          volumeMounts:
+            - mountPath: /fileupload
+              name: {{ include "player-api.fullname" . }}-vol
+              subPath: {{ include "player-api.fullname" . }}/fileuploads
+            - mountPath: /mnt/scripts/vol-permissions.sh
+              name: {{ include "player-api.fullname" . }}-scripts
+              subPath: vol-permissions.sh
+          securityContext:
+            runAsUser: 0
+          {{- include "player-api.env" . | nindent 10 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- if .Values.existingSecret }}
-          envFrom:
-            - secretRef:
-                name: {{ include "player-api.fullname" . }}
-            - secretRef:
-                name: {{ (tpl .Values.existingSecret .) }}
-          {{- else }}
-          envFrom:
-            - secretRef:
-                name: {{ include "player-api.fullname" . }}
-          {{- end }}
+          {{- include "player-api.env" . | nindent 10 }}
           command: {{- toYaml .Values.command | nindent 10 }}
+          {{- if .Values.certificateMap }}
+          env:
+            - name: SSL_CERT_DIR
+              value: /usr/local/share/ca-certificates/
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
         {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
@@ -92,7 +101,7 @@ spec:
             {{- end }}
             - mountPath: /fileupload
               name: {{ include "player-api.fullname" . }}-vol
-              subPath: {{ include "player-api.fullname" . }}/fileuploads          
+              subPath: {{ include "player-api.fullname" . }}/fileuploads
       volumes:
         {{ if .Values.certificateMap }}
         - name: certificates
@@ -110,7 +119,11 @@ spec:
         {{- else }}
         - name: {{ include "player-api.fullname" . }}-vol
           emptyDir: {}
-        {{- end }}      
+        {{- end }}
+        - name: {{ include "player-api.fullname" . }}-scripts
+          configMap:
+            name: {{ include "player-api.fullname" . }}-scripts
+            defaultMode: 0755
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/player-api/templates/scripts/vol-permissions.tpl
+++ b/charts/player/charts/player-api/templates/scripts/vol-permissions.tpl
@@ -1,0 +1,21 @@
+{{- define "vol-permissions" }}
+#!/bin/bash
+
+DIR="${1}"
+USER_ID="${2:-1654}"
+GROUP_ID="${3:-1654}"
+
+if [ "${SKIP_VOL_PERMISSIONS,,}" == "true" ]; then
+    echo "Skipping volume permissions check."
+    exit 0
+fi
+
+echo "Checking and updating ownership in: $DIR for UID:GID = $USER_ID:$GROUP_ID"
+
+if find "$DIR" \( \! -user "$USER_ID" -o \! -group "$GROUP_ID" \) -exec chown "$USER_ID:$GROUP_ID" {} +; then
+    echo "Ownership check/update completed successfully."
+else
+    echo "Error: Failed to update file ownership."
+    exit 1
+fi
+{{- end }}

--- a/charts/player/charts/player-api/templates/service.yaml
+++ b/charts/player/charts/player-api/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "player-api.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ default 80 .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -40,7 +40,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 probes:
   livenessProbe:
@@ -114,8 +114,7 @@ tolerations: []
 
 affinity: {}
 
-command: ['bash', '-c', 'update-ca-certificates && dotnet Player.Api.dll']
-
+command: ["./Player.Api"]
 
 # storage - either an existing pvc, the size for a new pvc, or emptyDir
 storage:
@@ -139,6 +138,8 @@ env:
 
   ## If hosting in virtual directory, specify path base
   PathBase: ""
+
+  SKIP_VOL_PERMISSIONS: false
 
   Logging__IncludeScopes: false
   Logging__Debug__LogLevel__Default: Information

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -3,4 +3,4 @@ name: vm-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.5.0
-appVersion: 3.7.0
+appVersion: 3.8.0

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: 3.8.0

--- a/charts/player/charts/vm-api/templates/deployment.yaml
+++ b/charts/player/charts/vm-api/templates/deployment.yaml
@@ -32,22 +32,23 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "vm-api.fullname" . }}
+          {{- if .Values.existingSecret }}
             - secretRef:
                 name: {{ (tpl .Values.existingSecret .) }}
-          {{- else }}
-          envFrom:
-            - secretRef:
-                name: {{ include "vm-api.fullname" . }}
+          {{- end }}
+          {{- if .Values.certificateMap }}
+          env:
+            - name: SSL_CERT_DIR
+              value: /usr/local/share/ca-certificates/
           {{- end }}
           command: {{- toYaml .Values.command | nindent 10 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -74,7 +75,7 @@ spec:
             - name: {{ include "vm-api.fullname" . }}-iso
               mountPath: /app/isos/player
           {{- end }}
-      
+
       volumes:
       {{ if .Values.certificateMap }}
         - name: certificates

--- a/charts/player/charts/vm-api/templates/service.yaml
+++ b/charts/player/charts/vm-api/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "vm-api.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ default 80 .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -47,7 +47,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false
@@ -112,7 +112,7 @@ tolerations: []
 
 affinity: {}
 
-command: ['bash', '-c', 'update-ca-certificates && dotnet Player.Vm.Api.dll']
+command: ['dotnet', 'Player.Vm.Api.dll']
 
 ## existingSecret references a secret already in k8s. 
 ## The key/value pairs in the secret are added as environment variables.

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.4.0
 appVersion: 3.9.0

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -3,4 +3,4 @@ name: steamfitter-api
 description: A Helm chart for Kubernetes
 type: application
 version: 1.3.0
-appVersion: 3.8.0
+appVersion: 3.9.0

--- a/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
@@ -33,21 +33,22 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: {{- toYaml .Values.command | nindent 10 }}
-          {{- if .Values.existingSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "steamfitter-api.fullname" . }}
+          {{- if .Values.existingSecret }}
             - secretRef:
                 name: {{ (tpl .Values.existingSecret .) }}
-          {{- else }}
-          envFrom:
-            - secretRef:
-                name: {{ include "steamfitter-api.fullname" . }}
+          {{- end }}
+          {{- if .Values.certificateMap }}
+          env:
+            - name: SSL_CERT_DIR
+              value: /usr/local/share/ca-certificates/
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/steamfitter/charts/steamfitter-api/templates/service.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/service.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "steamfitter-api.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ default "ClusterIP" .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
+    - port: {{ default 80 .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -40,7 +40,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
 ingress:
   enabled: false
@@ -89,7 +89,7 @@ tolerations: []
 
 affinity: {}
 
-command: ['bash', '-c', 'update-ca-certificates && dotnet Steamfitter.Api.dll']
+command: ['./Steamfitter.Api']
 
 ## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.


### PR DESCRIPTION
Adds support for the latest versions of the crucible exercise apps that use a non-root user in their images by default.

- Updates containerPort to 8080
- Updates support for trusting certificates
   - Removes call to `update_ca_certificates` as it can only be run as root
   - Adds `SSL_CERT_DIR` env var when Values.certificateMap is specified
- Updates file system permissions for local volume mounts
  - Adds init containers to Player.Api and Caster.Api that runs as root to update file ownership to the app user
  - **POTENTIAL BREAKING CHANGE**: Operators may have to manually change NFS permissions for any mounted NFS volumes
- Moves Caster terraform installation script to an init container