### PR TITLE
use empty settings.shared.json when unset

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -3,7 +3,7 @@ name: alloy
 description: Alloy enables users to launch on-demand events or join instances of already-running
   simulations.
 type: application
-version: 1.7.2
+version: 1.7.3
 home: https://cmu-sei.github.io/crucible/alloy/
 sources:
 - https://github.com/cmu-sei/Alloy.Api

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: alloy-ui
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 3.4.2

--- a/charts/alloy/charts/alloy-ui/templates/configmap.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/alloy/charts/alloy-ui/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "alloy-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "alloy-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "alloy-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "alloy-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "alloy-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "alloy-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "alloy-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caster
 description: Caster enables the coded design and deployment of cyber topologies.
 type: application
-version: 1.8.2
+version: 1.8.3
 home: https://cmu-sei.github.io/crucible/caster/
 sources:
 - https://github.com/cmu-sei/Caster.Api/

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: caster-ui
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: 3.6.2

--- a/charts/caster/charts/caster-ui/templates/configmap.yaml
+++ b/charts/caster/charts/caster-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/caster/charts/caster-ui/templates/deployment.yaml
+++ b/charts/caster/charts/caster-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "caster-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "caster-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "caster-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "caster-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "caster-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "caster-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "caster-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -3,7 +3,7 @@ name: cite
 description: CITE enables participants from different organizations to evaluate, score,
   and comment on cyber incidents.
 type: application
-version: 1.9.1
+version: 1.9.2
 home: https://cmu-sei.github.io/crucible/cite/
 sources:
 - https://github.com/cmu-sei/cite.Api

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cite-ui
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.11.1

--- a/charts/cite/charts/cite-ui/templates/configmap.yaml
+++ b/charts/cite/charts/cite-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/cite/charts/cite-ui/templates/deployment.yaml
+++ b/charts/cite/charts/cite-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "cite-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "cite-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "cite-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "cite-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "cite-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "cite-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "cite-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -3,7 +3,7 @@ name: gallery
 description: Gallery enables participants to review cyber incident data by source
   type.
 type: application
-version: 1.9.1
+version: 1.9.2
 home: https://cmu-sei.github.io/crucible/gallery/
 sources:
 - https://github.com/cmu-sei/Gallery.Api/

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gallery-ui
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 1.10.1

--- a/charts/gallery/charts/gallery-ui/templates/configmap.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/gallery/charts/gallery-ui/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "gallery-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "gallery-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "gallery-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "gallery-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "gallery-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "gallery-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "gallery-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.9.2
+version: 1.9.3
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 3.4.1

--- a/charts/player/charts/console-ui/templates/configmap.yaml
+++ b/charts/player/charts/console-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/player/charts/console-ui/templates/deployment.yaml
+++ b/charts/player/charts/console-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "console-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "console-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "console-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "console-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "console-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "console-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "console-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-ui
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: 3.4.2

--- a/charts/player/charts/player-ui/templates/configmap.yaml
+++ b/charts/player/charts/player-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/player/charts/player-ui/templates/deployment.yaml
+++ b/charts/player/charts/player-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "player-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "player-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "player-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "player-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "player-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "player-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "player-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.8.0
+version: 1.8.1
 appVersion: 3.6.1

--- a/charts/player/charts/vm-ui/templates/configmap.yaml
+++ b/charts/player/charts/vm-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/player/charts/vm-ui/templates/deployment.yaml
+++ b/charts/player/charts/vm-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "vm-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "vm-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "vm-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "vm-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "vm-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "vm-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "vm-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -3,7 +3,7 @@ name: steamfitter
 description: Steamfitter enables the organization and execution of scenario tasks
   on virtual machines by integrating with StackStorm automation.
 type: application
-version: 1.7.2
+version: 1.7.3
 home: https://cmu-sei.github.io/crucible/steamfitter
 sources:
 - https://github.com/cmu-sei/steamfitter.api

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: steamfitter-ui
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 3.9.2

--- a/charts/steamfitter/charts/steamfitter-ui/templates/configmap.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/configmap.yaml
@@ -11,3 +11,4 @@ data:
 {{- else }}
 {{- (tpl .Values.settings .) | indent 4 }}
 {{- end }}
+  settings.shared.json: "{}"

--- a/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/templates/deployment.yaml
@@ -52,11 +52,9 @@ spec:
             - mountPath: /usr/share/nginx/html/assets/config/settings.env.json
               subPath: settings.env.json
               name: {{ include "steamfitter-ui.fullname" . }}-settings
-            {{- if .Values.sharedSettingsConfigMap }}
             - mountPath: /usr/share/nginx/html/assets/config/settings.shared.json
               subPath: settings.shared.json
               name: {{ include "steamfitter-ui.fullname" . }}-shared-settings
-            {{- end }}
             {{- include "steamfitter-ui.extraVolumeMounts" . | nindent 12 }}
       volumes:
         - name: {{ include "steamfitter-ui.fullname" . }}-settings
@@ -66,6 +64,13 @@ spec:
         - name: {{ include "steamfitter-ui.fullname" . }}-shared-settings
           configMap:
             name: {{ .Values.sharedSettingsConfigMap }}
+            items:
+              - key: settings.shared.json
+                path: settings.shared.json
+        {{- else }}
+        - name: {{ include "steamfitter-ui.fullname" . }}-shared-settings
+          configMap:
+            name: {{ include "steamfitter-ui.fullname" . }}
             items:
               - key: settings.shared.json
                 path: settings.shared.json


### PR DESCRIPTION
If sharedSettingsConfigMap is not set, mount an empty settings.shared.json to avoid unnecessary 404s and errors.