### PR TITLE
[topomojo] initcontainer bugfix

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.4
+version: 0.5.5

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.3
+version: 0.5.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
@@ -29,26 +29,26 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
       {{- if .Values.migrations.enabled }}
-      - name: "{{ .Chart.Name }}-init"
-        image: "groundnuty/k8s-wait-for:v1.4"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        args:
-        - "job"
-        - "{{ include "topomojo-api.fullname" . }}-{{ .Release.Revision}}"
+        - name: "{{ .Chart.Name }}-init"
+          image: "groundnuty/k8s-wait-for:v1.4"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - "job"
+          - "{{ include "topomojo-api.fullname" . }}-{{ .Release.Revision}}"
       {{- end }}
-      - name: {{ .Chart.Name}}-vol-permissions
-        image: bash
-        command: ["bash", "-c", "/mnt/scripts/vol-permissions.sh /docs"]
-        volumeMounts:
-          - mountPath: /docs
-            name: {{ include "topomojo-api.name" . }}-vol
-            subPath: {{ include "topomojo-api.fullname" . }}/_docs
-          - mountPath: /mnt/scripts/vol-permissions.sh
-            name: {{ include "topomojo-api.name" . }}-scripts
-            subPath: vol-permissions.sh
-        securityContext:
-          runAsUser: 0
-        {{- include "topomojo-api.env" . | nindent 10 }}
+        - name: {{ .Chart.Name}}-vol-permissions
+          image: bash
+          command: ["bash", "-c", "/mnt/scripts/vol-permissions.sh /docs"]
+          volumeMounts:
+            - mountPath: /docs
+              name: {{ include "topomojo-api.name" . }}-vol
+              subPath: {{ include "topomojo-api.fullname" . }}/_docs
+            - mountPath: /mnt/scripts/vol-permissions.sh
+              name: {{ include "topomojo-api.name" . }}-scripts
+              subPath: vol-permissions.sh
+          securityContext:
+            runAsUser: 0
+          {{- include "topomojo-api.env" . | nindent 10 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
Apologies, but there was an indentation problem in my previous PR that was treated as only a warning by helm, but as an error by argo. Previously,  line 51 of the api deployment was off by two spaces. I fixed this by changing the indentation style for the init container section to match that of the containers section. 

I verified it by installing a version of this chart via helm that printing out the env in the init container and I do see the SKIP_VOL_PERMISSIONS set now where it was not before. Also, I see that the old version printed a warning I had not noticed, which is no longer the case.

``` 
mpriest@mac-parrotapfel topotest % helm install -n imcite helm-mojo ~/helm-repo/helm-charts/charts/topomojo -f values.yaml
W0904 14:09:42.186830   81807 warnings.go:70] unknown field "spec.template.spec.initContainers[0].securityContext.envFrom"
NAME: helm-mojo
LAST DEPLOYED: Thu Sep  4 14:09:33 2025
NAMESPACE: imcite
STATUS: deployed
REVISION: 1
NOTES:
Course charted for helm-mojo-topomojo.
```