### PR TITLE
[mkdocs-material] Add option for installing the mkdocs-macros-plugin.

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/_helpers.tpl
+++ b/charts/mkdocs-material/templates/_helpers.tpl
@@ -128,16 +128,16 @@ Subpath prefix value to use for pvc mount points
   {{- end }}
   env:
     - name: MKDOCS_ADD_MACROS
-      value: {{ default "false" .Values.macroPlugin.enabled | toString | quote }}
+      value: {{ default "false" .Values.macrosPlugin.enabled | toString | quote }}
     - name: MKDOCS_MACROS_VERSION
-      value: {{ default "1.3.9" .Values.macroPlugin.version | toString | quote }}
+      value: {{ default "1.3.9" .Values.macrosPlugin.version | toString | quote }}
   {{- if .Values.gitPath }}
     - name: DOCS_GIT_PATH
       value: {{ .Values.gitPath | trimPrefix "/" }}
   {{- end }}
   volumeMounts:
-  {{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
-    - mountPath: {{ default "/mkdocs-vars" .Values.macroPlugin.extraYamlConfigMount }}
+  {{- if and .Values.macrosPlugin.enabled .Values.macrosPlugin.extraYamlConfig }}
+    - mountPath: {{ default "/mkdocs-vars" .Values.macrosPlugin.extraYamlConfigMount }}
       name: {{ include "mkdocs-material.fullname" . }}-macro-vars
   {{- end }}
   {{- if .Values.giturl }}
@@ -208,7 +208,7 @@ Subpath prefix value to use for pvc mount points
   configMap:
     name: {{ include "mkdocs-material.fullname" . }}-cacerts
 {{- end }}
-{{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
+{{- if and .Values.macrosPlugin.enabled .Values.macrosPlugin.extraYamlConfig }}
 - name: {{ include "mkdocs-material.fullname" . }}-macro-vars
   configMap:
     name: {{ include "mkdocs-material.fullname" . }}-macro-vars

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -30,8 +30,8 @@ data:
 
     git reset --hard
     git clean -f
-    
-    if [ -n "$DOCS_GIT_BRANCH" ]; then 
+
+    if [ -n "$DOCS_GIT_BRANCH" ]; then
         gitcheckoutoutput=`git checkout "$DOCS_GIT_BRANCH" 2>&1`
         echo "$gitcheckoutoutput" | grep "Switch*" > /dev/null 2>&1
         if [ "$?" -eq "0" ]; then
@@ -60,16 +60,22 @@ data:
 
         sed -i -r -e "s#^(site_url: )(.*)#\1${DOCS_SITE_URL}#" mkdocs.yml
         found_url=`grep -c 'site_url:' mkdocs.yml`
-        if [ $found_url = 0 ]; then 
+        if [ $found_url = 0 ]; then
         echo "site_url: ${DOCS_SITE_URL}" | cat - mkdocs.yml > tmp.yml
         mv tmp.yml mkdocs.yml
         fi
-    fi 
+    fi
 
   mkdocs-build.sh: |-
     #!/bin/sh
 
     if [ -f "/docs/.dirty" ]; then
+
+        if [ "$MKDOCS_ADD_MACROS" = "true" ]; then
+            echo "Installing mkdocs-macros-plugin version ${MKDOCS_MACROS_VERSION}..."
+            pip install --no-cache-dir mkdocs-macros-plugin=="$MKDOCS_MACROS_VERSION"
+        fi
+
         echo "Building docs..."
 
         if [ -n "$DOCS_GIT_PATH" ]; then
@@ -94,7 +100,7 @@ data:
                 cd /docs
                 tmp_path=`basename "$new_docs"`
                 chmod 775 "$tmp_path"
-                
+
                 ## Delete the previous symbolic link
                 rm "site"
 
@@ -104,7 +110,7 @@ data:
                 if [ -n "$old_docs" ]; then
                     echo "Removing old docs: $old_docs"
                     rm -Rf "$old_docs"
-                else 
+                else
                     echo "No old docs to remove"
                 fi
 
@@ -119,8 +125,8 @@ data:
             else
                 echo "Mkdocs build failed."
             fi
-        else 
-          echo "Docs directory not found: ${docs_dir}"    
+        else
+          echo "Docs directory not found: ${docs_dir}"
         fi
     else
         echo "Docs are up-to-date."

--- a/charts/mkdocs-material/templates/configmap-macro-vars.yaml
+++ b/charts/mkdocs-material/templates/configmap-macro-vars.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mkdocs-material.fullname" . }}-macro-vars
+  labels:
+    {{- include "mkdocs-material.labels" . | nindent 4 }}
+
+data:
+{{- range .Values.macroPlugin.extraYamlConfig }}
+{{- $configContent := toYaml .values }}
+  {{ .path }}: |-
+    {{- (tpl $configContent $) | nindent 4}}
+{{- end }}
+{{- end }}

--- a/charts/mkdocs-material/templates/configmap-macro-vars.yaml
+++ b/charts/mkdocs-material/templates/configmap-macro-vars.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
+{{- if and .Values.macrosPlugin.enabled .Values.macrosPlugin.extraYamlConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,7 +7,7 @@ metadata:
     {{- include "mkdocs-material.labels" . | nindent 4 }}
 
 data:
-{{- range .Values.macroPlugin.extraYamlConfig }}
+{{- range .Values.macrosPlugin.extraYamlConfig }}
 {{- $configContent := toYaml .values }}
   {{ .path }}: |-
     {{- (tpl $configContent $) | nindent 4}}

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -27,39 +27,5 @@ spec:
           containers:
           {{- include "mkdocs-material.mkdocs-container" . | nindent 12 }}
           volumes:
-            - name: {{ include "mkdocs-material.fullname" . }}-entry
-              configMap:
-                name: {{ include "mkdocs-material.fullname" . }}-entry
-                defaultMode: 0775
-            {{- if .Values.storage.existing }}
-            - name: {{ include "mkdocs-material.fullname" . }}-vol
-              persistentVolumeClaim:
-                claimName: {{ .Values.storage.existing }}
-            {{- else }}
-            - name: {{ include "mkdocs-material.fullname" . }}-vol
-              persistentVolumeClaim:
-                claimName: {{ include "mkdocs-material.fullname" . }}
-            {{- end }}
-            {{- if .Values.gitCredentialsSecret }}
-            - name: {{ include "mkdocs-material.fullname" . }}-git-creds
-              secret:
-                secretName: {{ .Values.gitCredentialsSecret }}
-                defaultMode: 0600
-            {{- end }}
-            {{- if .Values.certificateMap }}
-            - name: certificates
-              configMap:
-                name: {{ .Values.certificateMap }}
-            {{- end }}
-            {{- if .Values.cacert }}
-            - name: certificates
-              configMap:
-                name: {{ include "mkdocs-material.fullname" . }}-cacerts
-            {{- end }}
-            {{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
-            - name: {{ include "mkdocs-material.fullname" . }}-macro-vars
-              configMap:
-                name: {{ include "mkdocs-material.fullname" . }}-macro-vars
-            {{- end }}
-
+            {{- include "mkdocs-material.container-volumes" . | nindent 12 }}
 {{- end }}

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -23,62 +23,9 @@ spec:
         spec:
           restartPolicy: Never
           initContainers:
-            - name: git-pull
-              image: "bitnami/git"
-              command: ["/entry.d/git-pull.sh"]
-              env:
-                - name: DOCS_GIT_URL
-                  value: {{ (tpl .Values.giturl .) }}
-                - name: DOCS_GIT_BRANCH
-                  value: {{ .Values.gitbranch }}
-                {{- if .Values.gitCredentialsSecret }}
-                - name: DOCS_GIT_CRED_FILE
-                  value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
-                {{- end }}
-                {{- if .Values.gitPath }}
-                - name: DOCS_GIT_PATH
-                  value: {{ .Values.gitPath | trimPrefix "/" }}
-                {{- end }}
-                {{- if .Values.mkdocs.site_url }}
-                - name: DOCS_SITE_URL
-                  value: {{ .Values.mkdocs.site_url }}
-                {{- end }}
-              volumeMounts:
-                - mountPath: /entry.d
-                  name: {{ include "mkdocs-material.fullname" . }}-entry
-                - mountPath: /docs
-                  name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
-                - mountPath: /git
-                  name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
-                {{- if .Values.gitCredentialsSecret }}
-                - mountPath: /git-credentials
-                  name: {{ include "mkdocs-material.fullname" . }}-git-creds
-                {{- end }}
-                {{- if or .Values.certificateMap .Values.cacert }}
-                - mountPath: /usr/local/share/ca-certificates
-                  name: certificates
-                {{- end }}
+          {{- include "mkdocs-material.git-container" . | nindent 12 }}
           containers:
-            - name: mkdocs-build
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
-              command: ["/entry.d/mkdocs-build.sh"]
-              {{- if .Values.gitPath }}
-              env:
-                - name: DOCS_GIT_PATH
-                  value: {{ .Values.gitPath | trimPrefix "/" }}
-              {{- end }}
-              volumeMounts:
-                - mountPath: /entry.d
-                  name: {{ include "mkdocs-material.fullname" . }}-entry
-                - mountPath: /docs
-                  name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
-                - mountPath: /git
-                  name: {{ include "mkdocs-material.fullname" . }}-vol
-                  subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
+          {{- include "mkdocs-material.mkdocs-container" . | nindent 12 }}
           volumes:
             - name: {{ include "mkdocs-material.fullname" . }}-entry
               configMap:
@@ -88,7 +35,7 @@ spec:
             - name: {{ include "mkdocs-material.fullname" . }}-vol
               persistentVolumeClaim:
                 claimName: {{ .Values.storage.existing }}
-            {{- else }}    
+            {{- else }}
             - name: {{ include "mkdocs-material.fullname" . }}-vol
               persistentVolumeClaim:
                 claimName: {{ include "mkdocs-material.fullname" . }}
@@ -109,6 +56,10 @@ spec:
               configMap:
                 name: {{ include "mkdocs-material.fullname" . }}-cacerts
             {{- end }}
+            {{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
+            - name: {{ include "mkdocs-material.fullname" . }}-macro-vars
+              configMap:
+                name: {{ include "mkdocs-material.fullname" . }}-macro-vars
+            {{- end }}
 
 {{- end }}
-    

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -28,76 +28,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        {{- if .Values.giturl }}
-        - name: git-pull
-          image: "bitnami/git"
-          command: ["/entry.d/git-pull.sh"]
-          env:
-            - name: DOCS_GIT_URL
-              value: {{ (tpl .Values.giturl .) }}
-            - name: DOCS_GIT_BRANCH
-              value: {{ .Values.gitbranch }}
-            {{- if .Values.gitCredentialsSecret }}
-            - name: DOCS_GIT_CRED_FILE
-              value: {{ default ".git-credentials" .Values.gitCredentialsSecretKey }}
-            {{- end }}
-            {{- if .Values.gitPath }}
-            - name: DOCS_GIT_PATH
-              value: {{ .Values.gitPath | trimPrefix "/" }}
-            {{- end }}
-            {{- if .Values.mkdocs.site_url }}
-            - name: DOCS_SITE_URL
-              value: {{ .Values.mkdocs.site_url }}
-            {{- end }}
-          volumeMounts:
-            - mountPath: /entry.d
-              name: {{ include "mkdocs-material.fullname" . }}-entry
-            - mountPath: /docs
-              name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
-            - mountPath: /git
-              name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
-            {{- if .Values.gitCredentialsSecret }}
-            - mountPath: /git-credentials
-              name: {{ include "mkdocs-material.fullname" . }}-git-creds
-            {{- end }}
-            {{- if or .Values.certificateMap .Values.cacert }}
-            - mountPath: /usr/local/share/ca-certificates
-              name: certificates
-            {{- end }}
-        {{- end }}
-        - name: mkdocs-build
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-            {{- if .Values.giturl }}
-          command: ["/entry.d/mkdocs-build.sh"]
-          {{- if .Values.gitPath }}
-          env:
-            - name: DOCS_GIT_PATH
-              value: {{ .Values.gitPath | trimPrefix "/" }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /entry.d
-              name: {{ include "mkdocs-material.fullname" . }}-entry
-            - mountPath: /docs
-              name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs
-            - mountPath: /git
-              name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.subpathPrefix" . }}git
-            {{- else }}
-          args: ["build"]
-          volumeMounts:
-            - mountPath: /docs/mkdocs.yml
-              name: {{ include "mkdocs-material.fullname" . }}
-              subPath: mkdocs.yml
-            - mountPath: /docs/docs
-              name: {{ include "mkdocs-material.fullname" . }}-files
-            - mountPath: /docs/site
-              name: {{ include "mkdocs-material.fullname" . }}-vol
-              subPath: {{ include "mkdocs-material.subpathPrefix" . }}docs/site
-            {{- end }}
+        {{- include "mkdocs-material.git-container" . | nindent 8 }}
+        {{- include "mkdocs-material.mkdocs-container" . | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           image: nginx:alpine
@@ -171,3 +103,10 @@ spec:
         configMap:
           name: {{ include "mkdocs-material.fullname" . }}-cacerts
       {{- end }}
+      {{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
+      - name: {{ include "mkdocs-material.fullname" . }}-macro-vars
+        configMap:
+          name: {{ include "mkdocs-material.fullname" . }}-macro-vars
+      {{- end }}
+
+

--- a/charts/mkdocs-material/templates/deployment.yaml
+++ b/charts/mkdocs-material/templates/deployment.yaml
@@ -60,53 +60,5 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      - name: {{ include "mkdocs-material.fullname" . }}
-        configMap:
-          name: {{ include "mkdocs-material.fullname" . }}
-      {{- if .Values.giturl }}
-      - name: {{ include "mkdocs-material.fullname" . }}-entry
-        configMap:
-          name: {{ include "mkdocs-material.fullname" . }}-entry
-          defaultMode: 0775
-      {{- if .Values.gitCredentialsSecret }}
-      - name: {{ include "mkdocs-material.fullname" . }}-git-creds
-        secret:
-          secretName: {{ .Values.gitCredentialsSecret }}
-          defaultMode: 0600
-      {{- end }}
-      {{- else }}
-      - name: {{ include "mkdocs-material.fullname" . }}-files
-        configMap:
-          name: {{ include "mkdocs-material.fullname" . }}-files
-      {{- end }}
-      {{- if .Values.storage.existing }}
-      - name: {{ include "mkdocs-material.fullname" . }}-vol
-        persistentVolumeClaim:
-          claimName: {{ .Values.storage.existing }}
-      {{- else if .Values.storage.size }}
-      - name: {{ include "mkdocs-material.fullname" . }}-vol
-        persistentVolumeClaim:
-          claimName: {{ include "mkdocs-material.fullname" . }}
-      {{- else if .Values.giturl }}
-      {{- fail "Git deployment mode requires persistent volume" }}
-      {{- else }}
-      - name: {{ include "mkdocs-material.fullname" . }}-vol
-        emptyDir: {}
-      {{- end }}
-      {{- if .Values.certificateMap }}
-      - name: certificates
-        configMap:
-          name: {{ .Values.certificateMap }}
-      {{- end }}
-      {{- if .Values.cacert }}
-      - name: certificates
-        configMap:
-          name: {{ include "mkdocs-material.fullname" . }}-cacerts
-      {{- end }}
-      {{- if and .Values.macroPlugin.enabled .Values.macroPlugin.extraYamlConfig }}
-      - name: {{ include "mkdocs-material.fullname" . }}-macro-vars
-        configMap:
-          name: {{ include "mkdocs-material.fullname" . }}-macro-vars
-      {{- end }}
-
+        {{- include "mkdocs-material.container-volumes" . | nindent 8 }}
 

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -90,6 +90,43 @@ tolerations: []
 
 affinity: {}
 
+##############################################################
+# Option to add the mkdocs-macros-plugin                     #
+# See https://mkdocs-macros-plugin.readthedocs.io/en/latest/ #
+##############################################################
+macroPlugin:
+  enabled: false
+  version: 1.3.9       # pip version of mkdocs-macros-plugin
+  extraYamlConfigMount: /mkdocs-vars # The name of the volume mount path for extra yaml config files
+  # This section is used to pass values that are expected to appear as include_yaml entries
+  # in the mkdocs.yaml plugin section configuring the mkdocs-macros-plugin plugin.
+  extraYamlConfig: []
+  # extraYamlConfig:
+  #   - path: vars1.yaml  # paths are relative to the extraYamlConfigMount
+  #     values:           # values are copied into the defined structure in the target file
+  #       domain: example.net
+  #       shortName: myproject
+  #       longName: Sample Project
+  #   - path: vars2.yaml
+  #     values:
+  #       color: blue
+  #       fruit: banana
+
+  # Sample plugin config snippet from mkdocs.yaml using the files above.
+  # Note that you can have a local defaults file in your docs that can be optionally
+  # overridden by the files added via this chart. Mkdocs will give a warning if they
+  # don't exist locally, but will still build successfully, for example:
+  # INFO    -  [macros] - WARNING: YAML configuration file was not found! /mkdocs-vars/vars1.yaml
+  # The entries that appear later in the list have precedence of earlier values files.
+  # plugins:
+  #   - search
+  #   - macros:
+  #       on_undefined: strict
+  #       include_yaml:
+  #         - global: local-defaults.yaml
+  #         - global: /mkdocs-vars/vars1.yaml
+  #         - global: /mkdocs-vars/vars2.yaml
+
 ##################
 # Git deployment #
 ##################

--- a/charts/mkdocs-material/values.yaml
+++ b/charts/mkdocs-material/values.yaml
@@ -94,7 +94,7 @@ affinity: {}
 # Option to add the mkdocs-macros-plugin                     #
 # See https://mkdocs-macros-plugin.readthedocs.io/en/latest/ #
 ##############################################################
-macroPlugin:
+macrosPlugin:
   enabled: false
   version: 1.3.9       # pip version of mkdocs-macros-plugin
   extraYamlConfigMount: /mkdocs-vars # The name of the volume mount path for extra yaml config files


### PR DESCRIPTION
This PR adds support for the [mkdocs-macros-plugin](https://mkdocs-macros-plugin.readthedocs.io/en/latest/).

The template supports the use of optional [external yaml values files](https://mkdocs-macros-plugin.readthedocs.io/en/latest/advanced/#including-external-yaml-files) to be included via a ConfigMap mounted to the pod that builds mkdocs. As explained in detail in a comment in the values.yaml file, this allows docs to define local default values that can be used while testing doc changes locally, which will be overwritten by the external yaml files (which support embedded templating) when deployed.

There is also a consolidation of the git-pull and mkdocs-build container specs that are shared between the deployment and the cronjob to reduce maintenance [as per DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). 