### PR TITLE
TopoMojo: wire chart for new ISO upload feature in API v2.7.1, audit File Storage defaults

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.7.2
+version: 0.8.0
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
-- https://github.com/cmu-sei/TopoMojo
-- https://github.com/cmu-sei/TopoMojo-ui
+  - https://github.com/cmu-sei/TopoMojo
+  - https://github.com/cmu-sei/TopoMojo-ui

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.7.1
+version: 0.7.2
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
 - https://github.com/cmu-sei/TopoMojo

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -303,6 +303,33 @@ topomojo-api:
     class: "nfs-client"
 ```
 
+The chart does not impose a default `storage.size` — operators choose a value appropriate for their usage based on factors such as: workspace import/export volume, document-image footprint, and ISO uploads (if using datastore-API mode).
+
+##### Sizing for ISO uploads (datastore-API mode only)
+
+This guidance **only applies when `FileUpload__UseDatastoreApi: true`**. In NFS mode (the default), uploaded ISOs are written directly to the NFS share backing `Pod__IsoStore` and never touch this PVC, so PVC sizing is governed only by `TopoRoot` (workspace export data) and `DocRoot` (documents and images).
+
+When the datastore-API upload feature is enabled, TopoMojo stages each upload at `FileUpload__TempRoot` (a subdirectory on this PVC) before HTTP PUT to vSphere. Sizing this directory has to account for two cases:
+
+- **Non-ISO uploads are wrapped into an ISO before transfer.** A user can upload any file (e.g., an installer or media file) and TopoMojo will build a `.iso` container around it. During that wrap step the staging directory holds *both* the original file *and* the generated ISO — roughly **2× the original size** — until the wrap completes. The original is then deleted immediately, before the upload to vCenter starts.
+
+To size the PVC:
+
+1. **Cap per-upload size** by setting `FileUpload__MaxFileBytes` to a non-zero value. The chart default of `0` means unlimited. Pick a size based on the largest file you expect operators to upload (ISO or otherwise).
+2. **Allow at least 4× `FileUpload__MaxFileBytes`** of headroom on top of your normal `TopoRoot` working set. This covers a few concurrent uploads in flight (each transiently 2× during the ISO wrap step for non-ISO files) plus margin for failed async uploads waiting on Janitor cleanup. Environments expecting many simultaneous uploaders should size higher.
+3. **Shorten `FileUpload__TempFileExpirationHours`** if failed-upload residue is the bottleneck — successful uploads clean up immediately, so this knob only governs how long failures and crashed-mid-upload files linger.
+
+Example for a deployment expecting up to 20 GB ISOs:
+
+```yaml
+topomojo-api:
+  storage:
+    size: "100Gi"  # ~80Gi staging headroom + TopoRoot working set
+  env:
+    FileUpload__UseDatastoreApi: true
+    FileUpload__MaxFileBytes: 21474836480  # 20 GB cap
+```
+
 #### Extra Environment Sources
 
 Inject additional environment variables into the API container from existing Kubernetes Secrets or ConfigMaps using `extraEnvFrom`. This is useful for integrating with external secret managers such as AWS Secrets Manager (via the [External Secrets Operator](https://external-secrets.io/)) or HashiCorp Vault.

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -83,16 +83,62 @@ topomojo-api:
 
 ### File Storage
 
-| Setting | Description | Example |
-|---------|-------------|---------|
-| `FileUpload__TopoRoot` | Root directory for various files such as workspace import/export zips. The path provided is a path mounted in the container. (e.g., `/mnt/tm`) | `/opt/topomojo` (Default) |
-| `FileUpload__IsoRoot` | Directory for ISO files. This is typically an NFS mounted volume that is also presented as a datastore to the hypervisor to allow mounting ISOs to VMs. | `/opt/topomojo/isos` (Default) |
-| `FileUpload__DocRoot` | Directory for documentation | `/opt/topomojo/docs` (Default) |
+TopoMojo writes uploaded files to several directories inside the API pod. The most important is the path that holds ISOs, because ISOs ultimately need to be written where the hypervisor can read them. There are two ways the chart can deliver an uploaded ISO to the hypervisor:
+
+| Mode | Where TopoMojo writes the file | Where the hypervisor reads from | When to use |
+|---|---|---|---|
+| **NFS-mounted ISO datastore** (default) | `FileUpload__IsoRoot` — a path inside the container backed by an NFS share | The same NFS share, mounted on ESXi as a vSphere datastore (named in `Pod__IsoStore`) | When you have the ability to attach an NFS datastore to ESXi hosts |
+| **vSphere HTTP datastore upload** (`FileUpload__UseDatastoreApi: true`) | `FileUpload__TempRoot` — a transient staging dir on the API pod, then HTTP PUT to vSphere | The vSphere datastore named in `Pod__IsoStore` (vSAN, VMFS, etc.), populated by the upload | VMware Cloud on AWS or any environment where the ESXi/SDDC hosts cannot mount your NFS share as a datastore |
+
+In NFS mode, `IsoRoot` is the *final destination* — the file is written once and stays there, visible to both TopoMojo and the hypervisor through the shared NFS mount. In datastore-API mode, `TempRoot` is just a staging area: the file is written there, optionally wrapped in an ISO, HTTP PUT to the vSphere datastore through vCenter, and then reaped by the Janitor when stale.
+
+`TempRoot` is therefore unrelated to `IsoRoot`. They never both contain the same file. `TempRoot` is only read when `UseDatastoreApi=true`; `IsoRoot` is only used as a destination when `UseDatastoreApi=false`. Both are still set on the chart at all times — they're just unused in the mode they don't apply to.
+
+#### Path settings
+
+| Setting | Description | Chart default |
+|---------|-------------|---------------|
+| `FileUpload__TopoRoot` | Root directory for workspace import/export zips and other persistent files. Backed by the topomojo PVC mount. | `/mnt/tm` |
+| `FileUpload__IsoRoot` | Directory for ISO files in NFS mode. Must be accessible to both TopoMojo and the hypervisor — typically an NFS share that ESXi mounts as a vSphere datastore. Unused when `FileUpload__UseDatastoreApi=true`. | `/mnt/tm/isos` |
+| `FileUpload__DocRoot` | Directory where workspace document images are stored and served. Points at the chart's dedicated `wwwroot/docs` mount so uploaded images are served by ASP.NET's static-file handler. | `/home/app/wwwroot/docs` |
+| `FileUpload__TempRoot` | Staging directory for datastore-API uploads. Backed by a subdirectory on the topomojo PVC; the vol-permissions init container creates and chowns it. Override only if you have provisioned alternative storage yourself. Unused when `FileUpload__UseDatastoreApi=false`. | `/mnt/tm/_iso-staging` |
 
 **Important**
 - These paths must be on persistent storage for data to remain after a pod restart.
-- ISO directory must be accessible to both TopoMojo and hypervisors (typically NFS).
+- **NFS mode:** the chart default `FileUpload__IsoRoot` points at the topomojo PVC, which is *not* readable by ESXi. Override it to a path mounted from the same NFS share your hypervisor uses as a vSphere datastore (the share named in `Pod__IsoStore`); otherwise uploaded ISOs never reach the hypervisor.
+- **Datastore-API mode:** `TempRoot` does **not** need to be visible to the hypervisor — only the API pod writes to it. ISOs reach the hypervisor over HTTP via vCenter.
 - See the [Storage Section](#storage) for more information on storage.
+
+#### Datastore-API upload settings (VMware Cloud)
+
+In environments where the ESXi hosts cannot mount the shared NFS share
+backing `Pod__IsoStore` — most notably **VMware Cloud on AWS**, where
+the SDDC's hosts can only see datastores presented by the SDDC itself
+(vSAN or attached VMFS) — set `FileUpload__UseDatastoreApi: true`.
+TopoMojo will stage uploads to `FileUpload__TempRoot` and then HTTP PUT
+them to the vSphere datastore named in `Pod__IsoStore` through vCenter.
+The chart provisions `TempRoot` automatically; no extra storage values
+are required.
+
+To enable:
+
+```yaml
+topomojo-api:
+  env:
+    FileUpload__UseDatastoreApi: true
+```
+
+Optional tuning knobs (defaults shown):
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `FileUpload__MaxFileBytes` | Max upload size in bytes (`0` for unlimited) | `0` |
+| `FileUpload__UploadTimeoutMinutes` | HTTP timeout for the datastore PUT | `120` |
+| `FileUpload__AsyncUploadThresholdBytes` | Files above this size upload asynchronously | `1073741824` (1 GB) |
+| `FileUpload__TempFileExpirationHours` | Stale temp file cleanup threshold | `24` |
+
+Existing NFS-mount deployments leave `FileUpload__UseDatastoreApi`
+unset (the default is `false`) and behavior is unchanged.
 
 ### Core Application Settings
 

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -134,7 +134,6 @@ Optional tuning knobs (defaults shown):
 |---------|-------------|---------|
 | `FileUpload__MaxFileBytes` | Max upload size in bytes (`0` for unlimited) | `0` |
 | `FileUpload__UploadTimeoutMinutes` | HTTP timeout for the datastore PUT | `120` |
-| `FileUpload__AsyncUploadThresholdBytes` | Files above this size upload asynchronously | `1073741824` (1 GB) |
 | `FileUpload__TempFileExpirationHours` | Stale temp file cleanup threshold | `24` |
 
 Existing NFS-mount deployments leave `FileUpload__UseDatastoreApi`
@@ -316,8 +315,8 @@ When the datastore-API upload feature is enabled, TopoMojo stages each upload at
 To size the PVC:
 
 1. **Cap per-upload size** by setting `FileUpload__MaxFileBytes` to a non-zero value. The chart default of `0` means unlimited. Pick a size based on the largest file you expect operators to upload (ISO or otherwise).
-2. **Allow at least 4× `FileUpload__MaxFileBytes`** of headroom on top of your normal `TopoRoot` working set. This covers a few concurrent uploads in flight (each transiently 2× during the ISO wrap step for non-ISO files) plus margin for failed async uploads waiting on Janitor cleanup. Environments expecting many simultaneous uploaders should size higher.
-3. **Shorten `FileUpload__TempFileExpirationHours`** if failed-upload residue is the bottleneck — successful uploads clean up immediately, so this knob only governs how long failures and crashed-mid-upload files linger.
+2. **Allow at least 4× `FileUpload__MaxFileBytes`** of headroom on top of your normal `TopoRoot` working set. This covers a few concurrent uploads in flight (each transiently 2× during the ISO wrap step for non-ISO files). Environments expecting many simultaneous uploaders should size higher.
+3. **Shorten `FileUpload__TempFileExpirationHours`** if mid-upload crashes are leaving residue — successful and failed uploads both clean up immediately, so this knob only governs how long files orphaned by an unclean pod restart linger.
 
 Example for a deployment expecting up to 20 GB ISOs:
 

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: topomojo-api
 type: application
 version: 0.7.1
-appVersion: 2.7.1
+appVersion: 2.8.0

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: topomojo-api
 type: application
-version: 0.7.0
-appVersion: 2.7.0
+version: 0.7.1
+appVersion: 2.7.1

--- a/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
+++ b/charts/topomojo/charts/topomojo-api/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
             - |
               /mnt/scripts/vol-permissions.sh /docs
               /mnt/scripts/vol-permissions.sh /theme
+              /mnt/scripts/vol-permissions.sh /iso-staging
           volumeMounts:
             - mountPath: /docs
               name: {{ include "topomojo-api.name" . }}-vol
@@ -48,6 +49,9 @@ spec:
             - mountPath: /theme
               name: {{ include "topomojo-api.name" . }}-vol
               subPath: {{ include "topomojo-api.fullname" . }}/_theme
+            - mountPath: /iso-staging
+              name: {{ include "topomojo-api.name" . }}-vol
+              subPath: {{ include "topomojo-api.fullname" . }}/_iso-staging
             - mountPath: /mnt/scripts/vol-permissions.sh
               name: {{ include "topomojo-api.name" . }}-scripts
               subPath: vol-permissions.sh

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -256,7 +256,6 @@ env:
   FileUpload__TempRoot: /mnt/tm/_iso-staging
   # FileUpload__UseDatastoreApi: false
   # FileUpload__UploadTimeoutMinutes: 180
-  # FileUpload__AsyncUploadThresholdBytes: 1073741824  # 1GB
   # FileUpload__TempFileExpirationHours: 24
 
   # Core__DefaultGamespaceMinutes: 120

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -158,9 +158,14 @@ resources: {}
   # limits:
   #   cpu: 200m
   #   memory: 512Mi
+  #   # When using FileUpload__UseDatastoreApi without persistent volume for TempRoot,
+  #   # set ephemeral-storage to prevent node crashes. Recommended: MaxFileBytes × 4
+  #   # Example for 20GB max file: ephemeral-storage: "80Gi"
+  #   # ephemeral-storage: "80Gi"
   # requests:
   #   cpu: 100m
   #   memory: 256Mi
+  #   # ephemeral-storage: "40Gi"
 
 nodeSelector: {}
 
@@ -239,6 +244,13 @@ env:
   # FileUpload__TopoRoot: tm
   # FileUpload__IsoRoot: tm/isos
   # FileUpload__DocRoot: tm/_docs
+  # FileUpload__MaxFileBytes: 21474836480  # 20GB
+  ## VMware Cloud API upload settings (when NFS mount unavailable)
+  # FileUpload__UseDatastoreApi: false
+  # FileUpload__TempRoot: /mnt/tm/topoiso-staging  # Use EFS/persistent volume, NOT /tmp
+  # FileUpload__UploadTimeoutMinutes: 180
+  # FileUpload__AsyncUploadThresholdBytes: 1073741824  # 1GB
+  # FileUpload__TempFileExpirationHours: 24
   # Core__DefaultGamespaceMinutes: 120
   # Core__DefaultGamespaceLimit: 2
   # Core__DefaultWorkspaceLimit: 0

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -253,7 +253,7 @@ env:
   ## TempRoot is set to a subdirectory of the existing topomojo
   ## PVC mount; the vol-permissions init container creates and chowns it.
   ## Override only if you have provisioned alternative storage yourself.
-  FileUpload__TempRoot: "/mnt/tm/_iso-staging"
+  FileUpload__TempRoot: /mnt/tm/_iso-staging
   # FileUpload__UseDatastoreApi: false
   # FileUpload__UploadTimeoutMinutes: 180
   # FileUpload__AsyncUploadThresholdBytes: 1073741824  # 1GB

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -158,14 +158,9 @@ resources: {}
   # limits:
   #   cpu: 200m
   #   memory: 512Mi
-  #   # When using FileUpload__UseDatastoreApi without persistent volume for TempRoot,
-  #   # set ephemeral-storage to prevent node crashes. Recommended: MaxFileBytes × 4
-  #   # Example for 20GB max file: ephemeral-storage: "80Gi"
-  #   # ephemeral-storage: "80Gi"
   # requests:
   #   cpu: 100m
   #   memory: 256Mi
-  #   # ephemeral-storage: "40Gi"
 
 nodeSelector: {}
 
@@ -230,27 +225,40 @@ env:
   # Oidc__UserRolesClaimMap__observer: Observer
   # Oidc__UserRolesClaimMap__user: user
   # Oidc__UserRolesClaimPath = realm_access.roles
+
   # Database__Provider: InMemory
   # Database__ConnectionString: topomojo_db
   # Database__SeedFile: seed-data.json
   # Database__AdminId: ""
   # Database__AdminName: ""
+
   # Cache__RedisUrl: ""
   # Cache__Key: ""
   # Cache__SharedFolder: ""
+
   # OpenApi__Enabled: true
   # OpenApi__ApiName: TopoMojo
   # OpenApi__Client__ClientId: topomojo-swagger
-  # FileUpload__TopoRoot: tm
-  # FileUpload__IsoRoot: tm/isos
-  # FileUpload__DocRoot: tm/_docs
+
+  FileUpload__TopoRoot: /mnt/tm
+  ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
+  ## the NFS share your ESXi hosts also mount as a vSphere datastore.
+  FileUpload__IsoRoot: /mnt/tm/isos
+  ## DocRoot points at the chart's dedicated wwwroot/docs mount so uploaded
+  ## images are served by ASP.NET's static-file handler.
+  FileUpload__DocRoot: /home/app/wwwroot/docs
   # FileUpload__MaxFileBytes: 21474836480  # 20GB
-  ## VMware Cloud API upload settings (when NFS mount unavailable)
+
+  ## VMware Cloud API upload settings (when NFS mount unavailable).
+  ## TempRoot is set to a subdirectory of the existing topomojo
+  ## PVC mount; the vol-permissions init container creates and chowns it.
+  ## Override only if you have provisioned alternative storage yourself.
+  FileUpload__TempRoot: "/mnt/tm/_iso-staging"
   # FileUpload__UseDatastoreApi: false
-  # FileUpload__TempRoot: /mnt/tm/topoiso-staging  # Use EFS/persistent volume, NOT /tmp
   # FileUpload__UploadTimeoutMinutes: 180
   # FileUpload__AsyncUploadThresholdBytes: 1073741824  # 1GB
   # FileUpload__TempFileExpirationHours: 24
+
   # Core__DefaultGamespaceMinutes: 120
   # Core__DefaultGamespaceLimit: 2
   # Core__DefaultWorkspaceLimit: 0
@@ -263,6 +271,7 @@ env:
   # Core__LaunchUrl: /lp?
   # Core__DocPath: wwwroot/docs
   # Core__AllowUnprivilegedVmReconfigure: false
+
   # Pod__Url: ""
   # Pod__User: ""
   # Pod__Password: ""
@@ -283,9 +292,12 @@ env:
   # Pod__Sddc__AuthUrl: ""
   # Pod__Sddc__CertificatePath: ""
   # Pod__Sddc__CertificatePassword: ""
+
   # Logging__Console__DisableColors: false
   # Logging__LogLevel__Default: Information
+
   # Ui__Branding__BackgroundImageUrl = theme/demo.png
+
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
   # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
   # OTEL_SERVICE_NAME: topomojo-api


### PR DESCRIPTION
## Summary

Wires the TopoMojo chart for the [VMware Cloud ISO upload feature](https://github.com/cmu-sei/TopoMojo/pull/110), re-using the existing TopoMojo PVC for staging. Also audits the chart's `FileUpload__*` defaults — several were inaccurate or pointed at paths the chart doesn't actually mount.

## What changed

  ### New `FileUpload__UseDatastoreApi` plumbing
  - Init container creates and chowns `_iso-staging` on the TopoMojo PVC, alongside the existing `_docs` and `_theme` directories.
  - Sets `FileUpload__TempRoot=/mnt/tm/_iso-staging` as an active default in `values.yaml`, so the TopoMojo app's startup `ValidateTempStorage` warning never fires and uploads land on persistent storage by default.
  - Operators enable the feature with a single flip: `topomojo-api.env.FileUpload__UseDatastoreApi: true`. The other tuning knobs (`UploadTimeoutMinutes`, `AsyncUploadThresholdBytes`, `TempFileExpirationHours`, `MaxFileBytes`) are exposed as commented hints with the TopoMojo defaults documented.

  ### File Storage defaults audit
  Existing `FileUpload__*` defaults in `values.yaml` were misaligned with the chart's actual mounts. Fixed:
  - `FileUpload__TopoRoot: /mnt/tm` — matches the chart's umbrella PVC mount.
  - `FileUpload__IsoRoot: /mnt/tm/isos` — works in datastore-API mode.
  - `FileUpload__DocRoot: /home/app/wwwroot/docs` — points at the chart's dedicated wwwroot mount (chowned by the init container) so uploaded document images are served by ASP.NET's static-file handler. Was previously pointing at `/mnt/tm/_docs`, which worked only by accident because both paths were subPath mounts of the same PVC subdir.

### Documentation
README's `### File Storage` section is now the single authoritative place that explains both upload modes:
  - Mode-comparison table (NFS vs datastore-API: where the file is written, where the hypervisor reads, when to use).
  - Updated path-settings table with accurate chart defaults.
  - "Important" callouts for the NFS-mode `IsoRoot` override and the datastore-API `TempRoot` semantics.
  - Dedicated subsection for the datastore-API tuning knobs.

  ### Versions
  - `topomojo` umbrella chart: 0.7.1 → 0.7.2
  - `topomojo-api` subchart: 0.7.0 → 0.7.1 (`appVersion` 2.7.0 → 2.7.1)

## Backwards compatibility
UseDatastoreApi defaults to false, so **existing deployments see no behavioral change** beyond:
  - one extra harmless mkdir/chown of _iso-staging during init,
  - one additional FileUpload__TempRoot env var on the API container (unread when the flag is off).

NFS-mode operators relying on the previous IsoRoot defaults: no change in effective behavior — the previous wwwroot/isos C# default was already wrong for any real deployment, and operators were already overriding IsoRoot to point at their actual NFS mount. The new chart default /mnt/tm/isos is documented as requiring an override in NFS mode (was implicitly required before, now explicit).

NFS-mode operators relying on the previous DocRoot: /opt/topomojo/docs or accidentally-functional /mnt/tm/_docs: should land on the same on-disk PVC subdir via the now-explicit /home/app/wwwroot/docs path.