### PR TITLE
[mkdocs-material] Forbid concurrent CronJobs

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -10,6 +10,7 @@ metadata:
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   schedule: "*/{{ .Values.pollInterval | default 5 }} * * * *"
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
If the git CronJob for mkdocs-material stalls (when it can't load a Secret, for example), the cluster will continually create new jobs.

This fixes the problem by only allowing a single CronJob at a time.