### PR TITLE
GB UI - default settingsYaml to null

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.8

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/gameboard/charts/gameboard-ui/values.yaml
+++ b/charts/gameboard/charts/gameboard-ui/values.yaml
@@ -89,8 +89,10 @@ basehref: ""
 settings: "{}"
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-settingsYaml:
-  appname: Gameboard
+## NOTE: If specified here, will override the generated settings.json for installations that are using
+## the `settings` key. Change with caution.
+settingsYaml: null
+  # appname: Gameboard
   # apphost: http://localhost:5002
   # basehref: "gb"
   # imghost: 'http://localhost:5002/img'
@@ -99,7 +101,7 @@ settingsYaml:
   # tocfile: ''
   # countdownStartSecondsAtMinute: 5
   # custom_background: 'custom-bg-dark-gray'
-  consoleForgeConfig:
+  # consoleForgeConfig:
   #   canvasRecording:
   #     autoDownloadCompletedRecordings: true
   #     chunkLength: 1000
@@ -107,7 +109,7 @@ settingsYaml:
   #     maxDuration: 10000
   #     mimeType: 'video/webm'
   #   consoleBackgroundStyle: 'rgb(40, 40, 40)'
-    defaultConsoleType: vmware # or "proxmox"
+  # defaultConsoleType: vmware # or "proxmox"
   #   disabledFeatures:
   #     clipboard: false
   #     consoleScreenRecord: false

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -289,8 +289,10 @@ gameboard-ui:
   settings: "{}"
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-  settingsYaml:
-    appname: Gameboard
+  ## NOTE: If specified here, will override the generated settings.json for installations that are using
+  ## the `settings` key. Change with caution.
+  settingsYaml: null
+    # appname: Gameboard
     # apphost: http://localhost:5002
     # basehref: "gb"
     # imghost: 'http://localhost:5002/img'
@@ -299,7 +301,7 @@ gameboard-ui:
     # tocfile: ''
     # countdownStartSecondsAtMinute: 5
     # custom_background: 'custom-bg-dark-gray'
-    consoleForgeConfig:
+    # consoleForgeConfig:
     #   canvasRecording:
     #     autoDownloadCompletedRecordings: true
     #     chunkLength: 1000
@@ -307,7 +309,7 @@ gameboard-ui:
     #     maxDuration: 10000
     #     mimeType: 'video/webm'
     #   consoleBackgroundStyle: 'rgb(40, 40, 40)'
-      defaultConsoleType: vmware # or "proxmox"
+    #  defaultConsoleType: vmware # or "proxmox"
     #   disabledFeatures:
     #     clipboard: false
     #     consoleScreenRecord: false


### PR DESCRIPTION
This rolls back a change that supplied some defaults to `settingsYaml` for GBUI. The issue is that if this value is specified, any downstream apps that are using `settings` to configure their apps will have them overridden by the default `settingsYaml` from our values.

Changed this value to `null` in the greater GB chart and the GB UI chart, and added a note explaining this until we find a better way forward for settings more generally.