### PR TITLE
Feature/standardize health probes

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -3,7 +3,7 @@ name: alloy
 description: Alloy enables users to launch on-demand events or join instances of already-running
   simulations.
 type: application
-version: 1.7.8
+version: 1.7.9
 home: https://cmu-sei.github.io/crucible/alloy/
 sources:
 - https://github.com/cmu-sei/Alloy.Api

--- a/charts/alloy/README.md
+++ b/charts/alloy/README.md
@@ -200,9 +200,9 @@ alloy-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/alloy/README.md
+++ b/charts/alloy/README.md
@@ -177,6 +177,38 @@ Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/doc
 
 The following are configurations for the Alloy API Helm Chart and application configurations that are configured outside of the `alloy-api.env` section.
 
+#### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+alloy-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 #### Ingress
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).
 

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: alloy-api
 type: application
-version: 1.6.16
+version: 1.6.17
 appVersion: 3.6.7

--- a/charts/alloy/charts/alloy-api/templates/deployment.yaml
+++ b/charts/alloy/charts/alloy-api/templates/deployment.yaml
@@ -51,14 +51,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.certificateMap }}

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -36,6 +36,31 @@ service:
   type: ClusterIP
   port: 80
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -55,9 +55,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -22,9 +22,9 @@ alloy-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -3,6 +3,31 @@ alloy-api:
   image:
     tag: ""
 
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -3,7 +3,7 @@ name: blueprint
 description: Blueprint enables collaborative creation and visualization of a Master
   Scenario Event List (MSEL) for an exercise.
 type: application
-version: 1.9.3
+version: 1.9.4
 home: https://cmu-sei.github.io/crucible/blueprint/
 sources:
 - https://github.com/cmu-sei/Blueprint.Api

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -132,9 +132,9 @@ blueprint-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -109,6 +109,38 @@ Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/doc
 
 The following are configurations for the Blueprint API Helm Chart and application configurations that are configured outside of the `blueprint-api.env` section.
 
+#### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+blueprint-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 #### Ingress
 
 ```yaml

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: blueprint-api
 type: application
-version: 1.8.13
+version: 1.8.14
 appVersion: 1.6.15

--- a/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
+++ b/charts/blueprint/charts/blueprint-api/templates/deployment.yaml
@@ -42,6 +42,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.certificateMap }}

--- a/charts/blueprint/charts/blueprint-api/values.yaml
+++ b/charts/blueprint/charts/blueprint-api/values.yaml
@@ -59,9 +59,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/blueprint/charts/blueprint-api/values.yaml
+++ b/charts/blueprint/charts/blueprint-api/values.yaml
@@ -40,6 +40,31 @@ service:
   type: ClusterIP
   port: 8080
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -22,9 +22,9 @@ blueprint-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -3,6 +3,31 @@ blueprint-api:
   image:
     tag: ""
 
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caster
 description: Caster enables the coded design and deployment of cyber topologies.
 type: application
-version: 1.8.10
+version: 1.8.11
 home: https://cmu-sei.github.io/crucible/caster/
 sources:
 - https://github.com/cmu-sei/Caster.Api/

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -321,9 +321,9 @@ caster-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -298,6 +298,38 @@ caster-api:
 
 ### Helm Deployment Configuration
 
+#### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+caster-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 #### Ingress
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).
 

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: caster-api
 type: application
-version: 1.6.23
+version: 1.6.24
 appVersion: 3.6.8

--- a/charts/caster/charts/caster-api/templates/deployment.yaml
+++ b/charts/caster/charts/caster-api/templates/deployment.yaml
@@ -63,20 +63,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /api/health/live
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -38,6 +38,31 @@ service:
   type: ClusterIP
   port: 80
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -57,9 +57,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -22,9 +22,9 @@ caster-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -3,6 +3,31 @@ caster-api:
   image:
     tag: ""
 
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -3,7 +3,7 @@ name: cite
 description: CITE enables participants from different organizations to evaluate, score,
   and comment on cyber incidents.
 type: application
-version: 1.9.7
+version: 1.9.8
 home: https://cmu-sei.github.io/crucible/cite/
 sources:
 - https://github.com/cmu-sei/cite.Api

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -115,6 +115,38 @@ Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/doc
 
 The following are configurations for the CITE API Helm Chart and application configurations that are configured outside of the `cite-api.env` section.
 
+### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+cite-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 ### Ingress
 
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -138,9 +138,9 @@ cite-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/cite/charts/cite-api/Chart.yaml
+++ b/charts/cite/charts/cite-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cite-api
 type: application
-version: 1.8.8
+version: 1.8.9
 appVersion: 1.11.7

--- a/charts/cite/charts/cite-api/templates/deployment.yaml
+++ b/charts/cite/charts/cite-api/templates/deployment.yaml
@@ -42,6 +42,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -38,6 +38,31 @@ service:
   type: ClusterIP
   port: 8080
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -57,9 +57,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -3,6 +3,31 @@ cite-api:
   image:
     tag: ""
 
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -22,9 +22,9 @@ cite-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -3,7 +3,7 @@ name: gallery
 description: Gallery enables participants to review cyber incident data by source
   type.
 type: application
-version: 1.9.7
+version: 1.9.8
 home: https://cmu-sei.github.io/crucible/gallery/
 sources:
 - https://github.com/cmu-sei/Gallery.Api/

--- a/charts/gallery/README.md
+++ b/charts/gallery/README.md
@@ -132,9 +132,9 @@ gallery-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/gallery/README.md
+++ b/charts/gallery/README.md
@@ -109,6 +109,38 @@ Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/doc
 
 The following are configurations for the Gallery API Helm Chart and application configurations that are configured outside of the `gallery-api.env` section.
 
+#### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+gallery-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 #### Ingress
 
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).

--- a/charts/gallery/charts/gallery-api/Chart.yaml
+++ b/charts/gallery/charts/gallery-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gallery-api
 type: application
-version: 1.8.8
+version: 1.8.9
 appVersion: 1.10.7

--- a/charts/gallery/charts/gallery-api/templates/deployment.yaml
+++ b/charts/gallery/charts/gallery-api/templates/deployment.yaml
@@ -42,6 +42,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /api/health/ready
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /api/health/live
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.certificateMap }}

--- a/charts/gallery/charts/gallery-api/values.yaml
+++ b/charts/gallery/charts/gallery-api/values.yaml
@@ -38,6 +38,31 @@ service:
   type: ClusterIP
   port: 8080
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/gallery/charts/gallery-api/values.yaml
+++ b/charts/gallery/charts/gallery-api/values.yaml
@@ -57,9 +57,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -22,9 +22,9 @@ gallery-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -3,6 +3,31 @@ gallery-api:
   image:
     tag: ""
 
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.9.14
+version: 1.9.15
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -191,6 +191,38 @@ player-api:
     class: "default"
 ```
 
+### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+player-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 ### Ingress
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).
 
@@ -452,6 +484,38 @@ vm-api:
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+vm-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
 
 ### Ingress
 

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -214,9 +214,9 @@ player-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```
@@ -508,9 +508,9 @@ vm-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-api
 type: application
-version: 1.8.10
+version: 1.8.11
 appVersion: 3.5.7

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -58,9 +58,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -44,16 +44,16 @@ probes:
     enabled: true
     initialDelaySeconds: 30
     periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
+    timeoutSeconds: 15
+    failureThreshold: 5
     successThreshold: 1
 
   readinessProbe:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 6
+    timeoutSeconds: 15
+    failureThreshold: 5
     successThreshold: 1
 
   startupProbe:

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.7.13
+version: 1.7.14
 appVersion: 3.8.9

--- a/charts/player/charts/vm-api/templates/deployment.yaml
+++ b/charts/player/charts/vm-api/templates/deployment.yaml
@@ -51,20 +51,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /api/health/live
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -64,9 +64,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -45,6 +45,31 @@ service:
   type: ClusterIP
   port: 80
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -6,16 +6,16 @@ player-api:
       enabled: true
       initialDelaySeconds: 30
       periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
+      timeoutSeconds: 15
+      failureThreshold: 5
       successThreshold: 1
 
     readinessProbe:
       enabled: true
       initialDelaySeconds: 5
       periodSeconds: 10
-      timeoutSeconds: 5
-      failureThreshold: 6
+      timeoutSeconds: 15
+      failureThreshold: 5
       successThreshold: 1
 
     startupProbe:
@@ -289,6 +289,31 @@ vm-api:
     size: ""
     server: ""
     path: ""
+
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
 
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -20,9 +20,9 @@ player-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 
@@ -309,9 +309,9 @@ vm-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -3,7 +3,7 @@ name: steamfitter
 description: Steamfitter enables the organization and execution of scenario tasks
   on virtual machines by integrating with StackStorm automation.
 type: application
-version: 1.7.7
+version: 1.7.8
 home: https://cmu-sei.github.io/crucible/steamfitter
 sources:
 - https://github.com/cmu-sei/steamfitter.api

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -168,6 +168,38 @@ Steamfitter needs to communicate to the Crucible [VM API](https://github.com/cmu
 
 See the [StackStorm](https://docs.stackstorm.com/) documentation for more information.
 
+### Health Probes
+
+The deployment configures Kubernetes liveness, readiness, and startup probes against the API's `/api/health/live` and `/api/health/ready` endpoints. Defaults are tuned to tolerate slow startups (e.g. EF Core migrations, cold JIT) while still surfacing failures.
+
+```yaml
+steamfitter-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+```
+
+Set `enabled: false` on a probe to disable it.
+
 ### Ingress
 Configure the ingress to allow connections to the application (typically uses an ingress controller like [ingress-nginx](https://github.com/kubernetes/ingress-nginx)).
 

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -191,9 +191,9 @@ steamfitter-api:
       successThreshold: 1
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 ```

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: steamfitter-api
 type: application
