### PR TITLE
Remove 'image.tag' values in favor of Chart.yaml appVersion

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: alloy
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -1,7 +1,7 @@
 alloy-api:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of alloy-api child chart
   image:
-    tag: '3.4.3'
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -77,9 +77,9 @@ alloy-api:
     ClientSettings__urls__steamfitterApi: https://steamfitter.example.com/
 
 alloy-ui:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of alloy-ui child chart
   image:
-    tag: '3.2.6'
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -1,6 +1,7 @@
 blueprint-api:
+  # Docker image release version. Defaults to appVersion of blueprint-api child chart
   image:
-    tag: "0.3.10"
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -44,9 +45,9 @@ blueprint-api:
     Authorization__ClientName: Blueprint API Swagger
 
 blueprint-ui:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of blueprint-ui child chart
   image:
-    tag: '0.3.12'
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: caster
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.0
-appVersion: 3.5.0
+version: 1.6.2
+appVersion: 3.5.1

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.1
-appVersion: 3.4.1
+version: 1.6.2
+appVersion: 3.4.2

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -1,9 +1,8 @@
 caster-api:
 
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of caster-api child chart
   image:
-    # Caster API version
-    tag: "3.3.0"
+    tag: ""
   
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -201,9 +200,9 @@ caster-api:
 
 caster-ui:
 
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of caster-ui child chart
   image:
-    tag: "3.3.0"
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -1,5 +1,5 @@
 cite-api:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of cite-api child chart
   image:
     tag: '1.3.1'
 
@@ -69,7 +69,7 @@ cite-api:
     seed: ""
 
 cite-ui:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of cite-ui child chart
   image:
     tag: '1.3.5'
 

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gallery
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -1,6 +1,7 @@
 gallery-api:
+  # Docker image release version. Defaults to appVersion of gallery-api child chart
   image:
-    tag: "1.5.1"
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
@@ -44,9 +45,9 @@ gallery-api:
     Authorization__ClientName: Gallery API Swagger
 
 gallery-ui:
-  # Docker image release version
+  # Docker image release version. Defaults to appVersion of gallery-ui child chart
   image:
-    tag: '1.5.2'
+    tag: ""
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured

--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.32.1
+appVersion: 3.33.0

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.5.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.32.1
+appVersion: 3.33.0


### PR DESCRIPTION
This updates the appVersion values for all of the Crucible apps to the latest published versions. We have been behind in keeping the 'image.tag' values up to date, and the idea with this change is that we can apply CI to this process down the road as we release new versions of Crucible apps.

This change does not impact users who have custom 'image.tag' values in their own deployments. It just makes the default values for each app more current.