### PR TITLE
[crucible] Add Ingress annotations templating

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: alloy
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.3
+version: 1.6.5

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.1
+version: 1.6.5
 appVersion: 3.6.1

--- a/charts/alloy/charts/alloy-api/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "alloy-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: alloy-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.2
+version: 1.6.5
 appVersion: 3.3.2

--- a/charts/alloy/charts/alloy-ui/templates/ingress.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "alloy-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: blueprint
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.6.3

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.6.3
 appVersion: 1.4.7

--- a/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "blueprint-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: blueprint-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.6.3
 appVersion: 1.4.8

--- a/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
+++ b/charts/blueprint/charts/blueprint-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "blueprint-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: caster
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.6.3

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: 3.5.1

--- a/charts/caster/charts/caster-api/templates/ingress.yaml
+++ b/charts/caster/charts/caster-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "caster-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: caster-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: 3.4.2

--- a/charts/caster/charts/caster-ui/templates/ingress.yaml
+++ b/charts/caster/charts/caster-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "caster-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cite
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.3
+version: 1.6.4

--- a/charts/cite/charts/cite-api/Chart.yaml
+++ b/charts/cite/charts/cite-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.6.4
 appVersion: 1.8.1

--- a/charts/cite/charts/cite-api/templates/ingress.yaml
+++ b/charts/cite/charts/cite-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "cite-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cite-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.6.4
 appVersion: 1.8.2

--- a/charts/cite/charts/cite-ui/templates/ingress.yaml
+++ b/charts/cite/charts/cite-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "cite-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gallery
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.6.3

--- a/charts/gallery/charts/gallery-api/Chart.yaml
+++ b/charts/gallery/charts/gallery-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.0
+version: 1.6.3
 appVersion: 1.7.4

--- a/charts/gallery/charts/gallery-api/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "gallery-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gallery-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.6.3
 appVersion: 1.7.4

--- a/charts/gallery/charts/gallery-ui/templates/ingress.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "gallery-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: player
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.2
+version: 1.7.1

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: console-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.1
+version: 1.7.1
 appVersion: 3.3.0

--- a/charts/player/charts/console-ui/templates/ingress.yaml
+++ b/charts/player/charts/console-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "console-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: 3.4.0

--- a/charts/player/charts/player-api/templates/ingress.yaml
+++ b/charts/player/charts/player-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "player-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: player-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.1
+version: 1.7.1
 appVersion: 3.3.1

--- a/charts/player/charts/player-ui/templates/ingress.yaml
+++ b/charts/player/charts/player-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "player-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.0
+version: 1.7.1
 appVersion: 3.8.0

--- a/charts/player/charts/vm-api/templates/ingress.yaml
+++ b/charts/player/charts/vm-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "vm-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: vm-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.3.2
+version: 1.7.1
 appVersion: 3.5.1

--- a/charts/player/charts/vm-ui/templates/ingress.yaml
+++ b/charts/player/charts/vm-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "vm-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: steamfitter
 description: A Helm chart for Kubernetes
 type: application
-version: 1.6.1
+version: 1.6.2

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-api
 description: A Helm chart for Kubernetes
 type: application
-version: 1.4.0
+version: 1.6.2
 appVersion: 3.9.0

--- a/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "steamfitter-api.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: steamfitter-ui
 description: A Helm chart for Kubernetes
 type: application
-version: 1.5.1
+version: 1.6.2
 appVersion: 3.8.0

--- a/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/ingress.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- include "steamfitter-ui.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}
 spec:
   {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}


### PR DESCRIPTION
Adds `tpl` function to Ingress annotations for Crucible apps that were missing it. Allows for customizing the issuer at deploy time.

Also synchronizes parent and child Chart.yaml versions.