-version: 1.6.19
+version: 1.6.20
 appVersion: 3.9.11

--- a/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/templates/deployment.yaml
@@ -51,20 +51,39 @@ spec:
             - name: http
               containerPort: {{ default 8080 .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.probes.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health/live
               port: http
+            initialDelaySeconds: {{ .Values.probes.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.livenessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health/ready
               port: http
+            initialDelaySeconds: {{ .Values.probes.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.readinessProbe.successThreshold }}
+        {{- end }}
+        {{- if .Values.probes.startupProbe.enabled }}
           startupProbe:
             httpGet:
               path: /api/health/live
               port: http
-            failureThreshold: 30
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.probes.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startupProbe.failureThreshold }}
+            successThreshold: {{ .Values.probes.startupProbe.successThreshold }}
+        {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{ if .Values.certificateMap }}

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -53,9 +53,9 @@ probes:
 
   startupProbe:
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 0
     periodSeconds: 10
-    timeoutSeconds: 1
+    timeoutSeconds: 15
     failureThreshold: 15
     successThreshold: 1
 

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -34,6 +34,31 @@ service:
   type: ClusterIP
   port: 80
 
+probes:
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 15
+    failureThreshold: 5
+    successThreshold: 1
+
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 15
+    successThreshold: 1
+
 ingress:
   enabled: false
   className: ""

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -1,4 +1,29 @@
 steamfitter-api:
+  probes:
+    livenessProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    readinessProbe:
+      enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 15
+      failureThreshold: 5
+      successThreshold: 1
+
+    startupProbe:
+      enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 15
+      successThreshold: 1
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -18,9 +18,9 @@ steamfitter-api:
 
     startupProbe:
       enabled: true
-      initialDelaySeconds: 30
+      initialDelaySeconds: 0
       periodSeconds: 10
-      timeoutSeconds: 1
+      timeoutSeconds: 15
       failureThreshold: 15
       successThreshold: 1
 


### PR DESCRIPTION
## Summary

Aligns liveness, readiness, and startup probes across Crucible API subcharts to a single set of defaults, propagates the same defaults up to the app-level `values.yaml` files so they're visible to operators at the top level, and documents the new probe section in every chart's README.md.

## Standardized defaults

| Probe | initialDelay | period | timeout | failureThreshold | success | 
| ------ | ------------- | ------- | --------- | ------------------ | ------- |
| livenessProbe | 30s | 10s | 15s | 5 | 1 |
| readinessProbe | 5s | 10s | 15s | 5 | 1 |
| startupProbe | 30s | 10s | 1s | 15 | 1 |

All probes hit the existing /api/health/live and /api/health/ready endpoints. Each probe is independently disable-able via `probes.<probe>.enabled: false`.

### Why these specific values

- timeoutSeconds: 15 accommodates the DB connectivity check tagged on both live and ready (PostgreSQL latency under load can exceed the kubelet's previous 5s default).
- failureThreshold: 5 × periodSeconds: 10 gives ~75s of tolerance before a pod is killed — enough headroom for transient DB or network blips while still being responsive.
- startupProbe with failureThreshold: 15 × periodSeconds: 10 yields a 150s startup budget, comfortable for EF Core migrations and cold-start JIT.
- startupProbe uses initialDelaySeconds: 0 so probing begins as soon as the container starts and timeoutSeconds: 15 to match liveness/readiness — since it hits the same /api/health/live endpoint and its DB connectivity check, a tighter timeout could falsely trip during cold start when that endpoint is most likely to be slow
- The kubelet runs one goroutine per probe and serializes ticks via a coalescing ticker, so timeouts longer than periodSeconds do not cause overlapping requests.

## Charts touched

- blueprint-api, cite-api, gallery-api
- player-api — was timeoutSeconds: 5, failureThreshold: 6; now 15/5
- vm-api, caster-api, alloy-api, steamfitter-api — previously had hardcoded probes (or none) directly in the deployment template. Now driven by values.yaml, with the same defaults as the rest

## Other changes

- App-level `values.yaml` files (charts/{alloy,blueprint,caster,cite,gallery,player,steamfitter}/values.yaml) now also publish the probes block under each `<chart>-api:` key. This means a deployer running helm show values <app> sees the same defaults as the subchart.
- Chart README.md files gained a Health Probes subsection under Helm Deployment Configuration.
- Chart version bumps for every modified subchart and its parent.

