### PR TITLE
[mkdocs-material] The name of the cronjob needs to be the full release name including the chart to avoid conflicts

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.11
+version: 0.2.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/cronjob.yaml
+++ b/charts/mkdocs-material/templates/cronjob.yaml
@@ -2,12 +2,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: "{{ .Release.Name }}-cron"
+  name: {{ include "mkdocs-material.fullname" . }}-cron
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- include "mkdocs-material.labels" . | nindent 4 }}
 spec:
   schedule: "*/{{ .Values.pollInterval | default 5 }} * * * *"
   concurrencyPolicy: Forbid
@@ -15,11 +12,9 @@ spec:
     spec:
       template:
         metadata:
-          name: "{{ .Release.Name }}"
+          name: {{ include "mkdocs-material.fullname" . }}-cron
           labels:
-            app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-            app.kubernetes.io/instance: {{ .Release.Name | quote }}
-            helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+            {{- include "mkdocs-material.labels" . | nindent 12 }}
         spec:
           restartPolicy: Never
           initContainers:


### PR DESCRIPTION
Fixing the name of the cronjob and it's labels to be consistent with the other templates.