### PR TITLE
Fix update umbrella action and script

### DIFF
--- a/.github/scripts/update-crucible-umbrella.sh
+++ b/.github/scripts/update-crucible-umbrella.sh
@@ -56,7 +56,7 @@ done < "$CHART_FILE"
 
 if [ ${#charts_to_update[@]} -eq 0 ]; then
     echo -e "${RED}No cmusei dependencies found in Chart.yaml${NC}"
-    exit 0
+    exit 1
 fi
 
 # Store version updates
@@ -97,6 +97,11 @@ for chart_name in "${charts_to_update[@]}"; do
         ((UPDATED++))
     fi
 done
+
+if [ $FAILED -gt 0 ]; then
+    echo -e "${RED}$FAILED chart(s) failed to fetch. Aborting before mutating Chart.yaml.${NC}"
+    exit 1
+fi
 
 # Apply all updates in a single pass if there are any
 if [ $UPDATED -gt 0 ]; then

--- a/.github/workflows/update-crucible-umbrella.yaml
+++ b/.github/workflows/update-crucible-umbrella.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Add Helm repositories
         run: |
-          helm repo add cemusei https://helm.cmusei.dev/charts
+          helm repo add cmusei https://helm.cmusei.dev/charts
           helm repo update
 
       - name: Run update script
@@ -47,7 +47,7 @@ jobs:
           .github/scripts/update-crucible-umbrella.sh
 
           # Check if there were any changes
-          if git diff --quiet charts/crucible/Chart.yaml charts/crucible/Chart.lock; then
+          if git diff --quiet charts/crucible-apps/Chart.yaml charts/crucible-apps/Chart.lock; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
             echo "No changes detected"
           else


### PR DESCRIPTION
1. Update umbrella script now has some `exit 1` conditions to properly fail
2. Fix typos in the umbrella action resulting from the crucible chart rename