### PR TITLE
GB/TM app version/settings updates (IDP role assignment)

### DIFF
--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.9

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.34.3
+appVersion: 3.35.0

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -188,6 +188,13 @@ env: {}
   # Oidc__DefaultUserNameInferFromEmail: false
   # Oidc__StoreUserEmails: false
 
+  # Oidc__UserRolesClaimMap__administrator: Admin
+  # Oidc__UserRolesClaimMap__director: Director
+  # Oidc__UserRolesClaimMap__member: Member
+  # Oidc__UserRolesClaimMap__support: Support
+  # Oidc__UserRolesClaimMap__tester: Tester
+  # Oidc__UserRolesClaimPath: realm_access.roles
+
 ## giturl is the url of the git repository of static markdown
 giturl: ""
 ## gitbranch sets which repo branch to publish

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.7
+version: 0.5.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.34.2
+appVersion: 3.35.0

--- a/charts/gameboard/charts/gameboard-ui/values.yaml
+++ b/charts/gameboard/charts/gameboard-ui/values.yaml
@@ -89,8 +89,8 @@ basehref: ""
 settings: "{}"
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-settingsYaml:
-  appname: Gameboard
+settingsYaml: {}
+  # appname: Gameboard
   # apphost: http://localhost:5002
   # basehref: "gb"
   # imghost: 'http://localhost:5002/img'
@@ -99,7 +99,7 @@ settingsYaml:
   # tocfile: ''
   # countdownStartSecondsAtMinute: 5
   # custom_background: 'custom-bg-dark-gray'
-  consoleForgeConfig:
+  # consoleForgeConfig:
   #   canvasRecording:
   #     autoDownloadCompletedRecordings: true
   #     chunkLength: 1000
@@ -107,7 +107,7 @@ settingsYaml:
   #     maxDuration: 10000
   #     mimeType: 'video/webm'
   #   consoleBackgroundStyle: 'rgb(40, 40, 40)'
-    defaultConsoleType: vmware # or "proxmox"
+  #   defaultConsoleType: vmware # or "proxmox"
   #   disabledFeatures:
   #     clipboard: false
   #     consoleScreenRecord: false

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -188,6 +188,12 @@ gameboard-api:
     # Oidc__Authority: http://localhost:8080/realms/foundry
     # Oidc__DefaultUserNameInferFromEmail: false
     # Oidc__StoreUserEmails: false
+    # Oidc__UserRolesClaimMap__administrator: Admin
+    # Oidc__UserRolesClaimMap__director: Director
+    # Oidc__UserRolesClaimMap__member: Member
+    # Oidc__UserRolesClaimMap__support: Support
+    # Oidc__UserRolesClaimMap__tester: Tester
+    # Oidc__UserRolesClaimPath: realm_access.roles
 
   ## giturl is the url of the git repository of static markdown
   giturl: ""
@@ -289,8 +295,8 @@ gameboard-ui:
   settings: "{}"
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-  settingsYaml:
-    appname: Gameboard
+  settingsYaml: {}
+    # appname: Gameboard
     # apphost: http://localhost:5002
     # basehref: "gb"
     # imghost: 'http://localhost:5002/img'
@@ -299,7 +305,7 @@ gameboard-ui:
     # tocfile: ''
     # countdownStartSecondsAtMinute: 5
     # custom_background: 'custom-bg-dark-gray'
-    consoleForgeConfig:
+    # consoleForgeConfig:
     #   canvasRecording:
     #     autoDownloadCompletedRecordings: true
     #     chunkLength: 1000
@@ -307,7 +313,7 @@ gameboard-ui:
     #     maxDuration: 10000
     #     mimeType: 'video/webm'
     #   consoleBackgroundStyle: 'rgb(40, 40, 40)'
-      defaultConsoleType: vmware # or "proxmox"
+      # defaultConsoleType: vmware # or "proxmox"
     #   disabledFeatures:
     #     clipboard: false
     #     consoleScreenRecord: false

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.3.12
+appVersion: 2.5.0

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -208,6 +208,12 @@ env:
   # Oidc__Authority: http://localhost:5000
   ## Set this to the string "null" to disable client credentials authentication (enabled by default)
   # Oidc__ServiceAccountClientIdClaimType: client_id
