### PR TITLE
crucible-apps: honor realmAdminUsername override and use helpers

### DIFF
--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: crucible-apps
 description: Crucible framework application deployment - A comprehensive cybersecurity training and exercise platform with Keycloak, Player, Caster, Alloy, Blueprint, CITE, Gallery, Gameboard, Steamfitter, TopoMojo, and Moodle
 type: application
-version: 0.2.1
+version: 0.2.2
 home: https://cmu-sei.github.io/crucible/
 
 dependencies:

--- a/charts/crucible-apps/templates/_helpers.tpl
+++ b/charts/crucible-apps/templates/_helpers.tpl
@@ -72,6 +72,13 @@ Return the name of the TLS certificate secret.
 {{- end }}
 
 {{/*
+Return the name of the OIDC client secrets secret.
+*/}}
+{{- define "crucible.oidcClientSecretsName" -}}
+{{- "crucible-oidc-client-secrets" -}}
+{{- end }}
+
+{{/*
 Return the Keycloak Operator service name.
 The operator creates a service named "<cr-name>-service".
 */}}

--- a/charts/crucible-apps/templates/job-realm-users.yaml
+++ b/charts/crucible-apps/templates/job-realm-users.yaml
@@ -40,11 +40,11 @@ spec:
               echo "Crucible realm is available"
 
               # Find admin user in crucible realm
-              USER_JSON=$(kubectl exec "${KEYCLOAK_POD}" -- ${KCADM} get users -r crucible ${KCADM_AUTH} -q username=admin -q exact=true 2>/dev/null)
+              USER_JSON=$(kubectl exec "${KEYCLOAK_POD}" -- ${KCADM} get users -r crucible ${KCADM_AUTH} -q "username=${REALM_ADMIN_USERNAME}" -q exact=true 2>/dev/null)
               USER_ID=$(echo "${USER_JSON}" | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*: *"//;s/"//')
 
               if [ -z "${USER_ID}" ] || [ "${USER_ID}" = "null" ]; then
-                echo "ERROR: Admin user not found in crucible realm"
+                echo "ERROR: Admin user '${REALM_ADMIN_USERNAME}' not found in crucible realm"
                 exit 1
               fi
               echo "Found admin user: ${USER_ID}"
@@ -68,10 +68,12 @@ spec:
                 secretKeyRef:
                   name: {{ include "crucible.keycloakAdminSecretName" . }}
                   key: password
+            - name: REALM_ADMIN_USERNAME
+              value: {{ .Values.keycloak.realmAdminUsername | quote }}
             - name: REALM_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: crucible-oidc-client-secrets
+                  name: {{ include "crucible.oidcClientSecretsName" . }}
                   key: realm-admin-password
 ---
 apiVersion: v1

--- a/charts/crucible-apps/templates/keycloak-ingress.yaml
+++ b/charts/crucible-apps/templates/keycloak-ingress.yaml
@@ -14,7 +14,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.global.domain }}
-      secretName: {{ .Values.keycloak.ingress.tlsSecretName | default "crucible-cert" }}
+      secretName: {{ .Values.keycloak.ingress.tlsSecretName | default (include "crucible.tlsSecretName" .) }}
   rules:
     - host: {{ .Values.global.domain }}
       http:

--- a/charts/crucible-apps/templates/secret.yaml
+++ b/charts/crucible-apps/templates/secret.yaml
@@ -56,7 +56,7 @@
 {{- $realmAdminPassword := "" -}}
 
 {{- if $createRealm -}}
-{{- $oidcSecretName := "crucible-oidc-client-secrets" -}}
+{{- $oidcSecretName := include "crucible.oidcClientSecretsName" . -}}
 {{- $existingOidc := lookup "v1" "Secret" .Release.Namespace $oidcSecretName -}}
 
 {{- $alloyAdminSecret = randAlphaNum 32 -}}
@@ -141,7 +141,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: crucible-oidc-client-secrets
+  name: {{ include "crucible.oidcClientSecretsName" . }}
   labels:
     {{- include "crucible.labels" . | nindent 4 }}
   annotations:
@@ -166,8 +166,8 @@ stringData:
 {{- if $createRealm }}
 {{- $realmJson := .Files.Get "files/crucible-realm.json" -}}
 {{- $realmJson = $realmJson | replace "__DOMAIN__" .Values.global.domain -}}
-{{- $realmJson = $realmJson | replace "__ADMIN_USERNAME__" (default "admin" .Values.keycloak.realmAdminUsername) -}}
-{{- $realmJson = $realmJson | replace "__ADMIN_EMAIL__" (default "admin@crucible.dev" .Values.keycloak.realmAdminEmail) -}}
+{{- $realmJson = $realmJson | replace "__ADMIN_USERNAME__" .Values.keycloak.realmAdminUsername -}}
+{{- $realmJson = $realmJson | replace "__ADMIN_EMAIL__" .Values.keycloak.realmAdminEmail -}}
 {{- $realmJson = $realmJson | replace "__ALLOY_ADMIN_SECRET__" $alloyAdminSecret -}}
 {{- $realmJson = $realmJson | replace "__GAMEBOARD_API_SECRET__" $gameboardApiSecret -}}
 {{- $realmJson = $realmJson | replace "__PLAYER_VM_WEBHOOKS_SECRET__" $playerVmWebhooksSecret -}}


### PR DESCRIPTION
Fixes a bug where the post-install realm-users job ignored keycloak.realmAdminUsername and always searched for a user literally named admin. Also consolidates a handful of hardcoded names that were duplicated across templates.                                                                   
                                                                  
## Changes                                                                                                                                                                                                                                                                                              
                                                                  
  - Fix: realmAdminUsername is now honored. templates/job-realm-users.yaml no longer hardcodes -q username=admin; it reads .Values.keycloak.realmAdminUsername via a new REALM_ADMIN_USERNAME env var. Previously, setting keycloak.realmAdminUsername in values would cause the realm to be created with the custom username but the post-install password-set job would fail to find the user.
  - Extract crucible.oidcClientSecretsName helper. The literal crucible-oidc-client-secrets appeared in three places (secret.yaml twice, job-realm-users.yaml once). Now defined once in _helpers.tpl.                                                                                                 
  - Use crucible.tlsSecretName helper in keycloak ingress. keycloak-ingress.yaml was duplicating the "crucible-cert" literal that already lived in the crucible.tlsSecretName helper. Switching to the helper means setting global.tls.secretName now affects the Keycloak ingress too, matching the rest of the chart.                                                                                                                                                                                                                                                                                   
  - Remove redundant template defaults. default "admin" and default "admin@crucible.dev" fallbacks in secret.yaml were duplicating the defaults already declared in values.yaml. Dropped so values.yaml is the single source of truth.                                                                 
                                                                                                                                                                                                                                                                                                       
## Behavior change to note                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                       
  If a user explicitly sets keycloak.realmAdminUsername: "" or keycloak.realmAdminEmail: "", the rendered realm JSON will now contain empty strings instead of silently falling back to admin / admin@crucible.dev. In practice this is not a breaking change because the values.yaml defaults still apply when the keys are unset.