### PR TITLE
[mkdocs-material, osticket] Update Docker image locations to bitnamilegacy organization

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.13
+version: 0.2.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/_helpers.tpl
+++ b/charts/mkdocs-material/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Subpath prefix value to use for pvc mount points
 {{- define "mkdocs-material.git-container" }}
 {{- if .Values.giturl }}
 - name: git-pull
-  image: "bitnami/git"
+  image: "bitnamilegacy/git"
   command: ["/entry.d/git-pull.sh"]
   env:
     - name: DOCS_GIT_URL

--- a/charts/osticket/Chart.yaml
+++ b/charts/osticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.5
+version: 1.17.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/osticket/charts/mysql/values.yaml
+++ b/charts/osticket/charts/mysql/values.yaml
@@ -72,7 +72,7 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnami/mysql
+  repository: bitnamilegacy/mysql
   tag: 8.0.30-debian-11-r15
   digest: ""
   ## Specify a imagePullPolicy


### PR DESCRIPTION
Updates Docker image tags in the mkdocs-material and osticket charts to push to the bitnamilegacy Docker Hub organization.