+  # Oidc__UserRolesClaimMap__administrator = Admin
+  # Oidc__UserRolesClaimMap__director = Director
+  # Oidc__UserRolesClaimMap__member = Member
+  # Oidc__UserRolesClaimMap__support = Support
+  # Oidc__UserRolesClaimMap__tester = Tester
+  # Oidc__UserRolesClaimPath = realm_access.roles
   # Database__Provider: InMemory
   # Database__ConnectionString: topomojo_db
   # Database__SeedFile: seed-data.json

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -208,11 +208,11 @@ env:
   # Oidc__Authority: http://localhost:5000
   ## Set this to the string "null" to disable client credentials authentication (enabled by default)
   # Oidc__ServiceAccountClientIdClaimType: client_id
-  # Oidc__UserRolesClaimMap__administrator = Admin
-  # Oidc__UserRolesClaimMap__director = Director
-  # Oidc__UserRolesClaimMap__member = Member
-  # Oidc__UserRolesClaimMap__support = Support
-  # Oidc__UserRolesClaimMap__tester = Tester
+  # Oidc__UserRolesClaimMap__administrator: Administrator
+  # Oidc__UserRolesClaimMap__builder: Builder
+  # Oidc__UserRolesClaimMap__creator: Creator
+  # Oidc__UserRolesClaimMap__observer: Observer
+  # Oidc__UserRolesClaimMap__user: user
   # Oidc__UserRolesClaimPath = realm_access.roles
   # Database__Provider: InMemory
   # Database__ConnectionString: topomojo_db

--- a/charts/topomojo/charts/topomojo-ui/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-ui/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.6
+version: 0.5.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 2.4.5
+appVersion: 2.5.0

--- a/charts/topomojo/charts/topomojo-ui/values.yaml
+++ b/charts/topomojo/charts/topomojo-ui/values.yaml
@@ -89,7 +89,7 @@ basehref: ""
 settings: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-settingsYaml:
+settingsYaml: {}
   # appname: TopoMojo
   # oidc:
   #   client_id: clientid

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -197,6 +197,12 @@ topomojo-api:
     # Oidc__Authority: http://localhost:5000
     ## Set this to the string "null" to disable client credentials authentication (enabled by default)
     # Oidc__ServiceAccountClientIdClaimType: client_id
+    # Oidc__UserRolesClaimMap__administrator = Admin
+    # Oidc__UserRolesClaimMap__director = Director
+    # Oidc__UserRolesClaimMap__member = Member
+    # Oidc__UserRolesClaimMap__support = Support
+    # Oidc__UserRolesClaimMap__tester = Tester
+    # Oidc__UserRolesClaimPath = realm_access.roles
     # Database__Provider: InMemory
     # Database__ConnectionString: topomojo_db
     # Database__SeedFile: seed-data.json

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -197,12 +197,12 @@ topomojo-api:
     # Oidc__Authority: http://localhost:5000
     ## Set this to the string "null" to disable client credentials authentication (enabled by default)
     # Oidc__ServiceAccountClientIdClaimType: client_id
-    # Oidc__UserRolesClaimMap__administrator = Admin
-    # Oidc__UserRolesClaimMap__director = Director
-    # Oidc__UserRolesClaimMap__member = Member
-    # Oidc__UserRolesClaimMap__support = Support
-    # Oidc__UserRolesClaimMap__tester = Tester
-    # Oidc__UserRolesClaimPath = realm_access.roles
+    # Oidc__UserRolesClaimMap__administrator: Administrator
+    # Oidc__UserRolesClaimMap__builder: Builder
+    # Oidc__UserRolesClaimMap__creator: Creator
+    # Oidc__UserRolesClaimMap__observer: Observer
+    # Oidc__UserRolesClaimMap__user: user
+    # Oidc__UserRolesClaimPath: realm_access.roles
     # Database__Provider: InMemory
     # Database__ConnectionString: topomojo_db
     # Database__SeedFile: seed-data.json


### PR DESCRIPTION
- Updates GB to 3.35.0, TM to 2.5.0
- Adds default settings hints for both in API charts
- Added a missing empty dict literal for `settingsYaml` in the topo UI chart