### PR TITLE
Parent child chart sync

### DIFF
--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -4,7 +4,7 @@ description:
   Alloy enables users to launch on-demand events or join instances of already-running
   simulations.
 type: application
-version: 1.7.10
+version: 1.8.0
 home: https://cmu-sei.github.io/crucible/alloy/
 sources:
   - https://github.com/cmu-sei/Alloy.Api

--- a/charts/alloy/Chart.yaml
+++ b/charts/alloy/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v2
 name: alloy
-description: Alloy enables users to launch on-demand events or join instances of already-running
+description:
+  Alloy enables users to launch on-demand events or join instances of already-running
   simulations.
 type: application
-version: 1.7.9
+version: 1.7.10
 home: https://cmu-sei.github.io/crucible/alloy/
 sources:
-- https://github.com/cmu-sei/Alloy.Api
-- https://github.com/cmu-sei/Alloy.Ui
+  - https://github.com/cmu-sei/Alloy.Api
+  - https://github.com/cmu-sei/Alloy.Ui

--- a/charts/alloy/README.md
+++ b/charts/alloy/README.md
@@ -96,12 +96,15 @@ Store secrets in a Kubernetes Secret and reference it via `alloy-api.existingSec
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://alloy.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
 
 ### Crucible Service Endpoints
 
@@ -253,6 +256,16 @@ alloy-api:
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+#### OpenTelemetry Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
 
 #### Custom metrics from Alloy
 - Gauges: `alloy_active_events`, `alloy_ended_events`, `alloy_failed_events`

--- a/charts/alloy/charts/alloy-api/Chart.yaml
+++ b/charts/alloy/charts/alloy-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: alloy-api
 type: application
-version: 1.6.17
+version: 1.7.0
 appVersion: 3.6.7

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -1,5 +1,3 @@
-# Default values for alloy-api.
-
 image:
   repository: cmusei/alloy-api
   pullPolicy: IfNotPresent
@@ -11,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -35,6 +28,22 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -62,15 +71,13 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -78,27 +85,9 @@ ingress:
   #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 command: ["./Alloy.Api"]
 
@@ -115,15 +104,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# env is pod env vars
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Alloy.Api/blob/main/Alloy.Api/appsettings.json
 env:
-  # http_proxy:
-  # https_proxy:
-  # HTTP_PROXY:
-  # HTTPS_PROXY:
-  # NO_PROXY:
-  # no_proxy:
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
@@ -135,15 +119,15 @@ env:
   Logging__Console__LogLevel__Microsoft: Error
   Logging__Console__LogLevel__System: Error
 
-  # database needs the 'uuid-ossp' extension installed
+  # database requires the 'uuid-ossp' extension installed
   ConnectionStrings__PostgreSQL: ""
   Database__AutoMigrate: true
   Database__DevModeRecreate: false
   Database__Provider: PostgreSQL
 
-  CorsPolicy__Origins__0: http://localhost:4403
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true

--- a/charts/alloy/charts/alloy-api/values.yaml
+++ b/charts/alloy/charts/alloy-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/alloy/charts/alloy-ui/Chart.yaml
+++ b/charts/alloy/charts/alloy-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: alloy-ui
 type: application
-version: 1.7.6
+version: 1.8.0
 appVersion: 3.4.4

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -1,5 +1,3 @@
-# Default values for alloy-ui.
-
 image:
   repository: cmusei/alloy-ui
   pullPolicy: IfNotPresent
@@ -11,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -65,10 +42,22 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
@@ -85,9 +74,7 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
-
 extraVolumeMounts: ""
-
 extraVolumes: ""
 
 # env is pod env vars
@@ -104,20 +91,20 @@ sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: http://localhost:4402
+  # ApiUrl: https://alloy.example.com
   # OIDCSettings:
-  #   authority: http://localhost:5000/
-  #   client_id: alloy.ui
-  #   redirect_uri: http://localhost:4403/auth-callback
-  #   post_logout_redirect_uri: http://localhost:4403
+  #   authority: https://identity.example.com/
+  #   client_id: alloy-ui
+  #   redirect_uri: https://alloy.example.com/auth-callback
+  #   post_logout_redirect_uri: https://alloy.example.com
   #   response_type: code
-  #   scope: openid profile s3 s3-vm alloy-api caster-api steamfitter-api
+  #   scope: openid profile alloy-api player-api caster-api steamfitter-api vm-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: http://localhost:4403/auth-callback-silent.html
+  #   silent_redirect_uri: https://alloy.example.com/auth-callback-silent.html
   # AppTitle: Alloy
   # AppTopBarText: Alloy
   # AppTopBarHexColor: "#0c918d"
-  # PlayerUIAddress: http://localhost:4301
+  # PlayerUIAddress: https://player.example.com
   # PollingIntervalMS: "3500"
   # UseLocalAuthStorage: true
   # HeaderBarSettings:

--- a/charts/alloy/charts/alloy-ui/values.yaml
+++ b/charts/alloy/charts/alloy-ui/values.yaml
@@ -118,6 +118,7 @@ settingsYaml:
   #   enabled: true
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "http://localhost:4402",
 #   "OIDCSettings": {

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -1,7 +1,50 @@
 alloy-api:
-  # Docker image release version. Defaults to appVersion of alloy-api child chart
   image:
+    repository: cmusei/alloy-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,30 +71,26 @@ alloy-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: alloy.example.com
+      - host: chart-example.local
         paths:
-          - path: /(api|swagger/hubs)
+          - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
   # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
+
+  command: ["./Alloy.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -68,16 +107,8 @@ alloy-api:
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/crucible/blob/master/alloy.api/Alloy.Api/appsettings.json
+  # see https://github.com/cmu-sei/Alloy.Api/blob/main/Alloy.Api/appsettings.json
   env:
-    # Proxy Settings
-    # http_proxy: proxy.example.com:9000
-    # https_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -89,39 +120,30 @@ alloy-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=alloy_api;Username=alloy_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
 
-    # CORS policy settings.
-    # The first entry should be the URL to Alloy
-    CorsPolicy__Origins__0: https://alloy.example.com
-    CorsPolicy__Origins__1: http://site2.com
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "alloy-api player-api caster-api steamfitter-api vm-api"
     Authorization__ClientId: alloy-api-dev
     Authorization__ClientName: "Alloy API"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
-    ClaimsTransformation__EnableCaching: true
-    ClaimsTransformation__CacheExpirationSeconds: 60
-
-    # OAuth2 Identity Client /w Password
-    ResourceOwnerAuthorization__Authority: https://identity.example.com
+    ResourceOwnerAuthorization__Authority: ""
     ResourceOwnerAuthorization__ClientId: alloy-api
     ResourceOwnerAuthorization__ClientSecret: ""
     ResourceOwnerAuthorization__UserName: ""
@@ -129,7 +151,6 @@ alloy-api:
     ResourceOwnerAuthorization__Scope: "alloy-api player-api caster-api steamfitter-api vm-api"
     ResourceOwnerAuthorization__TokenExpirationBufferSeconds: 900
 
-    # Crucible Application URLs
     ClientSettings__BackgroundTimerIntervalSeconds: 60
     ClientSettings__BackgroundTimerHealthSeconds: 180
     ClientSettings__CasterCheckIntervalSeconds: 30
@@ -140,11 +161,14 @@ alloy-api:
     ClientSettings__ApiClientRetryIntervalSeconds: 10
     ClientSettings__ApiClientLaunchFailureMaxRetries: 10
     ClientSettings__ApiClientEndFailureMaxRetries: 10
-    ClientSettings__urls__playerApi: https://player.example.com/
-    ClientSettings__urls__casterApi: https://caster.example.com/
-    ClientSettings__urls__steamfitterApi: https://steamfitter.example.com/
+    ClientSettings__urls__playerApi: ""
+    ClientSettings__urls__casterApi: ""
+    ClientSettings__urls__steamfitterApi: ""
 
     SeedData: ""
+
+    ClaimsTransformation__EnableCaching: true
+    ClaimsTransformation__CacheExpirationSeconds: 60
 
     Files__LocalDirectory: "/tmp/"
 
@@ -166,26 +190,66 @@ alloy-api:
     # OTEL_SERVICE_NAME: alloy-api
 
 alloy-ui:
-  # Docker image release version. Defaults to appVersion of alloy-ui child chart
   image:
+    repository: cmusei/alloy-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
-      - host: alloy.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
@@ -202,10 +266,10 @@ alloy-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
@@ -218,7 +282,6 @@ alloy-ui:
   sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-  # NOTE:  PlayerUIAddress is the URL to the Crucible - Player application
   settingsYaml:
     # ApiUrl: https://alloy.example.com
     # OIDCSettings:
@@ -232,7 +295,7 @@ alloy-ui:
     #   silent_redirect_uri: https://alloy.example.com/auth-callback-silent.html
     # AppTitle: Alloy
     # AppTopBarText: Alloy
-    # AppTopBarHexColor: "#b00"
+    # AppTopBarHexColor: "#0c918d"
     # PlayerUIAddress: https://player.example.com
     # PollingIntervalMS: "3500"
     # UseLocalAuthStorage: true
@@ -244,7 +307,35 @@ alloy-ui:
     #   message_text: ""
     #   message_text_color: "#ffffff"
     #   message_text_fontsize: "14"
-    #   enabled: false
+    #   enabled: true
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "http://localhost:4402",
+  #   "OIDCSettings": {
+  #     "authority": "http://localhost:5000/",
+  #     "client_id": "alloy.ui",
+  #     "redirect_uri": "http://localhost:4403/auth-callback",
+  #     "post_logout_redirect_uri": "http://localhost:4403",
+  #     "response_type": "code",
+  #     "scope": "openid profile s3 s3-vm alloy-api caster-api steamfitter-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "http://localhost:4403/auth-callback-silent.html"
+  #   },
+  #   "AppTitle": "Alloy",
+  #   "AppTopBarText": "Alloy",
+  #   "AppTopBarHexColor": "#0c918d",
+  #   "PlayerUIAddress": "http://localhost:4301",
+  #   "PollingIntervalMS": "3500",
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": true
+  #   }
+  # }'

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -221,7 +221,7 @@ alloy-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -310,6 +310,7 @@ alloy-ui:
     #   enabled: true
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "http://localhost:4402",
   #   "OIDCSettings": {

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -74,7 +74,13 @@ alloy-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -3,7 +3,7 @@ name: blueprint
 description: Blueprint enables collaborative creation and visualization of a Master
   Scenario Event List (MSEL) for an exercise.
 type: application
-version: 1.9.5
+version: 1.10.0
 home: https://cmu-sei.github.io/crucible/blueprint/
 sources:
 - https://github.com/cmu-sei/Blueprint.Api

--- a/charts/blueprint/Chart.yaml
+++ b/charts/blueprint/Chart.yaml
@@ -3,7 +3,7 @@ name: blueprint
 description: Blueprint enables collaborative creation and visualization of a Master
   Scenario Event List (MSEL) for an exercise.
 type: application
-version: 1.9.4
+version: 1.9.5
 home: https://cmu-sei.github.io/crucible/blueprint/
 sources:
 - https://github.com/cmu-sei/Blueprint.Api

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -207,7 +207,7 @@ blueprint-api:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `OpenTelemetry__AddAlwaysOnTracingSampler` | Use the AlwaysOn sampler instead of the default parent-based sampler | `false` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
 | `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to the console (useful for debugging) | `false` |
 | `OpenTelemetry__AddPrometheusExporter` | Expose a Prometheus `/metrics` scrape endpoint | `false` |
 | `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core and HttpClient activity sources | `true` |

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -83,7 +83,7 @@ Blueprint API supports sending xAPI statements to a Learning Record Store (LRS) 
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `XApiOptions__Enabled` | Enable xAPI statement submission | `false` |
+| `XApiOptions__Enabled` | Enable xAPI statement recording | `false` |
 | `XApiOptions__Endpoint` | LRS endpoint URL | `""` |
 | `XApiOptions__Username` | LRS basic-auth username | `""` |
 | `XApiOptions__Password` | LRS basic-auth password | `""` |

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -63,16 +63,38 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 | `Logging__Console__LogLevel__Microsoft` | Console log level Microsoft | `Warning` |
 | `Logging__Console__LogLevel__System` | Console log level System | `Warning` |
 
-### CORS Policy
+### CORS Policy Settings
 
 | Setting | Description | Example |
 |---------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://blueprint.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
+
+### xAPI Settings
+
+Blueprint API supports sending xAPI statements to a Learning Record Store (LRS) via the `XApiOptions` settings.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `XApiOptions__Enabled` | Enable xAPI statement submission | `false` |
+| `XApiOptions__Endpoint` | LRS endpoint URL | `""` |
+| `XApiOptions__Username` | LRS basic-auth username | `""` |
+| `XApiOptions__Password` | LRS basic-auth password | `""` |
+| `XApiOptions__IssuerUrl` | Identity provider issuer URL used in xAPI actor IFI | `""` |
+| `XApiOptions__ApiUrl` | Blueprint API base URL reported in xAPI statements | `""` |
+| `XApiOptions__UiUrl` | Blueprint UI base URL reported in xAPI statements | `""` |
+| `XApiOptions__EmailDomain` | Email domain used to construct actor mbox values | `""` |
+| `XApiOptions__Platform` | Platform name reported in xAPI statements | `Blueprint` |
+| `XApiOptions__RetentionDays` | Number of days to retain processed xAPI records | `7` |
+| `XApiOptions__ProcessingTimeoutMinutes` | Timeout in minutes for xAPI statement processing | `10` |
+| `XApiOptions__ProcessingDelaySeconds` | Delay in seconds between xAPI processing cycles | `30` |
 
 ### Claims Transformation
 
@@ -180,6 +202,16 @@ blueprint-api:
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+#### OpenTelemetry Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Use the AlwaysOn sampler instead of the default parent-based sampler | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to the console (useful for debugging) | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a Prometheus `/metrics` scrape endpoint | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core and HttpClient activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/blueprint/charts/blueprint-api/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: blueprint-api
 type: application
-version: 1.8.14
+version: 1.9.0
 appVersion: 1.6.15

--- a/charts/blueprint/charts/blueprint-api/values.yaml
+++ b/charts/blueprint/charts/blueprint-api/values.yaml
@@ -1,9 +1,3 @@
-# Default values for blueprint-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
-
 image:
   repository: cmusei/blueprint-api
   pullPolicy: IfNotPresent
@@ -15,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,7 +27,23 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -66,41 +71,21 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
 
@@ -119,15 +104,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# env is pod env vars
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Blueprint.Api/blob/main/Blueprint.Api/appsettings.json
 env:
-  # http_proxy: ""
-  # https_proxy: ""
-  # HTTP_PROXY: ""
-  # HTTPS_PROXY: ""
-  # NO_PROXY: ""
-  # no_proxy: ""
-
   Logging__IncludeScopes: false
   Logging__Debug__LogLevel__Default: Warning
   Logging__Debug__LogLevel__Microsoft: Warning
@@ -143,9 +123,9 @@ env:
   Database__Provider: PostgreSQL
   Database__SeedFile: seed-data.json
 
-  CorsPolicy__Origins__0: ""
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true

--- a/charts/blueprint/charts/blueprint-api/values.yaml
+++ b/charts/blueprint/charts/blueprint-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/blueprint/charts/blueprint-ui/Chart.yaml
+++ b/charts/blueprint/charts/blueprint-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: blueprint-ui
 type: application
-version: 1.8.2
+version: 1.9.0
 appVersion: 1.8.1

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for blueprint-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/blueprint-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: blueprint.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+    # - secretName: ""
+    #   hosts:
+    #     - example.com
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the white ruler icon from a file in a configMap:
 #
 # extraVolumes: |
@@ -84,12 +71,11 @@ affinity: {}
 #   - name: "replacement-icon-vol"
 #     mountPath: /usr/share/nginx/html/assets/img/pencil-ruler-white.png
 #     subPath: pencil-ruler-white.png
-
+#
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
-extraVolumes: ""
-
 extraVolumeMounts: ""
+extraVolumes: ""
 
 # env is pod env vars
 env:
@@ -114,22 +100,22 @@ settingsYaml:
   #   response_type: code
   #   scope: openid profile blueprint
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: https://blueprint.example.com/auth-callback-silent
+  #   silent_redirect_uri: https://blueprint.example.com/auth-callback-silent.html
   # AppTitle: Blueprint
+  # AppTopBarText: Blueprint  -  Exercise Planning
   # AppTopBarHexColor: "#2d69b4"
   # AppTopBarHexTextColor: "#FFFFFF"
-  # AppTopBarText: Blueprint  -  Exercise Planning
   # AppTopBarImage: /assets/img/monitor-dashboard-white.png
   # UseLocalAuthStorage: true
-#   HeaderBarSettings:
-#     banner_background_color: "#d40000ff"
-#     classification_text: ""
-#     classification_text_color: "#ffffff"
-#     classification_text_fontsize: "14"
-#     message_text: ""
-#     message_text_color: "#ffffff"
-#     message_text_fontsize: "14"
-#     enabled: false
+  # HeaderBarSettings:
+  #   banner_background_color: "#d40000ff"
+  #   classification_text: ""
+  #   classification_text_color: "#ffffff"
+  #   classification_text_fontsize: "14"
+  #   message_text: ""
+  #   message_text_color: "#ffffff"
+  #   message_text_fontsize: "14"
+  #   enabled: false
 
 ## settings is stringified json that gets included as appsettings.Production.json
 # settings: '{

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -118,6 +118,7 @@ settingsYaml:
   #   enabled: false
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://blueprint.example.com",
 #   "OIDCSettings": {

--- a/charts/blueprint/charts/blueprint-ui/values.yaml
+++ b/charts/blueprint/charts/blueprint-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: blueprint.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -293,6 +293,7 @@ blueprint-ui:
     #   enabled: false
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://blueprint.example.com",
   #   "OIDCSettings": {

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -230,9 +230,9 @@ blueprint-ui:
           - path: /
             pathType: ImplementationSpecific
     tls: []
-      # - secretName: ""
-      #   hosts:
-      #     - example.com
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the white ruler icon from a file in a configMap:

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -48,6 +48,11 @@ blueprint-api:
         hosts:
           - example.com
 
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certifcates and specify
+  # the configMap name here
+  certificateMap: ""
+
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
   existingSecret: ""
@@ -187,13 +192,6 @@ blueprint-ui:
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -204,7 +204,7 @@ blueprint-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -74,7 +74,13 @@ blueprint-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -225,7 +225,7 @@ blueprint-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: blueprint.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/blueprint/values.yaml
+++ b/charts/blueprint/values.yaml
@@ -1,7 +1,50 @@
 blueprint-api:
-  # Docker image release version. Defaults to appVersion of blueprint-api child chart
   image:
+    repository: cmusei/blueprint-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,30 +71,26 @@ blueprint-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: blueprint.example.com
+      - host: chart-example.local
         paths:
-          - path: /(api|swagger/hubs)
+          - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
+  # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
+
+  command: ["./Blueprint.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -66,14 +105,10 @@ blueprint-api:
   # - configMapRef:
   #     name: my-configmap
 
+  # Config app settings with environment vars.
+  # Those most likely needing values are listed. For others,
+  # see https://github.com/cmu-sei/Blueprint.Api/blob/main/Blueprint.Api/appsettings.json
   env:
-    # http_proxy: ""
-    # https_proxy: ""
-    # HTTP_PROXY: ""
-    # HTTPS_PROXY: ""
-    # NO_PROXY: ""
-    # no_proxy: ""
-
     Logging__IncludeScopes: false
     Logging__Debug__LogLevel__Default: Warning
     Logging__Debug__LogLevel__Microsoft: Warning
@@ -82,31 +117,27 @@ blueprint-api:
     Logging__Console__LogLevel__Microsoft: Warning
     Logging__Console__LogLevel__System: Warning
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=blueprint_api;Username=blueprint_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
     Database__SeedFile: seed-data.json
 
-    # CORS policy settings.
-    # The first entry should be the URL to Blueprint
-    CorsPolicy__Origins__0: https://blueprint.example.com
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
-    Authorization__AuthorizationScope: blueprint
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
+    Authorization__AuthorizationScope: "blueprint"
     Authorization__ClientId: blueprint.swagger
-    Authorization__ClientName: Blueprint API Swagger
+    Authorization__ClientName: "Blueprint API Swagger"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
@@ -142,26 +173,66 @@ blueprint-api:
     # OTEL_SERVICE_NAME: blueprint-api
 
 blueprint-ui:
-  # Docker image release version. Defaults to appVersion of blueprint-ui child chart
   image:
+    repository: cmusei/blueprint-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: blueprint.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+      # - secretName: ""
+      #   hosts:
+      #     - example.com
 
   ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the white ruler icon from a file in a configMap:
@@ -178,9 +249,13 @@ blueprint-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
+  # env is pod env vars
+  env:
+    ## basehref is path to the app
+    APP_BASEHREF: ""
 
   ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
   ## settings.shared.json key. When set, the file is mounted into the Angular
@@ -188,10 +263,6 @@ blueprint-ui:
   ## load shared UI configuration that is common across multiple Crucible services.
   ## Per-app values can still be overridden via settingsYaml.
   sharedSettingsConfigMap: ""
-
-  env:
-    ## basehref is path to the app
-    APP_BASEHREF: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -206,48 +277,48 @@ blueprint-ui:
     #   automaticSilentRenew: true
     #   silent_redirect_uri: https://blueprint.example.com/auth-callback-silent.html
     # AppTitle: Blueprint
+    # AppTopBarText: Blueprint  -  Exercise Planning
     # AppTopBarHexColor: "#2d69b4"
     # AppTopBarHexTextColor: "#FFFFFF"
-    # AppTopBarText: Blueprint  -  Exercise Planning
     # AppTopBarImage: /assets/img/monitor-dashboard-white.png
     # UseLocalAuthStorage: true
-#     HeaderBarSettings:
-#       banner_background_color: "#d40000ff"
-#       classification_text: ""
-#       classification_text_color: "#ffffff"
-#       classification_text_fontsize: "14"
-#       message_text: ""
-#       message_text_color: "#ffffff"
-#       message_text_fontsize: "14"
-#       enabled: false
+    # HeaderBarSettings:
+    #   banner_background_color: "#d40000ff"
+    #   classification_text: ""
+    #   classification_text_color: "#ffffff"
+    #   classification_text_fontsize: "14"
+    #   message_text: ""
+    #   message_text_color: "#ffffff"
+    #   message_text_fontsize: "14"
+    #   enabled: false
 
-    ## settings is stringified json that gets included as appsettings.Production.json
-    # settings: '{
-    #   "ApiUrl": "https://blueprint.example.com",
-    #   "OIDCSettings": {
-    #     "authority": "https://identity.example.com/",
-    #     "client_id": "blueprint-ui",
-    #     "redirect_uri": "https://blueprint.example.com/auth-callback",
-    #     "post_logout_redirect_uri": "https://blueprint.example.com",
-    #     "response_type": "code",
-    #     "scope": "openid profile blueprint",
-    #     "automaticSilentRenew": true,
-    #     "silent_redirect_uri": "https://blueprint.example.com/auth-callback-silent"
-    #   },
-    #   "AppTitle": "Blueprint",
-    #   "AppTopBarText": "Blueprint",
-    #   "AppTopBarHexColor": "#2d69b4",
-    #   "PlayerUIAddress": "http://blueprint.example.com",
-    #   "PollingIntervalMS": "3500",
-    #   "UseLocalAuthStorage": true,
-    #   "HeaderBarSettings": {
-    #     "banner_background_color": "#d40000ff",
-    #     "classification_text": "",
-    #     "classification_text_color": "#ffffff",
-    #     "classification_text_fontsize": "14",
-    #     "message_text": "",
-    #     "message_text_color": "#ffffff",
-    #     "message_text_fontsize": "14",
-    #     "enabled": false
-    #   }
-    # }'
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://blueprint.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "blueprint-ui",
+  #     "redirect_uri": "https://blueprint.example.com/auth-callback",
+  #     "post_logout_redirect_uri": "https://blueprint.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile blueprint",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://blueprint.example.com/auth-callback-silent"
+  #   },
+  #   "AppTitle": "Blueprint",
+  #   "AppTopBarText": "Blueprint",
+  #   "AppTopBarHexColor": "#2d69b4",
+  #   "PlayerUIAddress": "http://blueprint.example.com",
+  #   "PollingIntervalMS": "3500",
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": false
+  #   }
+  # }'

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caster
 description: Caster enables the coded design and deployment of cyber topologies.
 type: application
-version: 1.8.12
+version: 1.9.0
 home: https://cmu-sei.github.io/crucible/caster/
 sources:
 - https://github.com/cmu-sei/Caster.Api/

--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caster
 description: Caster enables the coded design and deployment of cyber topologies.
 type: application
-version: 1.8.11
+version: 1.8.12
 home: https://cmu-sei.github.io/crucible/caster/
 sources:
 - https://github.com/cmu-sei/Caster.Api/

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -62,16 +62,19 @@ The following settings are applied through `caster-api.env`. These Caster API se
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 ```
 
-### CORS Policy
+### CORS Policy Settings
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://caster.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
 
 ### Authentication (OIDC)
 
@@ -391,15 +394,17 @@ caster-api:
     # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     # Optional: override the service name reported to collectors
     # OTEL_SERVICE_NAME: caster-api
-
-    # These settings toggle ServiceDefaults configurations for Otel
-    # The values listed here are the defaults
-    # OpenTelemetry__AddAlwaysOnTracingSampler: false
-    # OpenTelemetry__AddConsoleExporter: false
-    # OpenTelemetry__AddPrometheusExporter: false
-    # OpenTelemetry__IncludeDefaultActivitySources: true
-    # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+#### OpenTelemetry Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (overrides the default parent-based sampler) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Write traces and metrics to stdout | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` Prometheus scrape endpoint | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core / HttpClient activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core / runtime meters | `true` |
 
 #### Custom metrics from Caster
 - Gauges: `caster_projects`, `caster_workspaces`
@@ -415,7 +420,7 @@ caster-api:
 |---------|-------------|---------|
 | `APP_BASEHREF` | Set when hosting the UI from a subpath | `/caster` |
 
-Use `settingsYaml` to configure settings for the Angular UI application.
+Use `settingsYaml` to configure settings for the Angular UI application. Alternatively, `settings` accepts the same configuration as a pre-serialized JSON string — useful when the values are managed by an external secrets tool or templating layer. When both are provided, `settingsYaml` takes precedence.
 
 | Setting | Description | Example |
 |---------|-------------|---------|

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -400,7 +400,7 @@ caster-api:
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (overrides the default parent-based sampler) | `false` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
 | `OpenTelemetry__AddConsoleExporter` | Write traces and metrics to stdout | `false` |
 | `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` Prometheus scrape endpoint | `false` |
 | `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core / HttpClient activity sources | `true` |

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -459,6 +459,27 @@ data:
 
 When `sharedSettingsConfigMap` is not set (the default), no shared settings file is mounted and the behavior is unchanged.
 
+### Extra Volumes
+
+Mount additional Kubernetes volumes into the UI container using `extraVolumes` and `extraVolumeMounts`. Both values accept stringified YAML following the standard Kubernetes volume spec.
+
+A common use case is replacing the application favicon with a custom icon stored in a ConfigMap:
+
+```yaml
+caster-ui:
+  extraVolumes: |
+    - name: replacement-icon-vol
+      configMap:
+        name: replacement-icons
+
+  extraVolumeMounts: |
+    - name: replacement-icon-vol
+      mountPath: /usr/share/nginx/html/assets/img/caster.ico
+      subPath: caster.ico
+```
+
+See the [Kubernetes volumes documentation](https://kubernetes.io/docs/concepts/storage/volumes/) for all supported volume types.
+
 ### Classification Banner
 
 Caster UI supports an optional classification banner via `HeaderBarSettings`. The banner is enabled by default with empty message values, resulting in no header bar being shown to the user. Configure `classification_text` and `message_text` to display content.

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: caster-api
 type: application
-version: 1.6.25
+version: 1.7.0
 appVersion: 3.6.9

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -229,7 +229,7 @@ env:
   Player__RemoveLoopSeconds: 300
 
   Terraform__BinaryPath: "/terraform/binaries"
-  Terraform__DefaultVersion: "0.12.24"
+  Terraform__DefaultVersion: "0.14.0"
   # Terraform__PluginDirectory: '/terraform/plugins'
   Terraform__PluginCache: "/terraform/plugin-cache"
   Terraform__RootWorkingDirectory: "/terraform/root"

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -1,7 +1,3 @@
-# Default values for caster-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/caster-api
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -37,6 +28,22 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -64,57 +71,22 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-# If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
-# the configMap name here
-certificateMap: ""
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-command: ["./Caster.Api"]
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-# storage - either an existing pvc, the size for a new pvc, or emptyDir
-storage:
-  existing: ""
-  size: ""
-  mode: ReadWriteOnce # If using Kubernetes execution mode, this should be a storage that supports ReadWriteMany to enable jobs running on different k8s nodes
-
-  class: default
-
-gitcredentials: ""
-
 # Use a .terraformrc file to overwrite standard Terraform configuration
+# https://www.terraform.io/docs/cli/config/config-file.html
+# NOTE:  If enabled,  Terraform__PluginDirectory environment variable must be set to empty explicitly
 terraformrc:
   enabled: false
   value: |
@@ -129,6 +101,26 @@ terraformrc:
         }
     }
 
+# storage - either an existing pvc, the size for a new pvc, or emptyDir
+storage:
+  existing: ""
+  size: ""
+  mode: ReadWriteOnce
+  class: default
+
+# If this deployment needs to trust non-public certificates,
+# create a configMap with the needed certificates and specify
+# the configMap name here
+certificateMap: ""
+
+# Gets placed in /app/.git-credentials to allow immediate Gitlab access via access token
+# Replace TOKEN with an access token created in Gitlab, and update the Gitlab URL
+# Example:
+# gitcredentials: "https://git-access-token:TOKEN@gitlab.example.com"
+gitcredentials: ""
+
+command: ["./Caster.Api"]
+
 ## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
 existingSecret: ""
@@ -142,25 +134,31 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/crucible/blob/master/caster.api/src/Caster.Api/appsettings.json
 env:
-  # http_proxy:
-  # https_proxy:
-  # HTTP_PROXY:
-  # HTTPS_PROXY:
-  # NO_PROXY:
-  # no_proxy:
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
+  # This deployment comes built in with a script to install Terraform and the necessary
+  # plugins to run Caster properly.  Internet access is required for this script to run properly.
+  # It's recommended that this should remain false.  Please see the file "terraform-installation.tpl"
+  # for more information on the installation process.
+  # Installation will always be skipped if Kubernetes Jobs are enabled.
   SKIP_TERRAFORM_INSTALLATION: false
   SKIP_VOL_PERMISSIONS: false
 
-  VSPHERE_SERVER:
-  VSPHERE_USER:
-  VSPHERE_PASSWORD:
+  VSPHERE_SERVER: ""
+  VSPHERE_USER: ""
+  VSPHERE_PASSWORD: ""
   VSPHERE_ALLOW_UNVERIFIED_SSL: true
 
+  # === Terraform Crucible Provider Section ===
+  # These variables only need filled in if you are using the following provider:
+  # https://registry.terraform.io/providers/cmu-sei/crucible/latest
+
+  # An Identity Service account with Caster Admin privileges
   SEI_CRUCIBLE_USERNAME: ""
   SEI_CRUCIBLE_PASSWORD: ""
   SEI_CRUCIBLE_AUTH_URL: ""
@@ -190,9 +188,9 @@ env:
   Logging__Console__LogLevel__Microsoft: Error
   Logging__Console__LogLevel__System: Error
 
-  CorsPolicy__Origins__0: http://localhost:4310
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true
@@ -207,9 +205,9 @@ env:
   Database__DevModeRecreate: false
   Database__Provider: PostgreSQL
 
-  Authorization__Authority:
-  Authorization__AuthorizationUrl:
-  Authorization__TokenUrl:
+  Authorization__Authority: ""
+  Authorization__AuthorizationUrl: ""
+  Authorization__TokenUrl: ""
   Authorization__AuthorizationScope: "caster-api"
   Authorization__ClientId: caster-api-dev
   Authorization__ClientName: "Caster API"
@@ -241,7 +239,7 @@ env:
     # Terraform__GitlabGroupId: 6
   Terraform__GitlabApiUrl: ""
   Terraform__GitlabToken: ""
-  Terraform__GitlabGroupId: 6
+  Terraform__GitlabGroupId: ""
   Terraform__OutputSaveInterval: 5000
   Terraform__StateRetryCount: 12
   Terraform__StateRetryIntervalSeconds: 5

--- a/charts/caster/charts/caster-ui/Chart.yaml
+++ b/charts/caster/charts/caster-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: caster-ui
 type: application
-version: 1.8.6
+version: 1.9.0
 appVersion: 3.6.5

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for caster-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/caster-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: caster.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
 #
 # extraVolumes: |
@@ -82,14 +69,18 @@ affinity: {}
 #
 # extraVolumeMounts: |
 #   - name: "replacement-icon-vol"
-#     mountPath: /usr/share/nginx/html/assets/img/alloy.ico
-#     subPath: alloy.ico
+#     mountPath: /usr/share/nginx/html/assets/img/caster.ico
+#     subPath: caster.ico
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
+# env is pod env vars
+env:
+  ## basehref is path to the app
+  APP_BASEHREF: ""
 
 ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
 ## settings.shared.json key. When set, the file is mounted into the Angular
@@ -98,25 +89,18 @@ extraVolumeMounts: ""
 ## Per-app values can still be overridden via settingsYaml.
 sharedSettingsConfigMap: ""
 
-env:
-  ## basehref is path to the app
-  APP_BASEHREF: ""
-
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
-
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: ""
+  # ApiUrl: https://caster.example.com
   # OIDCSettings:
-  #   authority: ""
+  #   authority: https://identity.example.com/
   #   client_id: caster-ui-dev
-  #   redirect_uri: ""
-  #   post_logout_redirect_uri: ""
+  #   redirect_uri: https://caster.example.com/auth-callback/
+  #   post_logout_redirect_uri: https://caster.example.com/
   #   response_type: code
   #   scope: openid profile email caster-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: ""
+  #   silent_redirect_uri: https://caster.example.com/auth-callback-silent.html
   # UseLocalAuthStorage: true
   # HeaderBarSettings:
   #   banner_background_color: "#d40000ff"
@@ -127,3 +111,29 @@ settingsYaml:
   #   message_text_color: "#ffffff"
   #   message_text_fontsize: "14"
   #   enabled: true
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://caster.example.com",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "caster-ui-dev",
+#     "redirect_uri": "https://caster.example.com/auth-callback/",
+#     "post_logout_redirect_uri": "https://caster.example.com/",
+#     "response_type": "code",
+#     "scope": "openid profile email caster-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://caster.example.com/auth-callback-silent.html"
+#   },
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": false
+#   }
+# }'

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -113,6 +113,7 @@ settingsYaml:
   #   enabled: true
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://caster.example.com",
 #   "OIDCSettings": {

--- a/charts/caster/charts/caster-ui/values.yaml
+++ b/charts/caster/charts/caster-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: caster.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -230,7 +230,7 @@ caster-api:
     Player__RemoveLoopSeconds: 300
 
     Terraform__BinaryPath: "/terraform/binaries"
-    Terraform__DefaultVersion: "0.12.24"
+    Terraform__DefaultVersion: "0.14.0"
     # Terraform__PluginDirectory: '/terraform/plugins'
     Terraform__PluginCache: "/terraform/plugin-cache"
     Terraform__RootWorkingDirectory: "/terraform/root"

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -318,7 +318,7 @@ caster-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -235,9 +235,9 @@ caster-api:
     Terraform__PluginCache: "/terraform/plugin-cache"
     Terraform__RootWorkingDirectory: "/terraform/root"
     # Example:
-      # Terraform__GitlabApiUrl: "https://gitlab.example.com/api/v4/"
-      # Terraform__GitlabToken: "your-gitlab-token"
-      # Terraform__GitlabGroupId: 6
+    # Terraform__GitlabApiUrl: "https://gitlab.example.com/api/v4/"
+    # Terraform__GitlabToken: "your-gitlab-token"
+    # Terraform__GitlabGroupId: 6
     Terraform__GitlabApiUrl: ""
     Terraform__GitlabToken: ""
     Terraform__GitlabGroupId: ""
@@ -339,7 +339,7 @@ caster-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: caster.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -1,7 +1,50 @@
 caster-api:
-  # Docker image release version. Defaults to appVersion of caster-api child chart
   image:
+    repository: cmusei/caster-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,25 +71,19 @@ caster-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: caster.example.com
+      - host: chart-example.local
         paths:
           - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # Use a .terraformrc file to overwrite standard Terraform configuration
   # https://www.terraform.io/docs/cli/config/config-file.html
@@ -73,7 +110,7 @@ caster-api:
     class: default
 
   # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
+  # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
 
@@ -82,6 +119,8 @@ caster-api:
   # Example:
   # gitcredentials: "https://git-access-token:TOKEN@gitlab.example.com"
   gitcredentials: ""
+
+  command: ["./Caster.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -100,14 +139,6 @@ caster-api:
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/crucible/blob/master/caster.api/src/Caster.Api/appsettings.json
   env:
-    # Proxy Settings
-    # http_proxy: proxy.example.com:9000
-    # https_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -119,10 +150,8 @@ caster-api:
     SKIP_TERRAFORM_INSTALLATION: false
     SKIP_VOL_PERMISSIONS: false
 
-    # VSphere settings:
-    # TODO - Document VSphere user role requirements
-    VSPHERE_SERVER: vcenter.example.com
-    VSPHERE_USER: caster-account@vsphere.local
+    VSPHERE_SERVER: ""
+    VSPHERE_USER: ""
     VSPHERE_PASSWORD: ""
     VSPHERE_ALLOW_UNVERIFIED_SSL: true
 
@@ -133,44 +162,16 @@ caster-api:
     # An Identity Service account with Caster Admin privileges
     SEI_CRUCIBLE_USERNAME: ""
     SEI_CRUCIBLE_PASSWORD: ""
-
-    # URL to the Identity Server Auth endpoint
-    SEI_CRUCIBLE_AUTH_URL: https://identity.example.com/connect/authorize
-    # URL to the Identity Server Token endpoint
-    SEI_CRUCIBLE_TOK_URL: https://identity.example.com/connect/token
-
-    # Identity Client information
-    SEI_CRUCIBLE_CLIENT_ID: player.provider
+    SEI_CRUCIBLE_AUTH_URL: ""
+    SEI_CRUCIBLE_TOK_URL: ""
+    SEI_CRUCIBLE_CLIENT_ID: ""
     SEI_CRUCIBLE_CLIENT_SECRET: ""
-
-    # URLs to Player API and VM API
-    SEI_CRUCIBLE_VM_API_URL: https://vm.example.com/api/
-    SEI_CRUCIBLE_PLAYER_API_URL: https://player.example.com/
-
-    # === End Terraform Crucible Provider Section ===
-
-    # === Terraform Identity Provider Section ===
-    # These variables only need filled in if you are using the following provider:
-    # https://registry.terraform.io/providers/cmu-sei/identity/latest
-
-    # URL to the Identity Server Auth endpoint
-    SEI_IDENTITY_TOK_URL: https://identity.example.com/connect/token
-    # URL to the Identity Server API endpoint
-    SEI_IDENTITY_API_URL: https://id.example.com/api/
-
-    # Identity Client information
-    SEI_IDENTITY_CLIENT_ID: terraform-identity-provider
+    SEI_CRUCIBLE_VM_API_URL: ""
+    SEI_CRUCIBLE_PLAYER_API_URL: ""
+    SEI_IDENTITY_TOK_URL: ""
+    SEI_IDENTITY_CLIENT_ID: ""
     SEI_IDENTITY_CLIENT_SECRET: ""
-
-    # === End Terraform Identity Provider Section ===
-
-    # === Terraform Azure Provider Section ===
-    # These variables only need filled in if you are using the following provider:
-    # https://registry.terraform.io/providers/hashicorp/azurerm/latest
-
-    # Remaining documentation provided by the plugin
-    # NOTE:  Use the certificateMap key in this chart to add certificates, which will be placed in:
-    #        /usr/local/share/ca-certificates
+    SEI_IDENTITY_API_URL: ""
     ARM_CLIENT_CERTIFICATE_PATH: ""
     ARM_CLIENT_ID: ""
     ARM_ENVIRONMENT: ""
@@ -178,8 +179,6 @@ caster-api:
     ARM_SUBSCRIPTION_ID: ""
     ARM_TENANT_ID: ""
 
-    # See here for more information regarding AllowedHosts
-    # https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.hostfiltering.hostfilteringoptions.allowedhosts?view=aspnetcore-3.1
     AllowedHosts: "*"
 
     Logging__IncludeScopes: false
@@ -190,38 +189,33 @@ caster-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # Connection String to database
-    # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=caster_api;Username=caster_dbu;Password=;"
-    Database__AutoMigrate: true
-    Database__DevModeRecreate: false
-    Database__Provider: PostgreSQL
-
-    # CORS policy settings.
-    # The first entry should be the URL to Caster
-    CorsPolicy__Origins__0: "https://caster.example.com"
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    ClaimsTransformation__EnableCaching: true
+    ClaimsTransformation__CacheExpirationSeconds: 60
+
+    # database requires the 'uuid-ossp' extension installed
+    ConnectionStrings__PostgreSQL: ""
+    Database__AutoMigrate: true
+    Database__DevModeRecreate: false
+    Database__Provider: PostgreSQL
+
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "caster-api"
     Authorization__ClientId: caster-api-dev
     Authorization__ClientName: "Caster API"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
-    ClaimsTransformation__EnableCaching: true
-    ClaimsTransformation__CacheExpirationSeconds: 60
-
-    # OAuth2 Identity Client /w Password
-    Client__TokenUrl: https://identity.example.com/connect/token
+    Client__TokenUrl: ""
     Client__ClientId: caster-admin
     Client__ClientSecret: ""
     Client__UserName: ""
@@ -230,25 +224,20 @@ caster-api:
     Client__MaxRetryDelaySeconds: 120
     Client__TokenRefreshSeconds: 600
 
-    # Crucible Player URLs
-    Player__VmApiUrl: "https://vm.example.com"
-    Player__VmConsoleUrl: "https://console.example.com/vm/{id}/console"
+    Player__VmApiUrl: ""
+    Player__VmConsoleUrl: ""
     Player__MaxParallelism: 8
     Player__RemoveLoopSeconds: 300
 
-    # Terraform Information
-    # - DefaultVersion - The default version to be used.
-    # - GitlabApiUrl - URL to the deployed Gitlab instance
-    # - TODO - Add link to Installation Documentation on how to get GitlabToken and GitlabGroupId
-    # Example:
-    # Terraform__GitlabApiUrl: "https://gitlab.example.com/api/v4/"
-    # Terraform__GitlabToken: "your-gitlab-token"
-    # Terraform__GitlabGroupId: 6
     Terraform__BinaryPath: "/terraform/binaries"
-    Terraform__DefaultVersion: "0.14.0"
+    Terraform__DefaultVersion: "0.12.24"
     # Terraform__PluginDirectory: '/terraform/plugins'
     Terraform__PluginCache: "/terraform/plugin-cache"
     Terraform__RootWorkingDirectory: "/terraform/root"
+    # Example:
+      # Terraform__GitlabApiUrl: "https://gitlab.example.com/api/v4/"
+      # Terraform__GitlabToken: "your-gitlab-token"
+      # Terraform__GitlabGroupId: 6
     Terraform__GitlabApiUrl: ""
     Terraform__GitlabToken: ""
     Terraform__GitlabGroupId: ""
@@ -279,22 +268,8 @@ caster-api:
     # Terraform__KubernetesJobs__ConfigMaps__0__Name: "caster-certs"
     # Terraform__KubernetesJobs__ConfigMaps__0__MountPath: "/usr/local/share/ca-certificates/"
 
-    # Configurable save lengths for Caster untagged versions
     FileVersions__DaysToSaveAllUntaggedVersions: 7
     FileVersions__DaysToSaveDailyUntaggedVersions: 31
-
-    # Basic seed data to jumpstart deployement
-    # TODO - Document seed data
-    # SeedData__Users__0__id: ""
-    # SeedData__Users__0__name: ""
-
-    # SeedData__Users__1__id: ""
-    # SeedData__Users__1__name: ""
-
-    # SeedData__UserPermissions__0__UserId:
-    # SeedData__UserPermissions__0__PermissionId:
-    # SeedData__UserPermissions__1__UserId:
-    # SeedData__UserPermissions__1__PermissionId:
 
     # Open Telemetry
     # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -312,28 +287,68 @@ caster-api:
     # OTEL_SERVICE_NAME: caster-api
 
 caster-ui:
-  # Docker image release version. Defaults to appVersion of caster-ui child chart
   image:
+    repository: cmusei/caster-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: caster.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
   #
   # extraVolumes: |
@@ -348,23 +363,20 @@ caster-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -387,4 +399,30 @@ caster-ui:
     #   message_text: ""
     #   message_text_color: "#ffffff"
     #   message_text_fontsize: "14"
-    #   enabled: false
+    #   enabled: true
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://caster.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "caster-ui-dev",
+  #     "redirect_uri": "https://caster.example.com/auth-callback/",
+  #     "post_logout_redirect_uri": "https://caster.example.com/",
+  #     "response_type": "code",
+  #     "scope": "openid profile email caster-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://caster.example.com/auth-callback-silent.html"
+  #   },
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": false
+  #   }
+  # }'

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -402,6 +402,7 @@ caster-ui:
     #   enabled: true
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://caster.example.com",
   #   "OIDCSettings": {

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -74,7 +74,13 @@ caster-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -3,7 +3,7 @@ name: cite
 description: CITE enables participants from different organizations to evaluate, score,
   and comment on cyber incidents.
 type: application
-version: 1.9.9
+version: 1.10.0
 home: https://cmu-sei.github.io/crucible/cite/
 sources:
 - https://github.com/cmu-sei/cite.Api

--- a/charts/cite/Chart.yaml
+++ b/charts/cite/Chart.yaml
@@ -3,7 +3,7 @@ name: cite
 description: CITE enables participants from different organizations to evaluate, score,
   and comment on cyber incidents.
 type: application
-version: 1.9.8
+version: 1.9.9
 home: https://cmu-sei.github.io/crucible/cite/
 sources:
 - https://github.com/cmu-sei/cite.Api

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -94,7 +94,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 CITE API can emit [xAPI](https://xapi.com/) (Experience API) statements to a Learning Record Store (LRS). Set `XApiOptions__Enabled` to `true` and configure the remaining options to activate xAPI reporting.
 
-| Setting | Description | Example |
+| Setting | Description | Default |
 |---------|-------------|---------|
 | `XApiOptions__Enabled` | Enable xAPI statement emission | `false` |
 | `XApiOptions__Endpoint` | LRS xAPI endpoint URL | `""` |
@@ -191,15 +191,6 @@ cite-api:
 
 CITE.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for CITE to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint URL | `""` |
-| `OpenTelemetry__AddAlwaysOnTracingSampler` | Enable always-on tracing sampler | `false` |
-| `OpenTelemetry__AddConsoleExporter` | Export telemetry to console | `false` |
-| `OpenTelemetry__AddPrometheusExporter` | Expose Prometheus metrics scrape endpoint | `false` |
-| `OpenTelemetry__IncludeDefaultActivitySources` | Register default ASP.NET Core activity sources | `true` |
-| `OpenTelemetry__IncludeDefaultMeters` | Register default ASP.NET Core meters | `true` |
-
 ```yaml
 cite-api:
   env:
@@ -219,6 +210,14 @@ cite-api:
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -73,6 +73,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin (add `__1`, `__2`, etc. for more) | `https://cite.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
@@ -86,6 +87,25 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 |-----------|-------------|---------|
 | `ClaimsTransformation__EnableCaching` | Enable claims caching | `true` |
 | `ClaimsTransformation__CacheExpirationSeconds` | Claims cache expiration in seconds | `60` |
+
+### xAPI Settings
+
+CITE API can emit [xAPI](https://xapi.com/) (Experience API) statements to a Learning Record Store (LRS). Set `XApiOptions__Enabled` to `true` and configure the remaining options to activate xAPI reporting.
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `XApiOptions__Enabled` | Enable xAPI statement emission | `false` |
+| `XApiOptions__Endpoint` | LRS xAPI endpoint URL | `""` |
+| `XApiOptions__Username` | LRS basic-auth username | `""` |
+| `XApiOptions__Password` | LRS basic-auth password | `""` |
+| `XApiOptions__IssuerUrl` | OIDC issuer URL used in actor IFI | `""` |
+| `XApiOptions__ApiUrl` | Public URL of the CITE API (used in statement object IDs) | `""` |
+| `XApiOptions__UiUrl` | Public URL of the CITE UI (used in statement context) | `""` |
+| `XApiOptions__EmailDomain` | Email domain appended to usernames for actor IFI | `""` |
+| `XApiOptions__Platform` | Platform name reported in xAPI statements | `CITE` |
+| `XApiOptions__RetentionDays` | Number of days to retain local xAPI records | `7` |
+| `XApiOptions__ProcessingTimeoutMinutes` | Timeout in minutes for xAPI processing jobs | `10` |
+| `XApiOptions__ProcessingDelaySeconds` | Delay in seconds between xAPI processing attempts | `30` |
 
 ### Certificate Trust
 
@@ -210,6 +230,7 @@ Use ``settingsYaml` to configure the Angular UI application.
 | `OIDCSettings.automaticSilentRenew` | Enables background token renewal | `true` |
 | `OIDCSettings.silent_redirect_uri` | URI for silent token renewal callbacks | `https://cite.example.com/auth-callback-silent.html` |
 | `UseLocalAuthStorage` | Persist auth state in browser local storage | `true` |
+| `XApiEnabled` | Show xAPI-related UI features | `false` |
 | `AppTitle` | Browser/application title | `CITE` |
 | `AppTopBarHexColor` | Hex color for the top bar background | `#2d69b4` |
 | `AppTopBarHexTextColor` | Hex color for the top bar text | `#FFFFFF` |

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -96,7 +96,7 @@ CITE API can emit [xAPI](https://xapi.com/) (Experience API) statements to a Lea
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `XApiOptions__Enabled` | Enable xAPI statement emission | `false` |
+| `XApiOptions__Enabled` | Enable xAPI statement recording | `false` |
 | `XApiOptions__Endpoint` | LRS xAPI endpoint URL | `""` |
 | `XApiOptions__Username` | LRS basic-auth username | `""` |
 | `XApiOptions__Password` | LRS basic-auth password | `""` |
@@ -246,7 +246,7 @@ Use ``settingsYaml` to configure the Angular UI application.
 | `OIDCSettings.automaticSilentRenew` | Enables background token renewal | `true` |
 | `OIDCSettings.silent_redirect_uri` | URI for silent token renewal callbacks | `https://cite.example.com/auth-callback-silent.html` |
 | `UseLocalAuthStorage` | Persist auth state in browser local storage | `true` |
-| `XApiEnabled` | Show xAPI-related UI features | `false` |
+| `XApiEnabled` | Enable xAPI tracking features | `false` |
 | `AppTitle` | Browser/application title | `CITE` |
 | `AppTopBarHexColor` | Hex color for the top bar background | `#2d69b4` |
 | `AppTopBarHexTextColor` | Hex color for the top bar text | `#FFFFFF` |

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -73,13 +73,15 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
-| `CorsPolicy__Origins__0` | First allowed CORS origin (add `__1`, `__2`, etc. for more) | `https://cite.example.com` |
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://cite.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
 
 ### Claims Transformation Settings
 
@@ -189,6 +191,15 @@ cite-api:
 
 CITE.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for CITE to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
 
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector endpoint URL | `""` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Enable always-on tracing sampler | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export telemetry to console | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose Prometheus metrics scrape endpoint | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register default ASP.NET Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register default ASP.NET Core meters | `true` |
+
 ```yaml
 cite-api:
   env:
@@ -217,6 +228,12 @@ cite-api:
 ## CITE UI Configuration
 
 Use ``settingsYaml` to configure the Angular UI application.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `APP_BASEHREF` | Base href path for the Angular app (set when hosting at a subpath) | `""` |
+
+### Application Settings (`settingsYaml`)
 
 | Setting | Description | Example |
 |---------|-------------|---------|
@@ -296,7 +313,7 @@ CITE UI supports an optional classification banner via `HeaderBarSettings`. The 
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `HeaderBarSettings.enabled` | Show or hide the classification banner | `true` |
+| `HeaderBarSettings.enabled` | Show or hide the classification banner | `false` |
 | `HeaderBarSettings.banner_background_color` | Background color of the banner (hex with alpha) | `#d40000ff` |
 | `HeaderBarSettings.classification_text` | Classification label displayed in the banner | `""` |
 | `HeaderBarSettings.classification_text_color` | Color of the classification label text | `#ffffff` |

--- a/charts/cite/charts/cite-api/Chart.yaml
+++ b/charts/cite/charts/cite-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cite-api
 type: application
-version: 1.8.9
+version: 1.9.0
 appVersion: 1.11.7

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/cite/charts/cite-api/values.yaml
+++ b/charts/cite/charts/cite-api/values.yaml
@@ -1,7 +1,3 @@
-# Default values for cite-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/cite-api
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,7 +27,23 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -64,45 +71,25 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
 
 command: ["./Cite.Api"]
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 ## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
@@ -117,14 +104,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Cite.Api/blob/main/Cite.Api/appsettings.json
 env:
-  # http_proxy:
-  # https_proxy:
-  # HTTP_PROXY:
-  # HTTPS_PROXY:
-  # NO_PROXY:
-  # no_proxy:
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
@@ -143,9 +126,9 @@ env:
   Database__Provider: PostgreSQL
   Database__SeedFile: ""
 
-  CorsPolicy__Origins__0: http://localhost:4401
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true

--- a/charts/cite/charts/cite-ui/Chart.yaml
+++ b/charts/cite/charts/cite-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: cite-ui
 type: application
-version: 1.8.5
+version: 1.9.0
 appVersion: 1.11.2

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for alloy-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/cite-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: cite.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the default dropdown indicator from a file in a configMap:
 #
 # extraVolumes: |
@@ -87,40 +74,37 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
-
-## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
-## load shared UI configuration that is common across multiple Crucible services.
-## Per-app values can still be overridden via settingsYaml.
-sharedSettingsConfigMap: ""
-
+# env is pod env vars
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+## settings.shared.json key. When set, the file is mounted into the Angular
+## app's assets/config/ directory alongside settings.json so the app can
+## load shared UI configuration that is common across multiple Crucible services.
+## Per-app values can still be overridden via settingsYaml.
+sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: http://localhost:4720
+  # ApiUrl: https://cite.example.com
   # OIDCSettings:
-  #   authority: http://localhost:5000/
-  #   client_id: cite.ui
-  #   redirect_uri: http://localhost:4721/auth-callback
-  #   post_logout_redirect_uri: http://localhost:4721
+  #   authority: https://identity.example.com/
+  #   client_id: cite-ui
+  #   redirect_uri: https://cite.example.com/auth-callback
+  #   post_logout_redirect_uri: https://cite.example.com
   #   response_type: code
-  #   scope: openid profile player player-vm cite
+  #   scope: openid profile alloy-api player-api vm-api cite-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: http://localhost:4721/auth-callback-silent.html
+  #   silent_redirect_uri: https://cite.example.com/auth-callback-silent.html
   # AppTitle: CITE
+  # AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
   # AppTopBarHexColor: "#2d69b4"
   # AppTopBarHexTextColor: "#FFFFFF"
-  # AppTopBarText: CITE  -  Financial Incident Threat Evaluator
   # UseLocalAuthStorage: true
   # XApiEnabled: false
   # DefaultScoringModelId: ""
@@ -134,4 +118,33 @@ settingsYaml:
   #   message_text: ""
   #   message_text_color: "#ffffff"
   #   message_text_fontsize: "14"
-  #   enabled: true
+  #   enabled: false
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://cite.example.com",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "cite-ui",
+#     "redirect_uri": "https://cite.example.com/auth-callback",
+#     "post_logout_redirect_uri": "https://cite.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile alloy-api player-api vm-api cite-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://cite.example.com/auth-callback-silent.html"
+#   },
+#   "AppTitle": "CITE",
+#   "AppTopBarText": "CITE",
+#   "AppTopBarHexColor": "#2d69b4",
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": false
+#   }
+# }'

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: cite.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/cite/charts/cite-ui/values.yaml
+++ b/charts/cite/charts/cite-ui/values.yaml
@@ -121,6 +121,7 @@ settingsYaml:
   #   enabled: false
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://cite.example.com",
 #   "OIDCSettings": {

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -74,7 +74,13 @@ cite-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -302,6 +302,7 @@ cite-ui:
     #   enabled: false
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://cite.example.com",
   #   "OIDCSettings": {

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -231,7 +231,7 @@ cite-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: cite.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -1,7 +1,50 @@
 cite-api:
-  # Docker image release version. Defaults to appVersion of cite-api child chart
   image:
+    repository: cmusei/cite-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,25 +71,26 @@ cite-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: cite.example.com
+      - host: chart-example.local
         paths:
-          - path: /(api|swagger/hubs)
+          - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certificates and specify
+  # the configMap name here
+  certificateMap: ""
+
+  command: ["./Cite.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -61,23 +105,10 @@ cite-api:
   # - configMapRef:
   #     name: my-configmap
 
-  # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
-  # the configMap name here
-  certificateMap: ""
-
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/crucible/blob/master/alloy.api/Alloy.Api/appsettings.json
+  # see https://github.com/cmu-sei/Cite.Api/blob/main/Cite.Api/appsettings.json
   env:
-    # Proxy Settings
-    # http_proxy: proxy.example.com:9000
-    # https_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -89,28 +120,24 @@ cite-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=cite_api;Username=cite_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
     Database__SeedFile: ""
 
-    # CORS policy settings.
-    # The first entry should be the URL to CITE
-    CorsPolicy__Origins__0: https://cite.example.com
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "cite-api"
     Authorization__ClientId: cite-api
     Authorization__ClientName: "CITE API"
@@ -148,33 +175,72 @@ cite-api:
     # Optional: override the service name reported to collectors
     # OTEL_SERVICE_NAME: cite-api
 
-  # Seed data configuration.  Documentation on seed data TBD when CITE gets open-sourced
   conf:
     seed: ""
 
 cite-ui:
-  # Docker image release version. Defaults to appVersion of cite-ui child chart
   image:
+    repository: cmusei/cite-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: cite.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the default dropdown indicator from a file in a configMap:
   #
   # extraVolumes: |
@@ -189,23 +255,20 @@ cite-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -220,9 +283,9 @@ cite-ui:
     #   automaticSilentRenew: true
     #   silent_redirect_uri: https://cite.example.com/auth-callback-silent.html
     # AppTitle: CITE
+    # AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
     # AppTopBarHexColor: "#2d69b4"
     # AppTopBarHexTextColor: "#FFFFFF"
-    # AppTopBarText: CITE  -  Collaborative Incident Threat Evaluator
     # UseLocalAuthStorage: true
     # XApiEnabled: false
     # DefaultScoringModelId: ""
@@ -237,3 +300,32 @@ cite-ui:
     #   message_text_color: "#ffffff"
     #   message_text_fontsize: "14"
     #   enabled: false
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://cite.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "cite-ui",
+  #     "redirect_uri": "https://cite.example.com/auth-callback",
+  #     "post_logout_redirect_uri": "https://cite.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile alloy-api player-api vm-api cite-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://cite.example.com/auth-callback-silent.html"
+  #   },
+  #   "AppTitle": "CITE",
+  #   "AppTopBarText": "CITE",
+  #   "AppTopBarHexColor": "#2d69b4",
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": false
+  #   }
+  # }'

--- a/charts/cite/values.yaml
+++ b/charts/cite/values.yaml
@@ -210,7 +210,7 @@ cite-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/crucible-apps/Chart.lock
+++ b/charts/crucible-apps/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: alloy
-  repository: file://../alloy
-  version: 1.8.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.7.8
 - name: blueprint
-  repository: file://../blueprint
-  version: 1.10.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.9.3
 - name: caster
-  repository: file://../caster
-  version: 1.9.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.8.9
 - name: cite
-  repository: file://../cite
-  version: 1.10.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.9.7
 - name: gallery
-  repository: file://../gallery
-  version: 1.10.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.9.7
 - name: gameboard
-  repository: file://../gameboard
-  version: 0.6.0
+  repository: https://helm.cmusei.dev/charts
+  version: 0.5.14
 - name: player
-  repository: file://../player
-  version: 1.10.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.9.13
 - name: steamfitter
-  repository: file://../steamfitter
-  version: 1.8.0
+  repository: https://helm.cmusei.dev/charts
+  version: 1.7.7
 - name: topomojo
-  repository: file://../topomojo
-  version: 0.9.0
+  repository: https://helm.cmusei.dev/charts
+  version: 0.7.1
 - name: moodle
-  repository: file://../moodle
+  repository: https://helm.cmusei.dev/charts
   version: 0.2.7
-digest: sha256:7960d8092dcd103d4946ceb1c5cf67ac480f19ee1e1acf38f2378b1297902b75
-generated: "2026-05-29T12:19:45.198685398Z"
+digest: sha256:8ccf05d336638888bf6573a9731371c1cfd6aef199d96b154f1ec148edb97b27
+generated: "2026-05-15T15:45:37.562945035Z"

--- a/charts/crucible-apps/Chart.lock
+++ b/charts/crucible-apps/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: alloy
-  repository: https://helm.cmusei.dev/charts
-  version: 1.7.8
+  repository: file://../alloy
+  version: 1.8.0
 - name: blueprint
-  repository: https://helm.cmusei.dev/charts
-  version: 1.9.3
+  repository: file://../blueprint
+  version: 1.10.0
 - name: caster
-  repository: https://helm.cmusei.dev/charts
-  version: 1.8.9
+  repository: file://../caster
+  version: 1.9.0
 - name: cite
-  repository: https://helm.cmusei.dev/charts
-  version: 1.9.7
+  repository: file://../cite
+  version: 1.10.0
 - name: gallery
-  repository: https://helm.cmusei.dev/charts
-  version: 1.9.7
+  repository: file://../gallery
+  version: 1.10.0
 - name: gameboard
-  repository: https://helm.cmusei.dev/charts
-  version: 0.5.14
+  repository: file://../gameboard
+  version: 0.6.0
 - name: player
-  repository: https://helm.cmusei.dev/charts
-  version: 1.9.13
+  repository: file://../player
+  version: 1.10.0
 - name: steamfitter
-  repository: https://helm.cmusei.dev/charts
-  version: 1.7.7
+  repository: file://../steamfitter
+  version: 1.8.0
 - name: topomojo
-  repository: https://helm.cmusei.dev/charts
-  version: 0.7.1
+  repository: file://../topomojo
+  version: 0.9.0
 - name: moodle
-  repository: https://helm.cmusei.dev/charts
+  repository: file://../moodle
   version: 0.2.7
-digest: sha256:8ccf05d336638888bf6573a9731371c1cfd6aef199d96b154f1ec148edb97b27
-generated: "2026-05-15T15:45:37.562945035Z"
+digest: sha256:7960d8092dcd103d4946ceb1c5cf67ac480f19ee1e1acf38f2378b1297902b75
+generated: "2026-05-29T12:19:45.198685398Z"

--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -8,52 +8,52 @@ home: https://cmu-sei.github.io/crucible/
 dependencies:
   # Crucible Applications
   - name: alloy
-    repository: https://helm.cmusei.dev/charts
-    version: 1.7.8
+    repository: file://../alloy
+    version: 1.8.0
     condition: alloy.enabled
 
   - name: blueprint
-    repository: https://helm.cmusei.dev/charts
-    version: 1.9.3
+    repository: file://../blueprint
+    version: 1.10.0
     condition: blueprint.enabled
 
   - name: caster
-    repository: https://helm.cmusei.dev/charts
-    version: 1.8.9
+    repository: file://../caster
+    version: 1.9.0
     condition: caster.enabled
 
   - name: cite
-    repository: https://helm.cmusei.dev/charts
-    version: 1.9.7
+    repository: file://../cite
+    version: 1.10.0
     condition: cite.enabled
 
   - name: gallery
-    repository: https://helm.cmusei.dev/charts
-    version: 1.9.7
+    repository: file://../gallery
+    version: 1.10.0
     condition: gallery.enabled
 
   - name: gameboard
-    repository: https://helm.cmusei.dev/charts
-    version: 0.5.14
+    repository: file://../gameboard
+    version: 0.6.0
     condition: gameboard.enabled
 
   - name: player
-    repository: https://helm.cmusei.dev/charts
-    version: 1.9.13
+    repository: file://../player
+    version: 1.10.0
     condition: player.enabled
 
   - name: steamfitter
-    repository: https://helm.cmusei.dev/charts
-    version: 1.7.7
+    repository: file://../steamfitter
+    version: 1.8.0
     condition: steamfitter.enabled
 
   - name: topomojo
-    repository: https://helm.cmusei.dev/charts
-    version: 0.7.1
+    repository: file://../topomojo
+    version: 0.9.0
     condition: topomojo.enabled
 
   # Moodle LMS
   - name: moodle
-    repository: https://helm.cmusei.dev/charts
+    repository: file://../moodle
     version: 0.2.7
     condition: moodle.enabled

--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -8,52 +8,52 @@ home: https://cmu-sei.github.io/crucible/
 dependencies:
   # Crucible Applications
   - name: alloy
-    repository: file://../alloy
-    version: 1.8.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.7.8
     condition: alloy.enabled
 
   - name: blueprint
-    repository: file://../blueprint
-    version: 1.10.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.9.3
     condition: blueprint.enabled
 
   - name: caster
-    repository: file://../caster
-    version: 1.9.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.8.9
     condition: caster.enabled
 
   - name: cite
-    repository: file://../cite
-    version: 1.10.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.9.7
     condition: cite.enabled
 
   - name: gallery
-    repository: file://../gallery
-    version: 1.10.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.9.7
     condition: gallery.enabled
 
   - name: gameboard
-    repository: file://../gameboard
-    version: 0.6.0
+    repository: https://helm.cmusei.dev/charts
+    version: 0.5.14
     condition: gameboard.enabled
 
   - name: player
-    repository: file://../player
-    version: 1.10.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.9.13
     condition: player.enabled
 
   - name: steamfitter
-    repository: file://../steamfitter
-    version: 1.8.0
+    repository: https://helm.cmusei.dev/charts
+    version: 1.7.7
     condition: steamfitter.enabled
 
   - name: topomojo
-    repository: file://../topomojo
-    version: 0.9.0
+    repository: https://helm.cmusei.dev/charts
+    version: 0.7.1
     condition: topomojo.enabled
 
   # Moodle LMS
   - name: moodle
-    repository: file://../moodle
+    repository: https://helm.cmusei.dev/charts
     version: 0.2.7
     condition: moodle.enabled

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -3,7 +3,7 @@ name: gallery
 description: Gallery enables participants to review cyber incident data by source
   type.
 type: application
-version: 1.9.9
+version: 1.10.0
 home: https://cmu-sei.github.io/crucible/gallery/
 sources:
 - https://github.com/cmu-sei/Gallery.Api/

--- a/charts/gallery/Chart.yaml
+++ b/charts/gallery/Chart.yaml
@@ -3,7 +3,7 @@ name: gallery
 description: Gallery enables participants to review cyber incident data by source
   type.
 type: application
-version: 1.9.8
+version: 1.9.9
 home: https://cmu-sei.github.io/crucible/gallery/
 sources:
 - https://github.com/cmu-sei/Gallery.Api/

--- a/charts/gallery/README.md
+++ b/charts/gallery/README.md
@@ -70,16 +70,38 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 | `ClaimsTransformation__EnableCaching` | Enable claims caching | `true` |
 | `ClaimsTransformation__CacheExpirationSeconds` | Claims cache expiration in seconds | `60` |
 
-### CORS Policy
+### CORS Policy Settings
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://gallery.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
+
+### xAPI Settings
+
+Gallery API supports sending [xAPI](https://xapi.com/) (Experience API) statements to a Learning Record Store (LRS). Configure the options below to enable this integration.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `XApiOptions__Enabled` | Enable xAPI statement recording | `false` |
+| `XApiOptions__Endpoint` | LRS xAPI endpoint URL | `""` |
+| `XApiOptions__Username` | LRS basic-auth username | `""` |
+| `XApiOptions__Password` | LRS basic-auth password | `""` |
+| `XApiOptions__IssuerUrl` | OIDC issuer URL used to build actor identifiers | `""` |
+| `XApiOptions__ApiUrl` | Gallery API base URL (used in statement context) | `""` |
+| `XApiOptions__UiUrl` | Gallery UI base URL (used in statement context) | `""` |
+| `XApiOptions__EmailDomain` | Email domain appended to usernames for actor mbox | `""` |
+| `XApiOptions__Platform` | Platform name reported in xAPI statements | `Gallery` |
+| `XApiOptions__RetentionDays` | Number of days to retain processed xAPI records | `7` |
+| `XApiOptions__ProcessingTimeoutMinutes` | Minutes before an in-progress statement times out | `10` |
+| `XApiOptions__ProcessingDelaySeconds` | Seconds to wait between processing batches | `30` |
 
 ### Certificate Trust
 
@@ -184,6 +206,16 @@ gallery-api:
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+The ServiceDefaults-specific toggles are documented in the table below.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Register the AlwaysOn sampler (traces every request) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export telemetry to stdout (useful for debugging) | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` Prometheus scrape endpoint | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the standard Crucible activity sources for tracing | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the standard Crucible meters for metrics | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/gallery/README.md
+++ b/charts/gallery/README.md
@@ -185,7 +185,7 @@ gallery-api:
 
 ### OpenTelemetry
 
-Gagllery.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for Gallery to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
+Gallery.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for Gallery to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
 
 ```yaml
 gallery-api:
@@ -207,15 +207,13 @@ gallery-api:
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
 
-The ServiceDefaults-specific toggles are documented in the table below.
-
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `OpenTelemetry__AddAlwaysOnTracingSampler` | Register the AlwaysOn sampler (traces every request) | `false` |
-| `OpenTelemetry__AddConsoleExporter` | Export telemetry to stdout (useful for debugging) | `false` |
-| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` Prometheus scrape endpoint | `false` |
-| `OpenTelemetry__IncludeDefaultActivitySources` | Register the standard Crucible activity sources for tracing | `true` |
-| `OpenTelemetry__IncludeDefaultMeters` | Register the standard Crucible meters for metrics | `true` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/gallery/charts/gallery-api/Chart.yaml
+++ b/charts/gallery/charts/gallery-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gallery-api
 type: application
-version: 1.8.9
+version: 1.9.0
 appVersion: 1.10.7

--- a/charts/gallery/charts/gallery-api/values.yaml
+++ b/charts/gallery/charts/gallery-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/gallery/charts/gallery-api/values.yaml
+++ b/charts/gallery/charts/gallery-api/values.yaml
@@ -1,7 +1,3 @@
-# Default values for gallery-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/gallery-api
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,7 +27,23 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -64,41 +71,21 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
 
@@ -117,15 +104,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# env is pod env vars
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Gallery.Api/blob/main/Gallery.Api/appsettings.json
 env:
-  # http_proxy: ""
-  # https_proxy: ""
-  # HTTP_PROXY: ""
-  # HTTPS_PROXY: ""
-  # NO_PROXY: ""
-  # no_proxy: ""
-
   Logging__IncludeScopes: false
   Logging__Debug__LogLevel__Default: Warning
   Logging__Debug__LogLevel__Microsoft: Warning
@@ -141,9 +123,9 @@ env:
   Database__Provider: PostgreSQL
   Database__SeedFile: seed-data.json
 
-  CorsPolicy__Origins__0: ""
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true

--- a/charts/gallery/charts/gallery-ui/Chart.yaml
+++ b/charts/gallery/charts/gallery-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gallery-ui
 type: application
-version: 1.8.3
+version: 1.9.0
 appVersion: 1.10.2

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: gallery.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -119,6 +119,7 @@ settingsYaml:
   #   enabled: false
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://gallery.example.com",
 #   "OIDCSettings": {

--- a/charts/gallery/charts/gallery-ui/values.yaml
+++ b/charts/gallery/charts/gallery-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for gallery-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/gallery-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: gallery.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the dropdown indicator from a file in a configMap:
 #
 # extraVolumes: |
@@ -87,19 +74,75 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
+# env is pod env vars
+env:
+  ## basehref is path to the app
+  APP_BASEHREF: ""
 
 ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
 ## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
+## app's assets/config/ directory alongside settings.json so the app can
 ## load shared UI configuration that is common across multiple Crucible services.
 ## Per-app values can still be overridden via settingsYaml.
 sharedSettingsConfigMap: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
-
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-settingsYaml: {}
+settingsYaml:
+  # ApiUrl: https://gallery.example.com
+  # OIDCSettings:
+  #   authority: https://identity.example.com/
+  #   client_id: gallery-ui
+  #   redirect_uri: https://gallery.example.com/auth-callback
+  #   post_logout_redirect_uri: https://gallery.example.com
+  #   response_type: code
+  #   scope: openid profile gallery
+  #   automaticSilentRenew: true
+  #   silent_redirect_uri: https://gallery.example.com/auth-callback-silent.html
+  # AppTitle: Gallery
+  # AppTopBarText: Gallery  -  Exercise Information Sharing
+  # AppTopBarHexColor: "#2d69b4"
+  # AppTopBarHexTextColor: "#FFFFFF"
+  # AppTopBarImage: /assets/img/monitor-dashboard-white.png
+  # UseLocalAuthStorage: true
+  # XApiEnabled: false
+  # HeaderBarSettings:
+  #   banner_background_color: "#d40000ff"
+  #   classification_text: ""
+  #   classification_text_color: "#ffffff"
+  #   classification_text_fontsize: "14"
+  #   message_text: ""
+  #   message_text_color: "#ffffff"
+  #   message_text_fontsize: "14"
+  #   enabled: false
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://gallery.example.com",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "gallery-ui",
+#     "redirect_uri": "https://gallery.example.com/auth-callback",
+#     "post_logout_redirect_uri": "https://gallery.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile gallery",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://gallery.example.com/auth-callback-silent.html"
+#   },
+#   "AppTitle": "Gallery",
+#   "AppTopBarText": "Gallery",
+#   "AppTopBarHexColor": "#2d69b4",
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": false
+#   }
+# }'

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -225,7 +225,7 @@ gallery-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: gallery.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -294,6 +294,7 @@ gallery-ui:
     #   enabled: false
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://gallery.example.com",
   #   "OIDCSettings": {

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -74,7 +74,13 @@ gallery-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -1,7 +1,50 @@
 gallery-api:
-  # Docker image release version. Defaults to appVersion of gallery-api child chart
   image:
+    repository: cmusei/gallery-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,25 +71,26 @@ gallery-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: gallery.example.com
+      - host: chart-example.local
         paths:
-          - path: /(api|swagger/hubs)
+          - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certificates and specify
+  # the configMap name here
+  certificateMap: ""
+
+  command: ["./Gallery.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -61,11 +105,9 @@ gallery-api:
   # - configMapRef:
   #     name: my-configmap
 
-  # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
-  # the configMap name here
-  certificateMap: ""
-
+  # Config app settings with environment vars.
+  # Those most likely needing values are listed. For others,
+  # see https://github.com/cmu-sei/Gallery.Api/blob/main/Gallery.Api/appsettings.json
   env:
     Logging__IncludeScopes: false
     Logging__Debug__LogLevel__Default: Warning
@@ -75,31 +117,27 @@ gallery-api:
     Logging__Console__LogLevel__Microsoft: Warning
     Logging__Console__LogLevel__System: Warning
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=gallery_api;Username=gallery_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
     Database__SeedFile: seed-data.json
 
-    # CORS policy settings.
-    # The first entry should be the URL to Gallery
-    CorsPolicy__Origins__0: https://gallery.example.com
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
-    Authorization__AuthorizationScope: gallery
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
+    Authorization__AuthorizationScope: "gallery"
     Authorization__ClientId: gallery.swagger
-    Authorization__ClientName: Gallery API Swagger
+    Authorization__ClientName: "Gallery API Swagger"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
@@ -135,28 +173,68 @@ gallery-api:
     # OTEL_SERVICE_NAME: gallery-api
 
 gallery-ui:
-  # Docker image release version. Defaults to appVersion of gallery-ui child chart
   image:
+    repository: cmusei/gallery-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: gallery.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the dropdown indicator from a file in a configMap:
   #
   # extraVolumes: |
@@ -171,21 +249,20 @@ gallery-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
+  # env is pod env vars
+  env:
+    ## basehref is path to the app
+    APP_BASEHREF: ""
 
   ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
   ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
+  ## app's assets/config/ directory alongside settings.json so the app can
   ## load shared UI configuration that is common across multiple Crucible services.
   ## Per-app values can still be overridden via settingsYaml.
   sharedSettingsConfigMap: ""
-
-  env:
-
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -200,9 +277,9 @@ gallery-ui:
     #   automaticSilentRenew: true
     #   silent_redirect_uri: https://gallery.example.com/auth-callback-silent.html
     # AppTitle: Gallery
+    # AppTopBarText: Gallery  -  Exercise Information Sharing
     # AppTopBarHexColor: "#2d69b4"
     # AppTopBarHexTextColor: "#FFFFFF"
-    # AppTopBarText: Gallery  -  Exercise Information Sharing
     # AppTopBarImage: /assets/img/monitor-dashboard-white.png
     # UseLocalAuthStorage: true
     # XApiEnabled: false
@@ -215,3 +292,32 @@ gallery-ui:
     #   message_text_color: "#ffffff"
     #   message_text_fontsize: "14"
     #   enabled: false
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://gallery.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "gallery-ui",
+  #     "redirect_uri": "https://gallery.example.com/auth-callback",
+  #     "post_logout_redirect_uri": "https://gallery.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile gallery",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://gallery.example.com/auth-callback-silent.html"
+  #   },
+  #   "AppTitle": "Gallery",
+  #   "AppTopBarText": "Gallery",
+  #   "AppTopBarHexColor": "#2d69b4",
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": false
+  #   }
+  # }'

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -61,6 +61,11 @@ gallery-api:
   # - configMapRef:
   #     name: my-configmap
 
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certifcates and specify
+  # the configMap name here
+  certificateMap: ""
+
   env:
     Logging__IncludeScopes: false
     Logging__Debug__LogLevel__Default: Warning

--- a/charts/gallery/values.yaml
+++ b/charts/gallery/values.yaml
@@ -204,7 +204,7 @@ gallery-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -3,7 +3,7 @@ name: gameboard
 description: Gameboard provides a competition-ready user interface for running cybersecurity
   games and challenges.
 type: application
-version: 0.5.15
+version: 0.6.0
 home: https://cmu-sei.github.io/crucible/gameboard/
 sources:
 - https://github.com/cmu-sei/Gameboard/

--- a/charts/gameboard/Chart.yaml
+++ b/charts/gameboard/Chart.yaml
@@ -3,7 +3,7 @@ name: gameboard
 description: Gameboard provides a competition-ready user interface for running cybersecurity
   games and challenges.
 type: application
-version: 0.5.14
+version: 0.5.15
 home: https://cmu-sei.github.io/crucible/gameboard/
 sources:
 - https://github.com/cmu-sei/Gameboard/

--- a/charts/gameboard/README.md
+++ b/charts/gameboard/README.md
@@ -214,19 +214,12 @@ gameboard-api:
       nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
       nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
+      nginx.ingress.kubernetes.io/use-regex: "true"
 
     hosts:
       - host: gameboard.example.com
         paths:
-          - path: /gb/api
-            pathType: ImplementationSpecific
-          - path: /gb/hub
-            pathType: ImplementationSpecific
-          - path: /gb/img
-            pathType: ImplementationSpecific
-          - path: /gb/docs
-            pathType: ImplementationSpecific
-          - path: /gb/supportfiles
+          - path: /gb/(api|hub|img|docs|supportfiles)
             pathType: ImplementationSpecific
     tls:
       - secretName: tls-secret-name # this tls secret should already exist

--- a/charts/gameboard/README.md
+++ b/charts/gameboard/README.md
@@ -117,6 +117,48 @@ gameboard-api:
   certificateMap: "custom-ca-certs"
 ```
 
+### HTTP Headers Configuration
+
+Control CORS, forwarding, and security response headers for the API.
+
+#### CORS
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Headers__LogHeaders` | Log incoming request headers for debugging | `false` |
+| `Headers__Cors__Origins__0` | First allowed CORS origin | `""` |
+| `Headers__Cors__Methods__0` | Allowed HTTP method | `""` |
+| `Headers__Cors__Headers__0` | Allowed request header | `""` |
+| `Headers__Cors__AllowAnyOrigin` | Allow requests from any origin | `false` |
+| `Headers__Cors__AllowAnyMethod` | Allow any HTTP method | `false` |
+| `Headers__Cors__AllowAnyHeader` | Allow any request header | `false` |
+| `Headers__Cors__AllowCredentials` | Allow credentials (cookies, auth headers) in cross-origin requests | `false` |
+
+**Note:** Additional origins can be added using the pattern `Headers__Cors__Origins__1`, `Headers__Cors__Origins__2`, etc. The same indexed pattern applies to `Headers__Cors__Methods__*` and `Headers__Cors__Headers__*`.
+
+#### Forwarded Headers
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Headers__Forwarding__ForwardLimit` | Number of proxy hops to trust | `1` |
+| `Headers__Forwarding__TargetHeaders` | Which forwarded headers to process (e.g. `All`) | `None` |
+| `Headers__Forwarding__KnownNetworks` | Space-separated CIDR ranges of trusted upstream networks | `10.0.0.0/8 172.16.0.0/12 192.168.0.0/24 ::ffff:a00:0/104 ::ffff:b00a:0/108 ::ffff:c0d0:0/120` |
+| `Headers__Forwarding__KnownProxies` | Space-separated IP addresses of trusted proxies | `::1` |
+
+#### Security Headers
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Headers__Security__ContentSecurity` | `Content-Security-Policy` header value | `default-src 'self' 'unsafe-inline'; img-src data: 'self'` |
+| `Headers__Security__XContentType` | `X-Content-Type-Options` header value | `nosniff` |
+| `Headers__Security__XFrame` | `X-Frame-Options` header value | `SAMEORIGIN` |
+
+### Logging
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Logging__MinimumLogLevel` | Minimum log level for the application (`Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`) | `Information` |
+
 ### Existing Secret
 
 Reference a Kubernetes Secret whose key/value pairs will be injected as environment variables into the API container. This is the simplest way to supply sensitive configuration (e.g., database passwords) from a pre-existing secret.
@@ -225,6 +267,8 @@ Use `settingsYaml` to configure settings for the Angular UI application.
 | `appname` | Application display name shown in the UI and browser title. | `Gameboard` |
 | `apphost` | Base URL for the Gameboard application | `/gb` |
 | `tochost` | URL for table of contents/static markdown docs | `/gb/docs` |
+| `tocfile` | Filename of the table of contents document to load from `tochost` | `""` (empty — uses default) |
+| `countdownStartSecondsAtMinute` | Minute threshold (in seconds) at which the session countdown timer begins flashing to warn users | `5` |
 | `custom_background` | Set the background color to a custom color | `custom-bg-black` |
 | `unityclienthost` | Set the Unity Client Host for "External" game types that use a Unity game client (e.g., [Cubespace](https://github.com/cmu-sei/cubespace/)) | `https://gameboard.example.com/cubespace` |
 | `oidc.client_id` | The OIDC client identifier used when authenticating the UI with the identity provider. | `gameboard-ui` |

--- a/charts/gameboard/README.md
+++ b/charts/gameboard/README.md
@@ -117,24 +117,28 @@ gameboard-api:
   certificateMap: "custom-ca-certs"
 ```
 
+### CORS Policy Settings
+
+Gameboard uses `Headers__Cors__*` settings rather than the `CorsPolicy__*` prefix used by other Crucible applications, but the behavior is equivalent.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Headers__Cors__Origins__0` | First allowed CORS origin | `""` |
+| `Headers__Cors__Methods__0` | Allowed HTTP method | `""` |
+| `Headers__Cors__Headers__0` | Allowed request header | `""` |
+| `Headers__Cors__AllowCredentials` | Allow credentials (cookies, auth headers) in cross-origin requests | `false` |
+
+**Note:** Additional origins can be added using the pattern `Headers__Cors__Origins__1`, `Headers__Cors__Origins__2`, etc. The same indexed pattern applies to `Headers__Cors__Methods__*` and `Headers__Cors__Headers__*`. Setting any entry to `"*"` enables the corresponding allow-any behavior.
+
 ### HTTP Headers Configuration
 
-Control CORS, forwarding, and security response headers for the API.
+Control forwarding and security response headers for the API.
 
-#### CORS
+#### Header Logging
 
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `Headers__LogHeaders` | Log incoming request headers for debugging | `false` |
-| `Headers__Cors__Origins__0` | First allowed CORS origin | `""` |
-| `Headers__Cors__Methods__0` | Allowed HTTP method | `""` |
-| `Headers__Cors__Headers__0` | Allowed request header | `""` |
-| `Headers__Cors__AllowAnyOrigin` | Allow requests from any origin | `false` |
-| `Headers__Cors__AllowAnyMethod` | Allow any HTTP method | `false` |
-| `Headers__Cors__AllowAnyHeader` | Allow any request header | `false` |
-| `Headers__Cors__AllowCredentials` | Allow credentials (cookies, auth headers) in cross-origin requests | `false` |
-
-**Note:** Additional origins can be added using the pattern `Headers__Cors__Origins__1`, `Headers__Cors__Origins__2`, etc. The same indexed pattern applies to `Headers__Cors__Methods__*` and `Headers__Cors__Headers__*`.
 
 #### Forwarded Headers
 

--- a/charts/gameboard/README.md
+++ b/charts/gameboard/README.md
@@ -117,6 +117,15 @@ gameboard-api:
   certificateMap: "custom-ca-certs"
 ```
 
+### Existing Secret
+
+Reference a Kubernetes Secret whose key/value pairs will be injected as environment variables into the API container. This is the simplest way to supply sensitive configuration (e.g., database passwords) from a pre-existing secret.
+
+```yaml
+gameboard-api:
+  existingSecret: "gameboard-api-secret"
+```
+
 ### Extra Environment Sources
 
 Inject additional environment variables into the API container from existing Kubernetes Secrets or ConfigMaps using `extraEnvFrom`. This is useful for integrating with external secret managers such as AWS Secrets Manager (via the [External Secrets Operator](https://external-secrets.io/)) or HashiCorp Vault.

--- a/charts/gameboard/charts/gameboard-api/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gameboard-api
 type: application
-version: 0.5.12
+version: 0.6.0
 appVersion: 3.35.1

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -66,7 +66,7 @@ ingress:
   hosts:
     - host: chart-example.local
       paths:
-        - path: /(api|hub|img|docs)
+        - path: /(api|hub|img|docs|supportfiles)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -1,6 +1,3 @@
-# Default values for gameboard-api.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/gameboard-api
   pullPolicy: IfNotPresent
@@ -12,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -37,25 +29,21 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /api
-          pathType: ImplementationSpecific
-        - path: /hub
-          pathType: ImplementationSpecific
-        - path: /img
-          pathType: ImplementationSpecific
-        - path: /docs
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 200m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 health: {}
   # livenessProbe:
@@ -71,6 +59,25 @@ health: {}
   #   failureThreshold: 9
   #   periodSeconds: 10
 
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /(api|hub|img|docs)
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# If this deployment needs to trust non-public certificates,
+# create a configMap with the needed certificates and specify
+# the configMap name here
+certificateMap: ""
+
 # storage - either an existing pvc, the size for a new pvc, or emptyDir
 storage:
   existing: ""
@@ -78,23 +85,17 @@ storage:
   mode: ReadWriteOnce
   class: default
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 200m
-  #   memory: 512Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 256Mi
+# cacert - add custom CA certificate in-line
+# cacert: |-
+#   -----BEGIN CERTIFICATE-----
+#   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
+#   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
+#   …
+#   -----END CERTIFICATE-----
 
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
+# cacertSecret - Trust a custom CA certificate in an existing Secret
+cacertSecret: ""
+cacertSecretKey: ca.crt
 
 ## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
@@ -109,21 +110,9 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# cacert - add custom CA certificate in-line
-# cacert: |-
-#   -----BEGIN CERTIFICATE-----
-#   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
-#   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
-#   …
-#   -----END CERTIFICATE-----
-
-# cacertSecret - Trust a custom CA certificate in an existing Secret
-cacertSecret: ""
-cacertSecretKey: ca.crt
-
 # Config app settings with environment vars.
 # Those most likely needing values are listed. For others,
-# see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf
+# see https://github.com/cmu-sei/gameboard/blob/main/src/Gameboard.Api/appsettings.conf
 env: {}
   ####################################################
   ## CORE (behavior)

--- a/charts/gameboard/charts/gameboard-api/values.yaml
+++ b/charts/gameboard/charts/gameboard-api/values.yaml
@@ -62,7 +62,13 @@ health: {}
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/gameboard/charts/gameboard-ui/Chart.yaml
+++ b/charts/gameboard/charts/gameboard-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: gameboard-ui
 type: application
-version: 0.5.12
+version: 0.6.0
 appVersion: 3.35.2

--- a/charts/gameboard/charts/gameboard-ui/values.yaml
+++ b/charts/gameboard/charts/gameboard-ui/values.yaml
@@ -1,6 +1,3 @@
-# Default values for gameboard-ui.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/gameboard-ui
   pullPolicy: IfNotPresent
@@ -12,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,20 +28,6 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -64,10 +42,22 @@ resources: {}
   #   memory: 10Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## basehref is path to the app
 basehref: ""

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -67,7 +67,7 @@ gameboard-api:
     hosts:
       - host: chart-example.local
         paths:
-          - path: /(api|hub|img|docs)
+          - path: /(api|hub|img|docs|supportfiles)
             pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -197,6 +197,7 @@ gameboard-api:
     # Oidc__Authority: http://localhost:8080/realms/foundry
     # Oidc__DefaultUserNameInferFromEmail: false
     # Oidc__StoreUserEmails: false
+
     # Oidc__UserRolesClaimMap__administrator: Admin
     # Oidc__UserRolesClaimMap__director: Director
     # Oidc__UserRolesClaimMap__member: Member
@@ -213,7 +214,6 @@ gameboard-api:
 
 gameboard-ui:
   # Default values for gameboard-ui.
-  # This is a YAML-formatted file.
   # Declare variables to be passed into your templates.
 
   image:

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -1,7 +1,4 @@
 gameboard-api:
-  # Default values for gameboard-api.
-  # Declare variables to be passed into your templates.
-
   image:
     repository: cmusei/gameboard-api
     pullPolicy: IfNotPresent
@@ -13,19 +10,14 @@ gameboard-api:
   fullnameOverride: ""
 
   serviceAccount:
-    # Specifies whether a service account should be created
     create: true
-    # Annotations to add to the service account
     annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
     name: ""
 
   podAnnotations: {}
-
   podSecurityContext: {}
-    # fsGroup: 2000
-
   securityContext: {}
     # capabilities:
     #   drop:
@@ -38,25 +30,21 @@ gameboard-api:
     type: ClusterIP
     port: 80
 
-  ingress:
-    enabled: false
-    className: ""
-    annotations: {}
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /api
-            pathType: ImplementationSpecific
-          - path: /hub
-            pathType: ImplementationSpecific
-          - path: /img
-            pathType: ImplementationSpecific
-          - path: /docs
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   health: {}
     # livenessProbe:
@@ -72,6 +60,25 @@ gameboard-api:
     #   failureThreshold: 9
     #   periodSeconds: 10
 
+  ingress:
+    enabled: true
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /(api|hub|img|docs)
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certificates and specify
+  # the configMap name here
+  certificateMap: ""
+
   # storage - either an existing pvc, the size for a new pvc, or emptyDir
   storage:
     existing: ""
@@ -79,23 +86,17 @@ gameboard-api:
     mode: ReadWriteOnce
     class: default
 
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 200m
-    #   memory: 512Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 256Mi
+  # cacert - add custom CA certificate in-line
+  # cacert: |-
+  #   -----BEGIN CERTIFICATE-----
+  #   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
+  #   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
+  #   …
+  #   -----END CERTIFICATE-----
 
-  nodeSelector: {}
-
-  tolerations: []
-
-  affinity: {}
+  # cacertSecret - Trust a custom CA certificate in an existing Secret
+  cacertSecret: ""
+  cacertSecretKey: ca.crt
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -110,21 +111,9 @@ gameboard-api:
   # - configMapRef:
   #     name: my-configmap
 
-  # cacert - add custom CA certificate in-line
-  # cacert: |-
-  #   -----BEGIN CERTIFICATE-----
-  #   MIIDGDCCAgCgAwIBAgIUPO57TE7AQJRsMEtzii2SYwZ9TRIwDQYJKoZIhvcNAQEL
-  #   BQAwJDEiMCAGA1UEAxMZRm91bmRyeSBBcHBsaWFuY2UgUm9vdCBDQTAeFw0yMTAz
-  #   …
-  #   -----END CERTIFICATE-----
-
-  # cacertSecret - Trust a custom CA certificate in an existing Secret
-  cacertSecret: ""
-  cacertSecretKey: ca.crt
-
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/gameboard/blob/master/src/Gameboard.Api/appsettings.conf
+  # see https://github.com/cmu-sei/gameboard/blob/main/src/Gameboard.Api/appsettings.conf
   env: {}
     ####################################################
     ## CORE (behavior)
@@ -213,9 +202,6 @@ gameboard-api:
   pollInterval: 5
 
 gameboard-ui:
-  # Default values for gameboard-ui.
-  # Declare variables to be passed into your templates.
-
   image:
     repository: cmusei/gameboard-ui
     pullPolicy: IfNotPresent
@@ -227,19 +213,14 @@ gameboard-ui:
   fullnameOverride: ""
 
   serviceAccount:
-    # Specifies whether a service account should be created
     create: true
-    # Annotations to add to the service account
     annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
     name: ""
 
   podAnnotations: {}
-
   podSecurityContext: {}
-    # fsGroup: 2000
-
   securityContext: {}
     # capabilities:
     #   drop:
@@ -251,20 +232,6 @@ gameboard-ui:
   service:
     type: ClusterIP
     port: 80
-
-  ingress:
-    enabled: false
-    className: ""
-    annotations: {}
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -279,10 +246,22 @@ gameboard-ui:
     #   memory: 10Mi
 
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
+
+  ingress:
+    enabled: true
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   ## basehref is path to the app
   basehref: ""

--- a/charts/gameboard/values.yaml
+++ b/charts/gameboard/values.yaml
@@ -63,7 +63,13 @@ gameboard-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.9.16
+version: 1.10.0
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.9.15
+version: 1.9.16
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -586,6 +586,26 @@ Use `settingsYaml` to configure settings for the Angular UI application.
 | `UseLocalAuthStorage` | Whether authentication state is stored locally in browser    | `true`                                              |
 | `VmResolutionOptions` | List of width/height configurations for allowable display resolutions | `- width: 1920`<br>`  height: 1200`<br>`- width: 16280`<br>`  height: 1024` |
 
+### PasteSpeeds
+
+Controls the paste speed options available in the Console UI send-text dialog. Each entry has a `name` (display label) and `value` (delay in milliseconds between keystrokes).
+
+```yaml
+console-ui:
+  settingsYaml:
+    PasteSpeeds:
+      - name: Fastest
+        value: 10
+      - name: Fast
+        value: 30
+      - name: Normal
+        value: 60
+      - name: Slow
+        value: 100
+      - name: Slowest
+        value: 500
+```
+
 ## Shared Settings ConfigMap
 
 `sharedSettingsConfigMap` mounts a pre-existing Kubernetes ConfigMap as `settings.shared.json` into the Angular app's `assets/config/` directory alongside `settings.env.json`. This is intended for UI configuration values that are consistent across several Crucible applications, so the values only need to be defined in one place. Any value in the shared file can be overridden per-application using `settingsYaml`. Each Player UI application (player-ui, vm-ui, console-ui) can be configured independently.

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -258,6 +258,14 @@ player-api:
     # OTEL_SERVICE_NAME: player-api
 ```
 
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
+
 #### Custom metrics from Player
 - Meter: `player_view_users`
 - Gauge: `player_view_active_users` (current active users)

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -123,7 +123,7 @@ Add CORS origins to allow bidirectional communication between Player and the int
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
 
-Add more origins with `__3`, `__4`, etc.
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__3`, `CorsPolicy__Origins__4`, etc.
 
 ### Notifications
 
@@ -472,7 +472,7 @@ vm-api:
 | `IsoUpload__BasePath` | ISO upload base path | `"/app/isos/player"` |
 | `IsoUpload_MaxFileSize` | ISO upload max file size | `6000000000` |
 
-#### CORS
+#### CORS Policy Settings
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
@@ -484,6 +484,8 @@ vm-api:
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__2`, `CorsPolicy__Origins__3`, etc.
 
 ### Health Probes
 

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.8.3
+version: 1.9.0
 appVersion: 3.4.2

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -151,6 +151,7 @@ settingsYaml:
   #   enabled: true
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ConsoleApiUrl": "https://vm.example.com/api/",
 #   "OIDCSettings": {

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: console.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/player/charts/console-ui/values.yaml
+++ b/charts/player/charts/console-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for console-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/vm-console-ui
   pullPolicy: IfNotPresent
@@ -13,22 +9,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
-podSecurityContext:
-  {}
-  # fsGroup: 2000
-
-securityContext:
-  {}
+podSecurityContext: {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -40,25 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources:
-  {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -71,12 +42,24 @@ resources:
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: console.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
 #
 # extraVolumes: |
@@ -91,36 +74,33 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
-
-## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
-## load shared UI configuration that is common across multiple Crucible services.
-## Per-app values can still be overridden via settingsYaml.
-sharedSettingsConfigMap: ""
-
+# env is pod env vars
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+## settings.shared.json key. When set, the file is mounted into the Angular
+## app's assets/config/ directory alongside settings.json so the app can
+## load shared UI configuration that is common across multiple Crucible services.
+## Per-app values can still be overridden via settingsYaml.
+sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ConsoleApiUrl: https://example.com/vm/api
+  # ConsoleApiUrl: https://vm.example.com/api/
   # OIDCSettings:
-  #   authority: https://example.com/identity
-  #   client_id: vm-console-ui
-  #   redirect_uri: https://example.com/console/auth-callback
-  #   post_logout_redirect_uri: https://example.com/console
+  #   authority: https://identity.example.com/
+  #   client_id: vm-console-ui-dev
+  #   redirect_uri: https://console.example.com/auth-callback/
+  #   post_logout_redirect_uri: https://console.example.com
   #   response_type: code
-  #   scope: openid profile player-api vm-api
+  #   scope: openid profile player-api vm-api vm-console-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: https://example.com/console/auth-callback-silent.html
+  #   silent_redirect_uri: https://console.example.com/auth-callback-silent.html
   # UseLocalAuthStorage: true
   # VmResolutionOptions:
   #   - width: 2560
@@ -160,3 +140,38 @@ settingsYaml:
   #     value: 100
   #   - name: Slowest
   #     value: 500
+  # HeaderBarSettings:
+  #   banner_background_color: "#d40000ff"
+  #   classification_text: ""
+  #   classification_text_color: "#ffffff"
+  #   classification_text_fontsize: "14"
+  #   message_text: ""
+  #   message_text_color: "#ffffff"
+  #   message_text_fontsize: "14"
+  #   enabled: true
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ConsoleApiUrl": "https://vm.example.com/api/",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "vm-console-ui-dev",
+#     "redirect_uri": "https://console.example.com/auth-callback/",
+#     "post_logout_redirect_uri": "https://console.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile player-api vm-api vm-console-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://console.example.com/auth-callback-silent.html"
+#   },
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": true
+#   }
+# }'

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-api
 type: application
-version: 1.8.11
+version: 1.9.0
 appVersion: 3.5.7

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -1,8 +1,3 @@
-# Default values for player-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-kind: "Deployment"
 image:
   repository: cmusei/player-api
   pullPolicy: IfNotPresent
@@ -14,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,6 +28,24 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+kind: "Deployment"
 
 probes:
   livenessProbe:
@@ -65,15 +73,13 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -81,36 +87,19 @@ ingress:
   #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
-command: ["./Player.Api"]
-
 # storage - either an existing pvc, the size for a new pvc, or emptyDir
+# this is used to store uploaded files
 storage:
   existing: ""
   size: ""
   mode: ReadWriteOnce
   class: default
+
+command: ["./Player.Api"]
 
 ## existingSecret references a secret already in k8s.
 ## The key/value pairs in the secret are added as environment variables.
@@ -125,15 +114,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# env is pod env vars
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Player.Api/blob/main/Player.Api/appsettings.json
 env:
-  # http_proxy: ""
-  # https_proxy: ""
-  # HTTP_PROXY: ""
-  # HTTPS_PROXY: ""
-  # NO_PROXY: ""
-  # no_proxy: ""
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
@@ -153,9 +137,9 @@ env:
   Database__DevModeRecreate: false
   Database__Provider: PostgreSQL
 
-  CorsPolicy__Origins__0: ""
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true
@@ -187,6 +171,29 @@ env:
   FileUpload__allowedExtensions__5: ".docx"
   FileUpload__allowedExtensions__6: ".gif"
   FileUpload__allowedExtensions__7: ".txt"
+
+  # Basic seed data to jumpstart deployment
+  # This is a placeholder and needs to be updated for a new install.
+  # Upgrades should keep administrators from the previous install.
+
+  # SeedData__Permissions__0__Name: "Demo Permission"
+  # SeedData__Permissions__0__Description: "This is a demo permission"
+
+  # SeedData__Roles__0__Name: "Demo Role"
+  # SeedData__Roles__0__AllPermissions: false
+  # SeedData__Roles__0__Permissions__0: "Demo Permission"
+
+  # SeedData__TeamPermissions__0__Name: "Demo Team Permission"
+  # SeedData__TeamPermissions__0__Description: "Demo Team Permission"
+
+  # SeedData__TeamRoles__0__Name: "Demo Team Role Name"
+  # SeedData__TeamRoles__0__AllPermissions: false
+  # SeedData__TeamRoles__0__Permissions__0: "Demo Team Permission"
+  # SeedData__TeamRoles__0__Permissions__1: "ManageTeam"
+
+  # SeedData__Users__0__Id: "2d977dea-678f-4e99-98ef-a8c59ec0fdc9"
+  # SeedData__Users__0__Name: "Seed User"
+  # SeedData__Users__0__Role: "Demo Role"
 
   XApiOptions__Enabled: false
   XApiOptions__Endpoint: ""

--- a/charts/player/charts/player-api/values.yaml
+++ b/charts/player/charts/player-api/values.yaml
@@ -75,7 +75,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-ui
 type: application
-version: 1.8.7
+version: 1.9.0
 appVersion: 3.4.5

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -121,6 +121,7 @@ settingsYaml:
   #   enabled: true
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://player.example.com",
 #   "OIDCSettings": {

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: player.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/player/charts/player-ui/values.yaml
+++ b/charts/player/charts/player-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for player-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/player-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: player.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
 #
 # extraVolumes: |
@@ -87,38 +74,35 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
-
-## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
-## load shared UI configuration that is common across multiple Crucible services.
-## Per-app values can still be overridden via settingsYaml.
-sharedSettingsConfigMap: ""
-
+# env is pod env vars
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+## settings.shared.json key. When set, the file is mounted into the Angular
+## app's assets/config/ directory alongside settings.json so the app can
+## load shared UI configuration that is common across multiple Crucible services.
+## Per-app values can still be overridden via settingsYaml.
+sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: https://example.com/player
+  # ApiUrl: https://player.example.com
   # OIDCSettings:
-  #   authority: https://example.com/identity
-  #   client_id: player-ui
-  #   redirect_uri: https://example.com/player/auth-callback
-  #   post_logout_redirect_uri: https://example.com/player
+  #   authority: https://identity.example.com/
+  #   client_id: player-ui-dev
+  #   redirect_uri: https://player.example.com/auth-callback/
+  #   post_logout_redirect_uri: https://player.example.com
   #   response_type: code
   #   scope: openid profile player-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: https://example.com/player/auth-callback-silent.html
+  #   silent_redirect_uri: https://player.example.com/auth-callback-silent.html
   # NotificationsSettings:
-  #   url: https://example.com/player/hubs
+  #   url: https://player.example.com/hubs
   #   number_to_display: 4
   # AppTitle: Crucible
   # AppTopBarText: Crucible
@@ -135,3 +119,38 @@ settingsYaml:
   #   message_text_color: "#ffffff"
   #   message_text_fontsize: "14"
   #   enabled: true
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://player.example.com",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "player-ui-dev",
+#     "redirect_uri": "https://player.example.com/auth-callback/",
+#     "post_logout_redirect_uri": "https://player.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile player-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://player.example.com/auth-callback-silent.html"
+#   },
+#   "NotificationsSettings": {
+#     "url": "https://player.example.com/hubs",
+#     "number_to_display": 4
+#   },
+#   "AppTitle": "Crucible",
+#   "AppTopBarText": "Crucible",
+#   "AppTopBarHexColor": "#b00",
+#   "AppTopBarHexTextColor": "#FFFFFF",
+#   "UseLocalAuthStorage": true,
+#   "XApiEnabled": false,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": true
+#   }
+# }'

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.7.14
+version: 1.8.0
 appVersion: 3.8.9

--- a/charts/player/charts/vm-api/templates/console-ingress.yaml
+++ b/charts/player/charts/vm-api/templates/console-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingress.consoleIngress.deployConsoleProxy -}}
+{{- if .Values.consoleIngress.deployConsoleProxy -}}
 {{- $fullName := .Values.consoleIngress.name -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -91,12 +91,28 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# VM-API deployment adds a second ingress
+# - This ingress is used as a proxy for getting a websocket
+#   console connection to vCenter hosts.
+# - TLS and Host URLs need configured, but the snippet should be left alone
+# NOTES:
+# - This is only used if RewriteHost__RewriteHost below is true, otherwise
+#   connections will go directly from the UI to the vCenter hosts themselves
+# - The host value here corresponds to RewriteHost__RewriteHostUrl below
 consoleIngress:
   deployConsoleProxy: false
-  name: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
+  className: ""
+  name: player-connect
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location /ticket {
+          proxy_pass https://$arg_vmhost$uri;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_request_buffering off;
+          proxy_buffering off;
+          proxy_ssl_session_reuse on;
+      }
   hosts:
     - host: chart-example.local
       paths: []

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -91,19 +91,19 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-  consoleIngress:
-    deployConsoleProxy: false
-    name: ""
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths: []
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
+consoleIngress:
+  deployConsoleProxy: false
+  name: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
 # create a configMap with the needed certificates and specify

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -80,7 +80,14 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -1,7 +1,3 @@
-# Default values for vm-api.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/vm-api
   pullPolicy: IfNotPresent
@@ -12,27 +8,15 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-# iso - an NFS volume mount for ISO uploads
-iso:
-  enabled: false
-  size: ""
-  server: ""
-  path: ""
-
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -44,6 +28,29 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# iso - an NFS volume mount for ISO uploads
+iso:
+  enabled: false
+  size: ""
+  server: ""
+  path: ""
 
 probes:
   livenessProbe:
@@ -71,16 +78,13 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-    # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(notifications|hubs|api|swagger)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -102,27 +106,9 @@ ingress:
     #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 command: ["dotnet", "Player.Vm.Api.dll"]
 
@@ -139,15 +125,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
-# env is pod env vars
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Vm.Api/blob/main/src/Player.Vm.Api/appsettings.json
 env:
-  # http_proxy: ""
-  # https_proxy: ""
-  # HTTP_PROXY: ""
-  # HTTPS_PROXY: ""
-  # NO_PROXY: ""
-  # no_proxy: ""
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
@@ -165,10 +146,9 @@ env:
   Database__DevModeRecreate: false
   Database__Provider: PostgreSQL
 
-  CorsPolicy__Origins__0: ""
-  CorsPolicy__Origins__1: ""
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true
@@ -183,9 +163,21 @@ env:
   Authorization__ClientSecret: ""
   Authorization__RequireHttpsMetaData: false
 
+  ClaimsTransformation__EnableCaching: true
+  ClaimsTransformation__CacheExpirationSeconds: 60
+
   IsoUpload__BasePath: "/app/isos/player"
   IsoUpload_MaxFileSize: 6000000000
 
+  IdentityClient__TokenUrl: ""
+  IdentityClient__ClientId: "player-vm-admin"
+  IdentityClient__Scope: "player-api vm-api"
+  IdentityClient__Username: ""
+  IdentityClient__Password: ""
+  IdentityClient__MaxRetryDelaySeconds: 120
+  IdentityClient__TokenRefreshSeconds: 600
+
+  # Crucible Player URL
   ClientSettings__urls__playerApi: ""
 
   Vsphere__Host: ""
@@ -206,14 +198,6 @@ env:
   RewriteHost__RewriteHost: false
   RewriteHost__RewriteHostUrl: ""
   RewriteHost__RewriteHostQueryParam: "vmhost"
-
-  IdentityClient__TokenUrl: ""
-  IdentityClient__ClientId: "player-vm-admin"
-  IdentityClient__Scope: "player-api vm-api"
-  IdentityClient__Username: ""
-  IdentityClient__Password: ""
-  IdentityClient__MaxRetryDelaySeconds: 120
-  IdentityClient__TokenRefreshSeconds: 600
 
   # Open Telemetry
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.8.7
+version: 1.9.0
 appVersion: 3.6.5

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for vm-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/vm-ui
   pullPolicy: IfNotPresent
@@ -13,22 +9,15 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
-podSecurityContext:
-  {}
-  # fsGroup: 2000
-
-securityContext:
-  {}
+podSecurityContext: {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -40,25 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations:
-    {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources:
-  {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -71,12 +42,24 @@ resources:
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: vm.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
 #
 # extraVolumes: |
@@ -91,38 +74,74 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
-
-## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
-## load shared UI configuration that is common across multiple Crucible services.
-## Per-app values can still be overridden via settingsYaml.
-sharedSettingsConfigMap: ""
-
+# env is pod env vars
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+## settings.shared.json key. When set, the file is mounted into the Angular
+## app's assets/config/ directory alongside settings.json so the app can
+## load shared UI configuration that is common across multiple Crucible services.
+## Per-app values can still be overridden via settingsYaml.
+sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: https://example.com/vm/api
+  # ApiUrl: https://vm.example.com/api
   # DeployApiUrl: ""
-  # ApiPlayerUrl: https://example.com/player/api
+  # ApiPlayerUrl: https://player.example.com/api
   # WelderUrl: ""
-  # UserFollowUrl: https://example.com/vm/console/user/{userId}/view/{viewId}/console
+  # UserFollowUrl: https://console.example.com/user/{userId}/view/{viewId}/console
   # OIDCSettings:
-  #   authority: https://example.com/identity
-  #   client_id: vm-ui
-  #   redirect_uri: https://example.com/vm/auth-callback
-  #   post_logout_redirect_uri: https://example.com/vm
+  #   authority: https://identity.example.com/
+  #   client_id: vm-ui-dev
+  #   redirect_uri: https://vm.example.com/auth-callback/
+  #   post_logout_redirect_uri: https://vm.example.com
   #   response_type: code
   #   scope: openid profile player-api vm-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: https://example.com/vm/auth-callback-silent.html
+  #   silent_redirect_uri: https://vm.example.com/auth-callback-silent.html
   # UseLocalAuthStorage: true
+  # HeaderBarSettings:
+  #   banner_background_color: "#d40000ff"
+  #   classification_text: ""
+  #   classification_text_color: "#ffffff"
+  #   classification_text_fontsize: "14"
+  #   message_text: ""
+  #   message_text_color: "#ffffff"
+  #   message_text_fontsize: "14"
+  #   enabled: true
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://vm.example.com/api",
+#   "DeployApiUrl": "",
+#   "ApiPlayerUrl": "https://player.example.com/api",
+#   "WelderUrl": "",
+#   "UserFollowUrl": "https://console.example.com/user/{userId}/view/{viewId}/console",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "vm-ui-dev",
+#     "redirect_uri": "https://vm.example.com/auth-callback/",
+#     "post_logout_redirect_uri": "https://vm.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile player-api vm-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://vm.example.com/auth-callback-silent.html"
+#   },
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": true
+#   }
+# }'

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -117,6 +117,7 @@ settingsYaml:
   #   enabled: true
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://vm.example.com/api",
 #   "DeployApiUrl": "",

--- a/charts/player/charts/vm-ui/values.yaml
+++ b/charts/player/charts/vm-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: vm.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -1,7 +1,50 @@
 player-api:
-  # Docker image release version. Defaults to appVersion of player-api child chart
   image:
+    repository: cmusei/player-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   kind: "Deployment"
 
@@ -30,28 +73,22 @@ player-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: player.example.com
+      - host: chart-example.local
         paths:
-          - path: /(hubs|swagger|api)
+          - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
+  # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
 
@@ -62,6 +99,8 @@ player-api:
     size: ""
     mode: ReadWriteOnce
     class: default
+
+  command: ["./Player.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -78,16 +117,8 @@ player-api:
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/crucible/blob/master/player.api/S3.Player.Api/appsettings.json
+  # see https://github.com/cmu-sei/Player.Api/blob/main/Player.Api/appsettings.json
   env:
-    # Proxy Settings - Set these in your values file if you are behind a proxy.
-    # http_proxy: proxy.example.com:9000
-    # https_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -101,35 +132,23 @@ player-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # CORS policy settings.
-    # The first entry should be the URL to player
-    # The second entry should be the URL to VM App
-    # Subsequent entries can be other integrated apps, such as OSTicket
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=player_api;Username=player_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
 
-    # CORS policy settings.
-    # The first entry should be the URL to player
-    # The second entry should be the URL to VM App
-    # Subsequent entries can be other integrated apps, such as OSTicket
-    CorsPolicy__Origins__0: "https://player.example.com"
-    CorsPolicy__Origins__1: "https://vm.example.com"
-    CorsPolicy__Origins__2: "https://osticket.example.com"
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "player-api"
     Authorization__ClientId: player-api-dev
     Authorization__ClientName: "Player API"
@@ -154,7 +173,7 @@ player-api:
     FileUpload__allowedExtensions__6: ".gif"
     FileUpload__allowedExtensions__7: ".txt"
 
-    # Basic seed data to jumpstart deployement
+    # Basic seed data to jumpstart deployment
     # This is a placeholder and needs to be updated for a new install.
     # Upgrades should keep administrators from the previous install.
 
@@ -205,28 +224,68 @@ player-api:
     # OTEL_SERVICE_NAME: player-api
 
 player-ui:
-  # Docker image release version. Defaults to appVersion of player-ui child chart
   image:
+    repository: cmusei/player-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: player.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
   #
   # extraVolumes: |
@@ -241,29 +300,26 @@ player-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
     # ApiUrl: https://player.example.com
     # OIDCSettings:
-    #   authority: https://identity.example.com
+    #   authority: https://identity.example.com/
     #   client_id: player-ui-dev
     #   redirect_uri: https://player.example.com/auth-callback/
     #   post_logout_redirect_uri: https://player.example.com
@@ -290,10 +346,88 @@ player-ui:
     #   message_text_fontsize: "14"
     #   enabled: true
 
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://player.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "player-ui-dev",
+  #     "redirect_uri": "https://player.example.com/auth-callback/",
+  #     "post_logout_redirect_uri": "https://player.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile player-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://player.example.com/auth-callback-silent.html"
+  #   },
+  #   "NotificationsSettings": {
+  #     "url": "https://player.example.com/hubs",
+  #     "number_to_display": 4
+  #   },
+  #   "AppTitle": "Crucible",
+  #   "AppTopBarText": "Crucible",
+  #   "AppTopBarHexColor": "#b00",
+  #   "AppTopBarHexTextColor": "#FFFFFF",
+  #   "UseLocalAuthStorage": true,
+  #   "XApiEnabled": false,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": true
+  #   }
+  # }'
+
 vm-api:
-  # Docker image release version. Defaults to appVersion of vm-api child chart
   image:
+    repository: cmusei/vm-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   # iso - an NFS volume mount for ISO uploads
   iso:
@@ -327,64 +461,40 @@ vm-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
-      nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    annotations: {}
     hosts:
-      - host: vm.example.com
+      - host: chart-example.local
         paths:
           - path: /(notifications|hubs|api|swagger)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  # VM-API deployment adds a second ingress
-  # - This ingress is used as a proxy for getting a websocket
-  #   console connection to vCenter hosts.
-  # - TLS and Host URLs need configured, but the snippet should be left alone
-  # NOTES:
-  # - This is only used if RewriteHost__RewriteHost below is true, otherwise
-  #   connections will go directly from the UI to the vCenter hosts themselves
-  # - The host value here corresponds to RewriteHost__RewriteHostUrl below
-  consoleIngress:
-    deployConsoleProxy: false
-    className: ""
-    name: player-connect
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/server-snippet: |
-        location /ticket {
-            proxy_pass https://$arg_vmhost$uri;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_request_buffering off;
-            proxy_buffering off;
-            proxy_ssl_session_reuse on;
-        }
-    hosts:
-      - host: connect.example.com
-        paths: []
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    consoleIngress:
+      deployConsoleProxy: false
+      name: ""
+      annotations: {}
+        # kubernetes.io/ingress.class: nginx
+        # kubernetes.io/tls-acme: "true"
+      hosts:
+        - host: chart-example.local
+          paths: []
+      tls: []
+      #  - secretName: chart-example-tls
+      #    hosts:
+      #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
+  # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
+
+  command: ["dotnet", "Player.Vm.Api.dll"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -401,16 +511,8 @@ vm-api:
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/crucible/blob/master/vm.api/S3.VM.Api/appsettings.json
+  # see https://github.com/cmu-sei/Vm.Api/blob/main/src/Player.Vm.Api/appsettings.json
   env:
-    # Proxy Settings
-    # http_proxy: proxy.example.com:9000
-    # https_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -422,40 +524,36 @@ vm-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=vm_api;Username=vm_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
 
-    # CORS policy settings.
-    # The first entry should be the URL to VM App
-    # The second entry should be the URL to Console App
-    CorsPolicy__Origins__0: "https://vm.example.com"
-    CorsPolicy__Origins__1: "https://console.example.com"
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "vm-api player-api"
     Authorization__ClientId: vm-api-dev
     Authorization__ClientName: "VM API"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
+    ClaimsTransformation__EnableCaching: true
+    ClaimsTransformation__CacheExpirationSeconds: 60
+
     IsoUpload__BasePath: "/app/isos/player"
     IsoUpload_MaxFileSize: 6000000000
 
-    # OAuth2 Identity Client /w Password
-    IdentityClient__TokenUrl: https://identity.example.com/connect/token
+    IdentityClient__TokenUrl: ""
     IdentityClient__ClientId: "player-vm-admin"
     IdentityClient__Scope: "player-api vm-api"
     IdentityClient__Username: ""
@@ -464,19 +562,10 @@ vm-api:
     IdentityClient__TokenRefreshSeconds: 600
 
     # Crucible Player URL
-    ClientSettings__urls__playerApi: "https://player.example.com"
+    ClientSettings__urls__playerApi: ""
 
-    # VCenter settings
-    #
-    # A privileged vCenter used is required to read and write files
-    #
-    # A datastore needs to be created for Player to store files.  This is
-    # typically an NFS share in the format:  <DATASTORE>/player/
-    #
-    # - DsName denotes the DataStore name
-    # - BaseFolder is the folder inside the DataStore to use
-    Vsphere__Host: "vcenter.example.com"
-    Vsphere__Username: "player-account@vsphere.local"
+    Vsphere__Host: ""
+    Vsphere__Username: ""
     Vsphere__Password: ""
     Vsphere__DsName: ""
     Vsphere__BaseFolder: "player"
@@ -490,10 +579,8 @@ vm-api:
     Vsphere__ReCheckTaskProgressIntervalMilliseconds: 1000
     Vsphere__HealthAllowanceSeconds: 180
 
-    # Rewrite Host settings
-    # See "consoleIngress" section above for usage
     RewriteHost__RewriteHost: false
-    RewriteHost__RewriteHostUrl: "connect.example.com"
+    RewriteHost__RewriteHostUrl: ""
     RewriteHost__RewriteHostQueryParam: "vmhost"
 
     # Open Telemetry
@@ -512,28 +599,68 @@ vm-api:
     # OTEL_SERVICE_NAME: vm-api
 
 vm-ui:
-  # Docker image release version. Defaults to appVersion of vm-ui child chart
   image:
+    repository: cmusei/vm-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: vm.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
   #
   # extraVolumes: |
@@ -548,23 +675,20 @@ vm-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -574,7 +698,7 @@ vm-ui:
     # WelderUrl: ""
     # UserFollowUrl: https://console.example.com/user/{userId}/view/{viewId}/console
     # OIDCSettings:
-    #   authority: https://identity.example.com
+    #   authority: https://identity.example.com/
     #   client_id: vm-ui-dev
     #   redirect_uri: https://vm.example.com/auth-callback/
     #   post_logout_redirect_uri: https://vm.example.com
@@ -583,30 +707,109 @@ vm-ui:
     #   automaticSilentRenew: true
     #   silent_redirect_uri: https://vm.example.com/auth-callback-silent.html
     # UseLocalAuthStorage: true
+    # HeaderBarSettings:
+    #   banner_background_color: "#d40000ff"
+    #   classification_text: ""
+    #   classification_text_color: "#ffffff"
+    #   classification_text_fontsize: "14"
+    #   message_text: ""
+    #   message_text_color: "#ffffff"
+    #   message_text_fontsize: "14"
+    #   enabled: true
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://vm.example.com/api",
+  #   "DeployApiUrl": "",
+  #   "ApiPlayerUrl": "https://player.example.com/api",
+  #   "WelderUrl": "",
+  #   "UserFollowUrl": "https://console.example.com/user/{userId}/view/{viewId}/console",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "vm-ui-dev",
+  #     "redirect_uri": "https://vm.example.com/auth-callback/",
+  #     "post_logout_redirect_uri": "https://vm.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile player-api vm-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://vm.example.com/auth-callback-silent.html"
+  #   },
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": true
+  #   }
+  # }'
 
 console-ui:
-  # Docker image release version. Defaults to appVersion of console-ui child chart
   image:
+    repository: cmusei/vm-console-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: console.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
   #
   # extraVolumes: |
@@ -621,29 +824,26 @@ console-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
     # ConsoleApiUrl: https://vm.example.com/api/
     # OIDCSettings:
-    #   authority: https://identity.example.com
+    #   authority: https://identity.example.com/
     #   client_id: vm-console-ui-dev
     #   redirect_uri: https://console.example.com/auth-callback/
     #   post_logout_redirect_uri: https://console.example.com
@@ -690,3 +890,38 @@ console-ui:
     #     value: 100
     #   - name: Slowest
     #     value: 500
+    # HeaderBarSettings:
+    #   banner_background_color: "#d40000ff"
+    #   classification_text: ""
+    #   classification_text_color: "#ffffff"
+    #   classification_text_fontsize: "14"
+    #   message_text: ""
+    #   message_text_color: "#ffffff"
+    #   message_text_fontsize: "14"
+    #   enabled: true
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ConsoleApiUrl": "https://vm.example.com/api/",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "vm-console-ui-dev",
+  #     "redirect_uri": "https://console.example.com/auth-callback/",
+  #     "post_logout_redirect_uri": "https://console.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile player-api vm-api vm-console-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://console.example.com/auth-callback-silent.html"
+  #   },
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": true
+  #   }
+  # }'

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -76,7 +76,13 @@ player-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:
@@ -465,7 +471,14 @@ vm-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      # nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -347,6 +347,7 @@ player-ui:
     #   enabled: true
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://player.example.com",
   #   "OIDCSettings": {
@@ -718,6 +719,7 @@ vm-ui:
     #   enabled: true
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://vm.example.com/api",
   #   "DeployApiUrl": "",
@@ -901,6 +903,7 @@ console-ui:
     #   enabled: true
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ConsoleApiUrl": "https://vm.example.com/api/",
   #   "OIDCSettings": {

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -476,12 +476,28 @@ vm-api:
     #    hosts:
     #      - chart-example.local
 
+  # VM-API deployment adds a second ingress
+  # - This ingress is used as a proxy for getting a websocket
+  #   console connection to vCenter hosts.
+  # - TLS and Host URLs need configured, but the snippet should be left alone
+  # NOTES:
+  # - This is only used if RewriteHost__RewriteHost below is true, otherwise
+  #   connections will go directly from the UI to the vCenter hosts themselves
+  # - The host value here corresponds to RewriteHost__RewriteHostUrl below
   consoleIngress:
     deployConsoleProxy: false
-    name: ""
-    annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    className: ""
+    name: player-connect
+    annotations:
+      nginx.ingress.kubernetes.io/server-snippet: |
+        location /ticket {
+            proxy_pass https://$arg_vmhost$uri;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_request_buffering off;
+            proxy_buffering off;
+            proxy_ssl_session_reuse on;
+        }
     hosts:
       - host: chart-example.local
         paths: []

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -276,7 +276,7 @@ player-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: player.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -475,19 +475,19 @@ vm-api:
     #    hosts:
     #      - chart-example.local
 
-    consoleIngress:
-      deployConsoleProxy: false
-      name: ""
-      annotations: {}
-        # kubernetes.io/ingress.class: nginx
-        # kubernetes.io/tls-acme: "true"
-      hosts:
-        - host: chart-example.local
-          paths: []
-      tls: []
-      #  - secretName: chart-example-tls
-      #    hosts:
-      #      - chart-example.local
+  consoleIngress:
+    deployConsoleProxy: false
+    name: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths: []
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
   # create a configMap with the needed certificates and specify
@@ -651,7 +651,7 @@ vm-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: vm.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -800,7 +800,7 @@ console-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: console.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -255,7 +255,7 @@ player-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -630,7 +630,7 @@ vm-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -779,7 +779,7 @@ console-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -1,4 +1,8 @@
 player-api:
+  # Docker image release version. Defaults to appVersion of player-api child chart
+  image:
+    tag: ""
+
   kind: "Deployment"
 
   probes:
@@ -201,6 +205,10 @@ player-api:
     # OTEL_SERVICE_NAME: player-api
 
 player-ui:
+  # Docker image release version. Defaults to appVersion of player-ui child chart
+  image:
+    tag: ""
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
@@ -283,6 +291,10 @@ player-ui:
     #   enabled: true
 
 vm-api:
+  # Docker image release version. Defaults to appVersion of vm-api child chart
+  image:
+    tag: ""
+
   # iso - an NFS volume mount for ISO uploads
   iso:
     enabled: false
@@ -500,6 +512,10 @@ vm-api:
     # OTEL_SERVICE_NAME: vm-api
 
 vm-ui:
+  # Docker image release version. Defaults to appVersion of vm-ui child chart
+  image:
+    tag: ""
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:
@@ -569,6 +585,10 @@ vm-ui:
     # UseLocalAuthStorage: true
 
 console-ui:
+  # Docker image release version. Defaults to appVersion of console-ui child chart
+  image:
+    tag: ""
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -3,7 +3,7 @@ name: steamfitter
 description: Steamfitter enables the organization and execution of scenario tasks
   on virtual machines by integrating with StackStorm automation.
 type: application
-version: 1.7.9
+version: 1.8.0
 home: https://cmu-sei.github.io/crucible/steamfitter
 sources:
 - https://github.com/cmu-sei/steamfitter.api

--- a/charts/steamfitter/Chart.yaml
+++ b/charts/steamfitter/Chart.yaml
@@ -3,7 +3,7 @@ name: steamfitter
 description: Steamfitter enables the organization and execution of scenario tasks
   on virtual machines by integrating with StackStorm automation.
 type: application
-version: 1.7.8
+version: 1.7.9
 home: https://cmu-sei.github.io/crucible/steamfitter
 sources:
 - https://github.com/cmu-sei/steamfitter.api

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -80,16 +80,38 @@ steamfitter-api:
 | `Authorization__ClientSecret` | OAuth2 client secret | `""` |
 | `Authorization__RequireHttpsMetaData` | Require HTTPS for metadata | `false` |
 
-### CORS Policy
+### CORS Policy Settings
 
 | Setting | Description | Example |
 |---------|-------------|---------|
+| `CorsPolicy__Origins__0` | First allowed CORS origin | `https://steamfitter.example.com` |
 | `CorsPolicy__Methods__0` | CORS allowed methods | `""` |
 | `CorsPolicy__Headers__0` | CORS allowed headers | `""` |
 | `CorsPolicy__AllowAnyOrigin` | Allow any CORS origin | `false` |
 | `CorsPolicy__AllowAnyMethod` | Allow any CORS method | `true` |
 | `CorsPolicy__AllowAnyHeader` | Allow any CORS header | `true` |
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
+
+**Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
+
+### xAPI Options
+
+Steamfitter can emit [xAPI](https://xapi.com/) statements to a Learning Record Store (LRS) to record scenario task activity.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `XApiOptions__Enabled` | Enable xAPI statement emission | `false` |
+| `XApiOptions__Endpoint` | LRS endpoint URL | `""` |
+| `XApiOptions__Username` | LRS basic-auth username | `""` |
+| `XApiOptions__Password` | LRS basic-auth password | `""` |
+| `XApiOptions__IssuerUrl` | Identity provider issuer URL (used to resolve actor identifiers) | `""` |
+| `XApiOptions__ApiUrl` | Steamfitter API URL (used in statement context) | `""` |
+| `XApiOptions__UiUrl` | Steamfitter UI URL (used in statement context) | `""` |
+| `XApiOptions__EmailDomain` | Email domain appended to usernames to form xAPI actor mbox | `""` |
+| `XApiOptions__Platform` | Platform name reported in xAPI statements | `Steamfitter` |
+| `XApiOptions__RetentionDays` | Number of days to retain locally stored xAPI records | `7` |
+| `XApiOptions__ProcessingTimeoutMinutes` | Timeout in minutes for xAPI statement processing | `10` |
+| `XApiOptions__ProcessingDelaySeconds` | Delay in seconds between xAPI processing cycles | `30` |
 
 ### Claims Transformation
 

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -30,6 +30,12 @@ helm install steamfitter sei/steamfitter -f values.yaml
 
 The following are configured via the `steamfitter-api.env` settings. These Steamfitter API settings reflect the application's [appsettings.json](https://github.com/cmu-sei/Steamfitter.Api/blob/development/Steamfitter.Api/appsettings.json) which may contain more settings than are described here.
 
+### Image
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `image.tag` | Override the image tag (defaults to chart `appVersion`) | `""` |
+
 ### Database Settings
 
 | Setting | Description | Example |
@@ -253,6 +259,14 @@ Steamfitter-api:
 - Resource attribute `service_name` defaults to `Steamfitter-api` (or your `OTEL_SERVICE_NAME` override).
 
 ## Steamfitter UI Configuration
+
+### Image
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `image.tag` | Override the image tag (defaults to chart `appVersion`) | `""` |
+
+### Application Settings
 
 | Setting | Description | Example |
 |---------|-------------|---------|

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -94,7 +94,7 @@ steamfitter-api:
 
 **Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__1`, `CorsPolicy__Origins__2`, etc.
 
-### xAPI Options
+### xAPI Settings
 
 Steamfitter can emit [xAPI](https://xapi.com/) statements to a Learning Record Store (LRS) to record scenario task activity.
 
@@ -256,7 +256,7 @@ Configure the ingress to allow connections to the application (typically uses an
 Steamfitter.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for Steamfitter to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
 
 ```yaml
-Steamfitter-api:
+steamfitter-api:
   env:
     # This can be a kubernetes service address if the collector is running in the cluster
     OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
@@ -264,7 +264,7 @@ Steamfitter-api:
     # Optional: force HTTP instead of the default gRPC protocol
     # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     # Optional: override the service name reported to collectors
-    # OTEL_SERVICE_NAME: Steamfitter-api
+    # OTEL_SERVICE_NAME: steamfitter-api
 
     # These settings toggle ServiceDefaults configurations for Otel
     # The values listed here are the defaults
@@ -275,10 +275,18 @@ Steamfitter-api:
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
 
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
+
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.
 - Built-in meters: `Microsoft.AspNetCore.Hosting`, `Microsoft.AspNetCore.Server.Kestrel`, `System.Net.Http`, `System.Net.NameResolution`, `Microsoft.EntityFrameworkCore`, plus runtime/process meters.
-- Resource attribute `service_name` defaults to `Steamfitter-api` (or your `OTEL_SERVICE_NAME` override).
+- Resource attribute `service_name` defaults to `steamfitter-api` (or your `OTEL_SERVICE_NAME` override).
 
 ## Steamfitter UI Configuration
 

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -100,7 +100,7 @@ Steamfitter can emit [xAPI](https://xapi.com/) statements to a Learning Record S
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `XApiOptions__Enabled` | Enable xAPI statement emission | `false` |
+| `XApiOptions__Enabled` | Enable xAPI statement recording | `false` |
 | `XApiOptions__Endpoint` | LRS endpoint URL | `""` |
 | `XApiOptions__Username` | LRS basic-auth username | `""` |
 | `XApiOptions__Password` | LRS basic-auth password | `""` |

--- a/charts/steamfitter/charts/steamfitter-api/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: steamfitter-api
 type: application
-version: 1.6.20
+version: 1.7.0
 appVersion: 3.9.11

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -171,9 +171,9 @@ env:
 
   # Stackstorm Configuration
   VmTaskProcessing__ApiType: st2
-  VmTaskProcessing__ApiUsername: ""
-  VmTaskProcessing__ApiPassword: ""
-  VmTaskProcessing__ApiBaseUrl: ""
+  VmTaskProcessing__ApiUsername:
+  VmTaskProcessing__ApiPassword:
+  VmTaskProcessing__ApiBaseUrl:
   VmTaskProcessing__VmListUpdateIntervalMinutes: 5
   VmTaskProcessing__HealthCheckSeconds: 30
   VmTaskProcessing__HealthCheckTimeoutSeconds: 90

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -73,7 +73,13 @@ probes:
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/steamfitter/charts/steamfitter-api/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-api/values.yaml
@@ -9,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -33,6 +28,22 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
 
 probes:
   livenessProbe:
@@ -60,15 +71,13 @@ probes:
     successThreshold: 1
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
       paths:
-        - path: /
+        - path: /(api|swagger|hubs)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -76,27 +85,9 @@ ingress:
   #      - chart-example.local
 
 # If this deployment needs to trust non-public certificates,
-# create a configMap with the needed certifcates and specify
+# create a configMap with the needed certificates and specify
 # the configMap name here
 certificateMap: ""
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 command: ["./Steamfitter.Api"]
 
@@ -113,14 +104,10 @@ extraEnvFrom: []
 # - configMapRef:
 #     name: my-configmap
 
+# Config app settings with environment vars.
+# Those most likely needing values are listed. For others,
+# see https://github.com/cmu-sei/Steamfitter.Api/blob/main/Steamfitter.Api/appsettings.json
 env:
-  # http_proxy: ""
-  # https_proxy: ""
-  # HTTP_PROXY: ""
-  # HTTPS_PROXY: ""
-  # NO_PROXY: ""
-  # no_proxy: ""
-
   ## If hosting in virtual directory, specify path base
   PathBase: ""
 
@@ -138,9 +125,9 @@ env:
   Database__DevModeRecreate: false
   Database__Provider: PostgreSQL
 
-  CorsPolicy__Origins__0: ""
-  CorsPolicy__Methods__0: ""
-  CorsPolicy__Headers__0: ""
+  # CorsPolicy__Origins__0: ""
+  # CorsPolicy__Methods__0: ""
+  # CorsPolicy__Headers__0: ""
   CorsPolicy__AllowAnyOrigin: false
   CorsPolicy__AllowAnyMethod: true
   CorsPolicy__AllowAnyHeader: true
@@ -182,10 +169,11 @@ env:
   ClientSettings__urls__playerApi: ""
   ClientSettings__urls__vmApi: ""
 
+  # Stackstorm Configuration
   VmTaskProcessing__ApiType: st2
-  VmTaskProcessing__ApiUsername:
-  VmTaskProcessing__ApiPassword:
-  VmTaskProcessing__ApiBaseUrl:
+  VmTaskProcessing__ApiUsername: ""
+  VmTaskProcessing__ApiPassword: ""
+  VmTaskProcessing__ApiBaseUrl: ""
   VmTaskProcessing__VmListUpdateIntervalMinutes: 5
   VmTaskProcessing__HealthCheckSeconds: 30
   VmTaskProcessing__HealthCheckTimeoutSeconds: 90

--- a/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: steamfitter-ui
 type: application
-version: 1.7.5
+version: 1.8.0
 appVersion: 3.9.3

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -1,7 +1,3 @@
-# Default values for steamfitter-ui.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/steamfitter-ui
   pullPolicy: IfNotPresent
@@ -13,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -38,23 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
+  resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -67,12 +42,24 @@ resources: {}
   #   memory: 128Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: steamfitter.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
 # Example use to overwrite the favicon from a file in a configMap:
 #
 # extraVolumes: |
@@ -87,38 +74,35 @@ affinity: {}
 #
 # See kubernetes documentation for configuring your volumes:
 # https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
 extraVolumes: ""
 
-extraVolumeMounts: ""
-
-## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-## settings.shared.json key. When set, the file is mounted into the Angular
-## app's assets/config/ directory alongside settings.env.json so the app can
-## load shared UI configuration that is common across multiple Crucible services.
-## Per-app values can still be overridden via settingsYaml.
-sharedSettingsConfigMap: ""
-
+# env is pod env vars
 env:
   ## basehref is path to the app
   APP_BASEHREF: ""
 
-## settings is stringified json that gets included as assets/settings.json
-settings: "{}"
+## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+## settings.shared.json key. When set, the file is mounted into the Angular
+## app's assets/config/ directory alongside settings.json so the app can
+## load shared UI configuration that is common across multiple Crucible services.
+## Per-app values can still be overridden via settingsYaml.
+sharedSettingsConfigMap: ""
 
 ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
 settingsYaml:
-  # ApiUrl: http://host.docker.internal:4400
-  # VmApiUrl: http://host.docker.internal:4302/api
-  # ApiPlayerUrl: http://host.docker.internal:4300
+  # ApiUrl: https://steamfitter.example.com
+  # VmApiUrl: https://vm.example.com
+  # ApiPlayerUrl: https://player.example.com
   # OIDCSettings:
-  #   authority: http://host.docker.internal:5000/
-  #   client_id: steamfitter.web
-  #   redirect_uri: http://host.docker.internal:4401/auth-callback
-  #   post_logout_redirect_uri: http://host.docker.internal:4401
+  #   authority: https://identity.example.com/
+  #   client_id: steamfitter-ui-dev
+  #   redirect_uri: https://steamfitter.example.com/auth-callback/
+  #   post_logout_redirect_uri: https://steamfitter.example.com
   #   response_type: code
-  #   scope: openid profile s3 s3-vm steamfitter
+  #   scope: openid profile player-api vm-api steamfitter-api
   #   automaticSilentRenew: true
-  #   silent_redirect_uri: http://host.docker.internal:4401/auth-callback-silent.html
+  #   silent_redirect_uri: https://steamfitter.example.com/auth-callback-silent.html
   # UseLocalAuthStorage: true
   # HeaderBarSettings:
   #   banner_background_color: "#d40000ff"
@@ -128,4 +112,32 @@ settingsYaml:
   #   message_text: ""
   #   message_text_color: "#ffffff"
   #   message_text_fontsize: "14"
-  #   enabled: true
+  #   enabled: false
+
+## settings is stringified json that gets included as appsettings.Production.json
+# settings: '{
+#   "ApiUrl": "https://steamfitter.example.com",
+#   "VmApiUrl": "https://vm.example.com",
+#   "ApiPlayerUrl": "https://player.example.com",
+#   "OIDCSettings": {
+#     "authority": "https://identity.example.com/",
+#     "client_id": "steamfitter-ui-dev",
+#     "redirect_uri": "https://steamfitter.example.com/auth-callback/",
+#     "post_logout_redirect_uri": "https://steamfitter.example.com",
+#     "response_type": "code",
+#     "scope": "openid profile player-api vm-api steamfitter-api",
+#     "automaticSilentRenew": true,
+#     "silent_redirect_uri": "https://steamfitter.example.com/auth-callback-silent.html"
+#   },
+#   "UseLocalAuthStorage": true,
+#   "HeaderBarSettings": {
+#     "banner_background_color": "#d40000ff",
+#     "classification_text": "",
+#     "classification_text_color": "#ffffff",
+#     "classification_text_fontsize": "14",
+#     "message_text": "",
+#     "message_text_color": "#ffffff",
+#     "message_text_fontsize": "14",
+#     "enabled": false
+#   }
+# }'

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -29,7 +29,7 @@ service:
   type: ClusterIP
   port: 80
 
-  resources: {}
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -50,7 +50,7 @@ ingress:
   className: ""
   annotations: {}
   hosts:
-    - host: steamfitter.example.com
+    - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/charts/steamfitter/charts/steamfitter-ui/values.yaml
+++ b/charts/steamfitter/charts/steamfitter-ui/values.yaml
@@ -115,6 +115,7 @@ settingsYaml:
   #   enabled: false
 
 ## settings is stringified json that gets included as appsettings.Production.json
+settings: "{}"
 # settings: '{
 #   "ApiUrl": "https://steamfitter.example.com",
 #   "VmApiUrl": "https://vm.example.com",

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -1,7 +1,50 @@
 steamfitter-api:
-  # Docker image release version. Defaults to appVersion of steamfitter-api child chart
   image:
+    repository: cmusei/steamfitter-api
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
   probes:
     livenessProbe:
@@ -28,30 +71,26 @@ steamfitter-api:
       failureThreshold: 15
       successThreshold: 1
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
-      nginx.ingress.kubernetes.io/use-regex: "true"
+    annotations: {}
     hosts:
-      - host: steamfitter.example.com
+      - host: chart-example.local
         paths:
           - path: /(api|swagger|hubs)
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   # If this deployment needs to trust non-public certificates,
-  # create a configMap with the needed certifcates and specify
+  # create a configMap with the needed certificates and specify
   # the configMap name here
   certificateMap: ""
+
+  command: ["./Steamfitter.Api"]
 
   ## existingSecret references a secret already in k8s.
   ## The key/value pairs in the secret are added as environment variables.
@@ -68,16 +107,8 @@ steamfitter-api:
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/crucible/blob/master/steamfitter.api/Steamfitter.Api/appsettings.json
+  # see https://github.com/cmu-sei/Steamfitter.Api/blob/main/Steamfitter.Api/appsettings.json
   env:
-    # Proxy Settings
-    # https_proxy: proxy.example.com:9000
-    # http_proxy: proxy.example.com:9000
-    # HTTP_PROXY: proxy.example.com:9000
-    # HTTPS_PROXY: proxy.example.com:9000
-    # NO_PROXY: .local
-    # no_proxy: .local
-
     ## If hosting in virtual directory, specify path base
     PathBase: ""
 
@@ -89,39 +120,34 @@ steamfitter-api:
     Logging__Console__LogLevel__Microsoft: Error
     Logging__Console__LogLevel__System: Error
 
-    # Connection String to database
     # database requires the 'uuid-ossp' extension installed
-    ConnectionStrings__PostgreSQL: "Server=postgres;Port=5432;Database=steamfitter_api;Username=steamfitter_dbu;Password=;"
+    ConnectionStrings__PostgreSQL: ""
     Database__AutoMigrate: true
     Database__DevModeRecreate: false
     Database__Provider: PostgreSQL
 
-    # CORS policy settings.
-    # The first entry should be the URL to Steamfitter
-    CorsPolicy__Origins__0: https://steamfitter.example.com
-    CorsPolicy__Methods__0: ""
-    CorsPolicy__Headers__0: ""
+    # CorsPolicy__Origins__0: ""
+    # CorsPolicy__Methods__0: ""
+    # CorsPolicy__Headers__0: ""
     CorsPolicy__AllowAnyOrigin: false
     CorsPolicy__AllowAnyMethod: true
     CorsPolicy__AllowAnyHeader: true
     CorsPolicy__SupportsCredentials: true
 
-    # OAuth2 Identity Client for Application
-    Authorization__Authority: https://identity.example.com
-    Authorization__AuthorizationUrl: https://identity.example.com/connect/authorize
-    Authorization__TokenUrl: https://identity.example.com/connect/token
+    Authorization__Authority: ""
+    Authorization__AuthorizationUrl: ""
+    Authorization__TokenUrl: ""
     Authorization__AuthorizationScope: "player-api steamfitter-api vm-api"
     Authorization__ClientId: steamfitter-api-dev
     Authorization__ClientName: "Steamfitter API"
     Authorization__ClientSecret: ""
     Authorization__RequireHttpsMetaData: false
 
-    # OAuth2 Identity Client /w Password
-    ResourceOwnerAuthorization__Authority: https://identity.example.com
+    ResourceOwnerAuthorization__Authority: ""
     ResourceOwnerAuthorization__ClientId: steamfitter-api
     ResourceOwnerAuthorization__ClientSecret: ""
-    ResourceOwnerAuthorization__UserName:
-    ResourceOwnerAuthorization__Password:
+    ResourceOwnerAuthorization__UserName: ""
+    ResourceOwnerAuthorization__Password: ""
     ResourceOwnerAuthorization__Scope: "vm-api"
     ResourceOwnerAuthorization__TokenExpirationBufferSeconds: 900
 
@@ -141,15 +167,14 @@ steamfitter-api:
     XApiOptions__ProcessingTimeoutMinutes: 10
     XApiOptions__ProcessingDelaySeconds: 30
 
-    # Crucible URLs
-    ClientSettings__urls__playerApi: https://player.example.com/
-    ClientSettings__urls__vmApi: https://vm.example.com/
+    ClientSettings__urls__playerApi: ""
+    ClientSettings__urls__vmApi: ""
 
     # Stackstorm Configuration
     VmTaskProcessing__ApiType: st2
-    VmTaskProcessing__ApiUsername: "st2admin"
-    VmTaskProcessing__ApiPassword:
-    VmTaskProcessing__ApiBaseUrl: "https://stackstorm.example.com"
+    VmTaskProcessing__ApiUsername: ""
+    VmTaskProcessing__ApiPassword: ""
+    VmTaskProcessing__ApiBaseUrl: ""
     VmTaskProcessing__VmListUpdateIntervalMinutes: 5
     VmTaskProcessing__HealthCheckSeconds: 30
     VmTaskProcessing__HealthCheckTimeoutSeconds: 90
@@ -176,28 +201,68 @@ steamfitter-api:
     # OTEL_SERVICE_NAME: steamfitter-api
 
 steamfitter-ui:
-  # Docker image release version. Defaults to appVersion of steamfitter-ui child chart
   image:
+    repository: cmusei/steamfitter-ui
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
-  # Ingress configuration example for NGINX
-  # TLS and Host URLs need configured
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  serviceAccount:
+    create: true
+    annotations: {}
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
+    name: ""
+
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    port: 80
+
+    resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
   ingress:
     enabled: true
     className: ""
-    annotations:
-      kubernetes.io/ingress.class: nginx
+    annotations: {}
     hosts:
       - host: steamfitter.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
-    tls:
-      - secretName: ""
-        hosts:
-          - example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  ## extraVolumeMounts and extraVolumes are stringified YAML of kubernetes volume definitions
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
   # Example use to overwrite the favicon from a file in a configMap:
   #
   # extraVolumes: |
@@ -212,23 +277,20 @@ steamfitter-ui:
   #
   # See kubernetes documentation for configuring your volumes:
   # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
   extraVolumes: ""
 
-  extraVolumeMounts: ""
-
-  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
-  ## settings.shared.json key. When set, the file is mounted into the Angular
-  ## app's assets/config/ directory alongside settings.env.json so the app can
-  ## load shared UI configuration that is common across multiple Crucible services.
-  ## Per-app values can still be overridden via settingsYaml.
-  sharedSettingsConfigMap: ""
-
+  # env is pod env vars
   env:
     ## basehref is path to the app
     APP_BASEHREF: ""
 
-  ## settings is stringified json that gets included as assets/settings.json
-  settings: "{}"
+  ## sharedSettingsConfigMap is the name of an existing ConfigMap containing a
+  ## settings.shared.json key. When set, the file is mounted into the Angular
+  ## app's assets/config/ directory alongside settings.json so the app can
+  ## load shared UI configuration that is common across multiple Crucible services.
+  ## Per-app values can still be overridden via settingsYaml.
+  sharedSettingsConfigMap: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
   settingsYaml:
@@ -236,7 +298,7 @@ steamfitter-ui:
     # VmApiUrl: https://vm.example.com
     # ApiPlayerUrl: https://player.example.com
     # OIDCSettings:
-    #   authority: https://identity.example.com
+    #   authority: https://identity.example.com/
     #   client_id: steamfitter-ui-dev
     #   redirect_uri: https://steamfitter.example.com/auth-callback/
     #   post_logout_redirect_uri: https://steamfitter.example.com
@@ -254,3 +316,31 @@ steamfitter-ui:
     #   message_text_color: "#ffffff"
     #   message_text_fontsize: "14"
     #   enabled: false
+
+  ## settings is stringified json that gets included as appsettings.Production.json
+  # settings: '{
+  #   "ApiUrl": "https://steamfitter.example.com",
+  #   "VmApiUrl": "https://vm.example.com",
+  #   "ApiPlayerUrl": "https://player.example.com",
+  #   "OIDCSettings": {
+  #     "authority": "https://identity.example.com/",
+  #     "client_id": "steamfitter-ui-dev",
+  #     "redirect_uri": "https://steamfitter.example.com/auth-callback/",
+  #     "post_logout_redirect_uri": "https://steamfitter.example.com",
+  #     "response_type": "code",
+  #     "scope": "openid profile player-api vm-api steamfitter-api",
+  #     "automaticSilentRenew": true,
+  #     "silent_redirect_uri": "https://steamfitter.example.com/auth-callback-silent.html"
+  #   },
+  #   "UseLocalAuthStorage": true,
+  #   "HeaderBarSettings": {
+  #     "banner_background_color": "#d40000ff",
+  #     "classification_text": "",
+  #     "classification_text_color": "#ffffff",
+  #     "classification_text_fontsize": "14",
+  #     "message_text": "",
+  #     "message_text_color": "#ffffff",
+  #     "message_text_fontsize": "14",
+  #     "enabled": false
+  #   }
+  # }'

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -253,7 +253,7 @@ steamfitter-ui:
     className: ""
     annotations: {}
     hosts:
-      - host: steamfitter.example.com
+      - host: chart-example.local
         paths:
           - path: /
             pathType: ImplementationSpecific

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -318,6 +318,7 @@ steamfitter-ui:
     #   enabled: false
 
   ## settings is stringified json that gets included as appsettings.Production.json
+  settings: "{}"
   # settings: '{
   #   "ApiUrl": "https://steamfitter.example.com",
   #   "VmApiUrl": "https://vm.example.com",

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -74,7 +74,13 @@ steamfitter-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -1,4 +1,8 @@
 steamfitter-api:
+  # Docker image release version. Defaults to appVersion of steamfitter-api child chart
+  image:
+    tag: ""
+
   probes:
     livenessProbe:
       enabled: true
@@ -172,6 +176,10 @@ steamfitter-api:
     # OTEL_SERVICE_NAME: steamfitter-api
 
 steamfitter-ui:
+  # Docker image release version. Defaults to appVersion of steamfitter-ui child chart
+  image:
+    tag: ""
+
   # Ingress configuration example for NGINX
   # TLS and Host URLs need configured
   ingress:

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -232,7 +232,7 @@ steamfitter-ui:
     type: ClusterIP
     port: 80
 
-    resources: {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/charts/steamfitter/values.yaml
+++ b/charts/steamfitter/values.yaml
@@ -172,9 +172,9 @@ steamfitter-api:
 
     # Stackstorm Configuration
     VmTaskProcessing__ApiType: st2
-    VmTaskProcessing__ApiUsername: ""
-    VmTaskProcessing__ApiPassword: ""
-    VmTaskProcessing__ApiBaseUrl: ""
+    VmTaskProcessing__ApiUsername:
+    VmTaskProcessing__ApiPassword:
+    VmTaskProcessing__ApiBaseUrl:
     VmTaskProcessing__VmListUpdateIntervalMinutes: 5
     VmTaskProcessing__HealthCheckSeconds: 30
     VmTaskProcessing__HealthCheckTimeoutSeconds: 90

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.8.2
+version: 0.8.3
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
   - https://github.com/cmu-sei/TopoMojo

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.8.1
+version: 0.8.2
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
   - https://github.com/cmu-sei/TopoMojo

--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.8.3
+version: 0.9.0
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
   - https://github.com/cmu-sei/TopoMojo

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -295,17 +295,12 @@ Configure the ingress to allow connections to the application (typically uses an
       nginx.ingress.kubernetes.io/proxy-read-timeout: '3600'
       nginx.ingress.kubernetes.io/proxy-send-timeout: '3600'
       nginx.ingress.kubernetes.io/proxy-body-size: 30m
+      nginx.ingress.kubernetes.io/use-regex: "true"
 
     hosts:
       - host: topomojo.example.com
         paths:
-          - path: /tm/api
-            pathType: ImplementationSpecific
-          - path: /tm/hub
-            pathType: ImplementationSpecific
-          - path: /tm/docs
-            pathType: ImplementationSpecific
-          - path: /tm/theme
+          - path: /tm/(api|hub|docs|theme)
             pathType: ImplementationSpecific
     tls:
       - secretName: tls-secret-name # this tls secret should already exist

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -329,6 +329,16 @@ topomojo-api:
     FileUpload__MaxFileBytes: 21474836480  # 20 GB cap
 ```
 
+#### Volume Permissions
+
+On startup, an init container chowns the paths under `FileUpload__TopoRoot` and `FileUpload__DocRoot` to UID/GID `1654` (the .NET runtime user). Set `SKIP_VOL_PERMISSIONS` to `"true"` to skip this step — for example, when using a storage class that handles ownership automatically or when the pod runs with a different security context.
+
+```yaml
+topomojo-api:
+  env:
+    SKIP_VOL_PERMISSIONS: "true"
+```
+
 #### Extra Environment Sources
 
 Inject additional environment variables into the API container from existing Kubernetes Secrets or ConfigMaps using `extraEnvFrom`. This is useful for integrating with external secret managers such as AWS Secrets Manager (via the [External Secrets Operator](https://external-secrets.io/)) or HashiCorp Vault.

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -410,17 +410,13 @@ topomojo-api:
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
 
-#### OpenTelemetry Settings Reference
-
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | Wire protocol used by the OTLP exporter. Use `http/protobuf` to force HTTP instead of the default gRPC. | `http/protobuf` |
-| `OTEL_SERVICE_NAME` | Service name reported to the OpenTelemetry collector. Overrides the default derived from the application name. | `topomojo-api` |
-| `OpenTelemetry__AddAlwaysOnTracingSampler` | When `true`, enables an always-on sampler that records every trace regardless of upstream sampling decisions. | `false` |
-| `OpenTelemetry__AddConsoleExporter` | When `true`, exports traces and metrics to the console (stdout). Useful for local debugging. | `false` |
-| `OpenTelemetry__AddPrometheusExporter` | When `true`, exposes a `/metrics` Prometheus scrape endpoint. | `false` |
-| `OpenTelemetry__IncludeDefaultActivitySources` | When `true`, registers the default ASP.NET Core and HttpClient activity sources for distributed tracing. | `true` |
-| `OpenTelemetry__IncludeDefaultMeters` | When `true`, registers the default ASP.NET Core, HttpClient, EF Core, and runtime meters. | `true` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | Always sample every trace (useful for development; not recommended in high-traffic production) | `false` |
+| `OpenTelemetry__AddConsoleExporter` | Export traces and metrics to stdout in addition to the OTLP endpoint | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | Expose a `/metrics` scrape endpoint for Prometheus | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | Register the default ASP.NET Core, HttpClient, and EF Core activity sources | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | Register the default ASP.NET Core, HttpClient, and runtime meters | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -164,7 +164,6 @@ unset (the default is `false`) and behavior is unchanged.
 | `Core__DefaultTemplateLimit` | Max VMs per workspace | `3` |
 | `Core__DefaultUserScope` | Default scope assigned to new users for gamespace access | `everyone` |
 | `Core__ReplicaLimit` | Maximum number of replicas allowed per gamespace | `5` |
-| `Core__NetworkHostTemplateId` | Template ID used for network host VMs (0 = disabled) | `0` |
 | `Core__GameEngineIsoFolder` | Folder name within the ISO store used by the game engine | `static` |
 | `Core__LaunchUrl` | URL path used for gamespace launch links | `/lp` |
 | `Core__DocPath` | Server-relative path where workspace document assets are served from | `wwwroot/docs` |

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -24,6 +24,12 @@ helm install topomojo sei/topomojo -f values.yaml
 
 The following are configured via the `topomojo-api.env` settings. These TopoMojo API settings reflect the application's [appsettings.conf](https://github.com/cmu-sei/TopoMojo/blob/main/src/TopoMojo.Api/appsettings.conf) which may contain more settings than are described here.
 
+### General Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `PathBase` | Path base for virtual directory hosting (e.g., `/tm` when serving from a subpath) | `""` |
+
 ### Database Settings
 
 | Setting | Description | Values | Example |
@@ -38,12 +44,21 @@ The following are configured via the `topomojo-api.env` settings. These TopoMojo
 - For production, use `PostgreSQL` or `SqlServer`
 - `AdminId` should match the user's subject claim from your identity provider
 
+### Cache Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Cache__RedisUrl` | Redis connection URL for distributed caching. Leave empty to use the default in-process cache. | `""` |
+| `Cache__Key` | Cache key prefix used to namespace entries in the cache store. | `""` |
+| `Cache__SharedFolder` | Path to a shared folder used for file-based cache sharing between replicas. | `""` |
+
 ### Authentication (OIDC)
 
-| Setting | Description | Example |
+| Setting | Description | Default |
 |---------|-------------|---------|
-| `Oidc__Authority` | Identity provider URL | `https://identity.example.com` |
+| `Oidc__Authority` | Identity provider URL | `http://localhost:5000` |
 | `Oidc__Audience` | Expected audience in tokens | `topomojo-api` |
+| `Oidc__ServiceAccountClientIdClaimType` | JWT claim type used to identify service account clients. Set to `"null"` to disable client credentials authentication. | `client_id` |
 
 #### Identity Provider Role Mapping
 
@@ -141,13 +156,19 @@ unset (the default is `false`) and behavior is unchanged.
 
 ### Core Application Settings
 
-| Setting | Description | Example |
+| Setting | Description | Default |
 |---------|-------------|---------|
-| `Core__DefaultGamespaceMinutes` | Default gamespace duration | `60` (Default) |
-| `Core__DefaultGamespaceLimit` | Max concurrent gamespaces per user | `1` (Default) |
-| `Core__DefaultWorkspaceLimit` | Max workspaces per user (0=unlimited) | `10` (Default) |
-| `Core__DefaultTemplateLimit` | Max VMs per workspace | `10` (Default) |
-| `Core__AllowUnprivilegedVmReconfigure` | Allow users set VM networks to reserved network segments  | `false` (Default) |
+| `Core__DefaultGamespaceMinutes` | Default gamespace duration in minutes | `120` |
+| `Core__DefaultGamespaceLimit` | Max concurrent gamespaces per user | `2` |
+| `Core__DefaultWorkspaceLimit` | Max workspaces per user (0=unlimited) | `0` |
+| `Core__DefaultTemplateLimit` | Max VMs per workspace | `3` |
+| `Core__DefaultUserScope` | Default scope assigned to new users for gamespace access | `everyone` |
+| `Core__ReplicaLimit` | Maximum number of replicas allowed per gamespace | `5` |
+| `Core__NetworkHostTemplateId` | Template ID used for network host VMs (0 = disabled) | `0` |
+| `Core__GameEngineIsoFolder` | Folder name within the ISO store used by the game engine | `static` |
+| `Core__LaunchUrl` | URL path used for gamespace launch links | `/lp` |
+| `Core__DocPath` | Server-relative path where workspace document assets are served from | `wwwroot/docs` |
+| `Core__AllowUnprivilegedVmReconfigure` | Allow unprivileged users to set VM networks to reserved network segments | `false` |
 
 ### OpenAPI/Swagger
 
@@ -178,9 +199,14 @@ See the [TopoMojo documentation](https://github.com/cmu-sei/TopoMojo/blob/main/d
 | `Pod__Uplink` | Virtual switch for VM networking | `dvs-topomojo` or `vSwitch0` or `vmc-hostswitch` |
 | `Pod__Vlan__Range` | Available VLAN IDs for isolation | `100-200` or `10,20,30-40` |
 | `Pod__IsNsxNetwork` | Set to `true` when using NSX Networking. | `false` (default) |
+| `Pod__TicketUrlHandler` | Method used to construct VM console ticket URLs. | `querystring` |
 | `Pod__Sddc__AuthUrl` | When using a VMware Cloud SDDC, set the URL for SDDC authentication. | `https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize` |
-| `Pod__Sddc__MetadataUrl` | When using a VMware Cloud SDDC, set the URL used to read SDDC Metadata such as the NSX endpoint URLs | `https://vmc.vmware.com/vmc/api/orgs/<org_id>/sddcs/<sddc_id>`
-| Pod__Sddc__ApiKey` | When using a VMware Cloud SDDC, set the value of an API key for authentication | `api_key`
+| `Pod__Sddc__MetadataUrl` | When using a VMware Cloud SDDC, set the URL used to read SDDC Metadata such as the NSX endpoint URLs | `https://vmc.vmware.com/vmc/api/orgs/<org_id>/sddcs/<sddc_id>` |
+| `Pod__Sddc__ApiKey` | When using a VMware Cloud SDDC, set the value of an API key for authentication | `api_key` |
+| `Pod__Sddc__ApiUrl` | SDDC/vSphere API base URL for direct API calls (distinct from MetadataUrl). | `""` |
+| `Pod__Sddc__SegmentApiPath` | NSX-T API path used to manage SDDC network segments. | `policy/api/v1/infra/tier-1s/cgw/segments` |
+| `Pod__Sddc__CertificatePath` | Path to a client certificate file used for SDDC API authentication. | `""` |
+| `Pod__Sddc__CertificatePassword` | Password for the SDDC client certificate. | `""` |
 | `Pod__ExcludeNetworkMask` | Exclude network segments from TopoMojo | `vmcloud` |
 | `Pod__KeepAliveMinutes` | Connection keepalive interval | `10` |
 | `Pod__DebugVerbose` | Enable verbose hypervisor logging | `false` |
@@ -249,7 +275,7 @@ See the [TopoMojo documentation](https://github.com/cmu-sei/TopoMojo/blob/main/d
 | `Pod__Vlan__ResetDebounceDuration` | (Optional) Number of milliseconds to wait after a virtual network operation is initiated before reloading Proxmox's SDN. | `2000` |
 | `Pod__Vlan__ResetDebounceMaxDuration` | (Optional) Maximum number of milliseconds TopoMojo will debounce before it reloads Proxmox's SDN following a network operation. | `5000` |
 | `Pod__IsoStore` | Datastore for ISO files | `iso` |
-| `FileUpload_IsoRoot` | Path mounted to the container that ISOs uploaded through TopoMojo will be saved to - should map to the same storage as `Pod__IsoStore`. **For Proxmox deployments, this path must end with `/template/iso`.** | `/mnt/isos/template/iso` |
+| `FileUpload__IsoRoot` | Path mounted to the container that ISOs uploaded through TopoMojo will be saved to - should map to the same storage as `Pod__IsoStore`. **For Proxmox deployments, this path must end with `/template/iso`.** | `/mnt/isos/template/iso` |
 | `FileUpload_SupportsSubFolders` | Set to `false` for Proxmox deployments because Proxmox does not allow sub folders in ISO stores | `false` |
 
 
@@ -354,6 +380,13 @@ topomojo-api:
 
 Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables) spec and supports both `secretRef` and `configMapRef`.
 
+### Logging Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `Logging__Console__DisableColors` | Disable ANSI color codes in console log output (useful in environments that don't support color). | `false` |
+| `Logging__LogLevel__Default` | Default minimum log level for all categories. Valid values: `Trace`, `Debug`, `Information`, `Warning`, `Error`, `Critical`, `None`. | `Information` |
+
 ### OpenTelemetry
 
 TopoMojo.Api is wired with [Crucible.Common.ServiceDefaults](https://github.com/cmu-sei/crucible-common-dotnet/tree/main/src/Crucible.Common.ServiceDefaults), which auto-enables [OpenTelemetry](https://opentelemetry.io/) logs/traces/metrics. Configure the OTLP exporter endpoint and service name for TopoMojo to send OTLP to an OpenTelemetry Collector (e.g., [Otel Collector](https://opentelemetry.io/docs/collector/) or [Grafana Alloy](https://grafana.com/docs/alloy/latest/)):
@@ -377,6 +410,18 @@ topomojo-api:
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
 ```
+
+#### OpenTelemetry Settings Reference
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Wire protocol used by the OTLP exporter. Use `http/protobuf` to force HTTP instead of the default gRPC. | `http/protobuf` |
+| `OTEL_SERVICE_NAME` | Service name reported to the OpenTelemetry collector. Overrides the default derived from the application name. | `topomojo-api` |
+| `OpenTelemetry__AddAlwaysOnTracingSampler` | When `true`, enables an always-on sampler that records every trace regardless of upstream sampling decisions. | `false` |
+| `OpenTelemetry__AddConsoleExporter` | When `true`, exports traces and metrics to the console (stdout). Useful for local debugging. | `false` |
+| `OpenTelemetry__AddPrometheusExporter` | When `true`, exposes a `/metrics` Prometheus scrape endpoint. | `false` |
+| `OpenTelemetry__IncludeDefaultActivitySources` | When `true`, registers the default ASP.NET Core and HttpClient activity sources for distributed tracing. | `true` |
+| `OpenTelemetry__IncludeDefaultMeters` | When `true`, registers the default ASP.NET Core, HttpClient, EF Core, and runtime meters. | `true` |
 
 #### Default metrics from ServiceDefaults
 - Instrumentations: ASP.NET Core, HttpClient, Entity Framework Core, .NET runtime, and process resource metrics.

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: topomojo-api
 type: application
-version: 0.7.3
+version: 0.8.0
 appVersion: 2.8.0

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -226,9 +226,6 @@ env:
   # FileUpload__UploadTimeoutMinutes: 180
   # FileUpload__TempFileExpirationHours: 24
 
-  # FileUpload__TopoRoot: tm
-  # FileUpload__IsoRoot: tm/isos
-  # FileUpload__DocRoot: tm/_docs
   # Core__DefaultGamespaceMinutes: 120
   # Core__DefaultGamespaceLimit: 2
   # Core__DefaultWorkspaceLimit: 0

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -1,6 +1,3 @@
-# Default values for topomojo-api.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/topomojo-api
   pullPolicy: IfNotPresent
@@ -12,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -34,23 +26,47 @@ securityContext: {}
   # runAsUser: 1000
 
 service: {}
-#   type: ClusterIP
-#   port: 80
+  # type: ClusterIP
+  # port: 80
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 200m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+health: {}
+  # livenessProbe:
+  #   initialDelaySeconds: 10
+  #   httpGet:
+  #     path: /api/healthz
+  #     port: http
+  # startupProbe:
+  #   initialDelaySeconds: 30
+  #   httpGet:
+  #     path: /api/healthz
+  #     port: http
+  #   failureThreshold: 9
+  #   periodSeconds: 10
 
 ingress:
-  enabled: false
+  enabled: true
   className: ""
   annotations: {}
   hosts:
     - host: chart-example.local
       paths:
-        - path: /api
-          pathType: ImplementationSpecific
-        - path: /hub
-          pathType: ImplementationSpecific
-        - path: /docs
-          pathType: ImplementationSpecific
-        - path: /theme
+        - path: /(api|hub|docs|theme)
           pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
@@ -102,46 +118,15 @@ consoleIngress:
   hosts:
     - host: connect.example.com
       paths: []
-  tls:
-    - secretName: ""
-      hosts:
-        - connect.example.com
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
-health: {}
-  # livenessProbe:
-  #   httpGet:
-  #     port: 8080
-  #     path: /api/healthz/<template_id>
-  #     httpHeaders:
-  #       - name: Accept
-  #         value: "*/*"
-  #   initialDelaySeconds: 120
-  #   periodSeconds: 60
-  #   timeoutSeconds: 3
-  #   failureThreshold: 2
-
-  # startupProbe:
-  #   httpGet:
-  #     port: 8080
-  #     path: /api/healthz/<template_id>
-  #     httpHeaders:
-  #       - name: Accept
-  #         value: "*/*"
-  #   initialDelaySeconds: 10
-  #   periodSeconds: 10
-  #   timeoutSeconds: 3
-  #   failureThreshold: 60
-
-  # readinessProbe:
-  #   httpGet:
-  #     port: 8080
-  #     path: /api/healthz/<template_id>
-  #     httpHeaders:
-  #       - name: Accept
-  #         value: "*/*"
-  #   initialDelaySeconds: 120
-  #   periodSeconds: 10
-  #   timeoutSeconds: 3
+# If this deployment needs to trust non-public certificates,
+# create a configMap with the needed certificates and specify
+# the configMap name here
+certificateMap: ""
 
 # storage - either an existing pvc, the size for a new pvc, or emptyDir
 storage:
@@ -149,24 +134,6 @@ storage:
   size: ""
   mode: ReadWriteOnce
   class: default
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 200m
-  #   memory: 512Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 256Mi
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
 
 ## migrations sets how data migrations run
 ## If enabled, all replicas will wait until a single migration job runs.
@@ -209,7 +176,7 @@ extraEnvFrom: []
 
 # Config app settings with environment vars.
 # Those most likely needing values are listed. For others,
-# see https://github.com/cmu-sei/TopoMojo/blob/master/src/TopoMojo.Api/appsettings.conf
+# see https://github.com/cmu-sei/TopoMojo/blob/main/src/TopoMojo.Api/appsettings.conf
 env:
   ## By default we change ownership of the paths at and recursively below the root of the topomojo docs directory
   ## to that of the running user and group, which are both 1654 per .NET conventions.
@@ -240,25 +207,28 @@ env:
   # OpenApi__ApiName: TopoMojo
   # OpenApi__Client__ClientId: topomojo-swagger
 
-  FileUpload__TopoRoot: /mnt/tm
+  # FileUpload__TopoRoot: /mnt/tm
   ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
   ## the NFS share your ESXi hosts also mount as a vSphere datastore.
-  FileUpload__IsoRoot: /mnt/tm/isos
+  # FileUpload__IsoRoot: /mnt/tm/isos
   ## DocRoot points at the chart's dedicated wwwroot/docs mount so uploaded
   ## images are served by ASP.NET's static-file handler.
-  FileUpload__DocRoot: /home/app/wwwroot/docs
+  # FileUpload__DocRoot: /home/app/wwwroot/docs
   # FileUpload__MaxFileBytes: 21474836480  # 20GB
+  # FileUpload__SupportsSubfolders: false  # Set false for Proxmox with local ISO storage
 
   ## VMware Cloud API upload settings (when NFS mount unavailable).
   ## TempRoot is set to a subdirectory of the existing topomojo
   ## PVC mount; the vol-permissions init container creates and chowns it.
   ## Override only if you have provisioned alternative storage yourself.
-  FileUpload__TempRoot: /mnt/tm/_iso-staging
+  # FileUpload__TempRoot: /mnt/tm/_iso-staging
   # FileUpload__UseDatastoreApi: false
-  # FileUpload__SupportsSubfolders: true  # Set false for Proxmox with local ISO storage
   # FileUpload__UploadTimeoutMinutes: 180
   # FileUpload__TempFileExpirationHours: 24
 
+  # FileUpload__TopoRoot: tm
+  # FileUpload__IsoRoot: tm/isos
+  # FileUpload__DocRoot: tm/_docs
   # Core__DefaultGamespaceMinutes: 120
   # Core__DefaultGamespaceLimit: 2
   # Core__DefaultWorkspaceLimit: 0
@@ -298,14 +268,20 @@ env:
 
   # Ui__Branding__BackgroundImageUrl = theme/demo.png
 
+  # Open Telemetry
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
-  # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-  # OTEL_SERVICE_NAME: topomojo-api
+
+  # These settings toggle ServiceDefaults configurations for Otel
   # OpenTelemetry__AddAlwaysOnTracingSampler: false
   # OpenTelemetry__AddConsoleExporter: false
   # OpenTelemetry__AddPrometheusExporter: false
   # OpenTelemetry__IncludeDefaultActivitySources: true
   # OpenTelemetry__IncludeDefaultMeters: true
+
+  # Optional: force HTTP instead of the default gRPC protocol
+  # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+  # Optional: override the service name reported to collectors
+  # OTEL_SERVICE_NAME: topomojo-api
 
 ## Create a seed data file based on the contents of an existing secret
 ## or by values that support templating via the tpl function.

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -191,7 +191,7 @@ env:
   # Oidc__UserRolesClaimMap__creator: Creator
   # Oidc__UserRolesClaimMap__observer: Observer
   # Oidc__UserRolesClaimMap__user: user
-  # Oidc__UserRolesClaimPath = realm_access.roles
+  # Oidc__UserRolesClaimPath: realm_access.roles
 
   # Database__Provider: InMemory
   # Database__ConnectionString: topomojo_db
@@ -208,7 +208,7 @@ env:
   # OpenApi__Client__ClientId: topomojo-swagger
 
   # FileUpload__TopoRoot: /mnt/tm
-  ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
+  ## In NFS mode (UseDatastoreApi: false), override this to a path backed by
   ## the NFS share your ESXi hosts also mount as a vSphere datastore.
   # FileUpload__IsoRoot: /mnt/tm/isos
   ## DocRoot points at the chart's dedicated wwwroot/docs mount so uploaded
@@ -254,7 +254,7 @@ env:
   # Pod__IsNsxNetwork: false
   # Pod__Sddc__ApiUrl: ""
   # Pod__Sddc__MetadataUrl: ""
-  # Pod__Sddc__SegmentApiPath = policy/api/v1/infra/tier-1s/cgw/segments
+  # Pod__Sddc__SegmentApiPath: policy/api/v1/infra/tier-1s/cgw/segments
   # Pod__Sddc__ApiKey: ""
   # Pod__Sddc__AuthUrl: ""
   # Pod__Sddc__CertificatePath: ""
@@ -263,7 +263,7 @@ env:
   # Logging__Console__DisableColors: false
   # Logging__LogLevel__Default: Information
 
-  # Ui__Branding__BackgroundImageUrl = theme/demo.png
+  # Ui__Branding__BackgroundImageUrl: theme/demo.png
 
   # Open Telemetry
   # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -116,7 +116,7 @@ consoleIngress:
         proxy_ssl_session_reuse on;
       }
   hosts:
-    - host: connect.example.com
+    - host: chart-example.local
       paths: []
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -62,7 +62,13 @@ health: {}
 ingress:
   enabled: true
   className: ""
-  annotations: {}
+  # Default annotations target nginx-ingress. The use-regex flag is required
+  # for the regex-style ImplementationSpecific path below to actually match;
+  # without it, nginx treats the parens as literal characters.
+  annotations:
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/use-regex: "true"
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/topomojo/charts/topomojo-ui/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: topomojo-ui
 type: application
-version: 0.6.5
+version: 0.7.0
 appVersion: 2.5.10

--- a/charts/topomojo/charts/topomojo-ui/values.yaml
+++ b/charts/topomojo/charts/topomojo-ui/values.yaml
@@ -1,6 +1,3 @@
-# Default values for topomojo-ui.
-# Declare variables to be passed into your templates.
-
 image:
   repository: cmusei/topomojo-ui
   pullPolicy: IfNotPresent
@@ -12,19 +9,14 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
   create: false
-  # Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If name is not set and create is true,
+  # a name is generated using the fullname template
   name: ""
 
 podAnnotations: {}
-
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
   # capabilities:
   #   drop:
@@ -36,20 +28,6 @@ securityContext: {}
 service: {}
   # type: ClusterIP
   # port: 80
-
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -64,10 +42,22 @@ resources: {}
   #   memory: 10Mi
 
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
+
+ingress:
+  enabled: true
+  className: ""
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 ## basehref is path to the app
 basehref: ""

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -1,8 +1,4 @@
 topomojo-api:
-  # Default values for topomojo-api.
-  # This is a YAML-formatted file.
-  # Declare variables to be passed into your templates.
-
   image:
     repository: cmusei/topomojo-api
     pullPolicy: IfNotPresent
@@ -13,32 +9,15 @@ topomojo-api:
   nameOverride: ""
   fullnameOverride: ""
 
-  # livenessProbe:
-  #   httpGet:
-  #     path: /api/healthz/<template_id>
-
-  # startupProbe:
-  #   httpGet:
-  #     path: /api/healthz/<template_id>
-
-  # readinessProbe:
-  #   httpGet:
-  #     path: /api/healthz/<template_id>
-
   serviceAccount:
-    # Specifies whether a service account should be created
     create: true
-    # Annotations to add to the service account
     annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
     name: ""
 
   podAnnotations: {}
-
   podSecurityContext: {}
-    # fsGroup: 2000
-
   securityContext: {}
     # capabilities:
     #   drop:
@@ -51,20 +30,44 @@ topomojo-api:
     # type: ClusterIP
     # port: 80
 
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 200m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 256Mi
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  health: {}
+    # livenessProbe:
+    #   initialDelaySeconds: 10
+    #   httpGet:
+    #     path: /api/healthz
+    #     port: http
+    # startupProbe:
+    #   initialDelaySeconds: 30
+    #   httpGet:
+    #     path: /api/healthz
+    #     port: http
+    #   failureThreshold: 9
+    #   periodSeconds: 10
+
   ingress:
-    enabled: false
+    enabled: true
     className: ""
     annotations: {}
     hosts:
       - host: chart-example.local
         paths:
-          - path: /api
-            pathType: ImplementationSpecific
-          - path: /hub
-            pathType: ImplementationSpecific
-          - path: /docs
-            pathType: ImplementationSpecific
-          - path: /theme
+          - path: /(api|hub|docs|theme)
             pathType: ImplementationSpecific
     tls: []
     #  - secretName: chart-example-tls
@@ -116,24 +119,15 @@ topomojo-api:
     hosts:
       - host: connect.example.com
         paths: []
-    tls:
-      - secretName: ""
-        hosts:
-          - connect.example.com
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
-  health: {}
-    # livenessProbe:
-    #   initialDelaySeconds: 10
-    #   httpGet:
-    #     path: /api/healthz
-    #     port: http
-    # startupProbe:
-    #   initialDelaySeconds: 30
-    #   httpGet:
-    #     path: /api/healthz
-    #     port: http
-    #   failureThreshold: 9
-    #   periodSeconds: 10
+  # If this deployment needs to trust non-public certificates,
+  # create a configMap with the needed certificates and specify
+  # the configMap name here
+  certificateMap: ""
 
   # storage - either an existing pvc, the size for a new pvc, or emptyDir
   storage:
@@ -141,24 +135,6 @@ topomojo-api:
     size: ""
     mode: ReadWriteOnce
     class: default
-
-  resources: {}
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #   cpu: 200m
-    #   memory: 512Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 256Mi
-
-  nodeSelector: {}
-
-  tolerations: []
-
-  affinity: {}
 
   ## migrations sets how data migrations run
   ## If enabled, all replicas will wait until a single migration job runs.
@@ -201,7 +177,7 @@ topomojo-api:
 
   # Config app settings with environment vars.
   # Those most likely needing values are listed. For others,
-  # see https://github.com/cmu-sei/TopoMojo/blob/master/src/TopoMojo.Api/appsettings.conf
+  # see https://github.com/cmu-sei/TopoMojo/blob/main/src/TopoMojo.Api/appsettings.conf
   env:
     ## By default we change ownership of the paths at and recursively below the root of the topomojo docs directory
     ## to that of the running user and group, which are both 1654 per .NET conventions.
@@ -231,7 +207,7 @@ topomojo-api:
     # OpenApi__Enabled: true
     # OpenApi__ApiName: TopoMojo
     # OpenApi__Client__ClientId: topomojo-swagger
-    
+
     # FileUpload__TopoRoot: /mnt/tm
     ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
     ## the NFS share your ESXi hosts also mount as a vSphere datastore.
@@ -293,14 +269,20 @@ topomojo-api:
 
     # Ui__Branding__BackgroundImageUrl = theme/demo.png
 
+    # Open Telemetry
     # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
-    # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-    # OTEL_SERVICE_NAME: topomojo-api
+
+    # These settings toggle ServiceDefaults configurations for Otel
     # OpenTelemetry__AddAlwaysOnTracingSampler: false
     # OpenTelemetry__AddConsoleExporter: false
     # OpenTelemetry__AddPrometheusExporter: false
     # OpenTelemetry__IncludeDefaultActivitySources: true
     # OpenTelemetry__IncludeDefaultMeters: true
+
+    # Optional: force HTTP instead of the default gRPC protocol
+    # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+    # Optional: override the service name reported to collectors
+    # OTEL_SERVICE_NAME: topomojo-api
 
   ## Create a seed data file based on the contents of an existing secret
   ## or by values that support templating via the tpl function.
@@ -321,10 +303,6 @@ topomojo-api:
     #       IsAdmin: true
 
 topomojo-ui:
-  # Default values for topomojo-ui.
-  # This is a YAML-formatted file.
-  # Declare variables to be passed into your templates.
-
   image:
     repository: cmusei/topomojo-ui
     pullPolicy: IfNotPresent
@@ -336,19 +314,14 @@ topomojo-ui:
   fullnameOverride: ""
 
   serviceAccount:
-    # Specifies whether a service account should be created
     create: false
-    # Annotations to add to the service account
     annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
+    # If name is not set and create is true,
+    # a name is generated using the fullname template
     name: ""
 
   podAnnotations: {}
-
   podSecurityContext: {}
-    # fsGroup: 2000
-
   securityContext: {}
     # capabilities:
     #   drop:
@@ -360,20 +333,6 @@ topomojo-ui:
   service: {}
     # type: ClusterIP
     # port: 80
-
-  ingress:
-    enabled: false
-    className: ""
-    annotations: {}
-    hosts:
-      - host: chart-example.local
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
@@ -388,10 +347,22 @@ topomojo-ui:
     #   memory: 10Mi
 
   nodeSelector: {}
-
   tolerations: []
-
   affinity: {}
+
+  ingress:
+    enabled: true
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
 
   ## basehref is path to the app
   basehref: ""

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -53,8 +53,8 @@ topomojo-api:
 
   ingress:
     enabled: false
+    className: ""
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
     hosts:
       - host: chart-example.local
         paths:
@@ -187,7 +187,7 @@ topomojo-api:
     #     cd /app && dotnet TopoMojo.Api.dll
     #   cacert.crt: ""
 
-  ## existingSecret references a secret already in k8s. The values are saved as files in `/app/conf`.
+  ## existingSecret references a secret already in k8s. The values are saved as files in `/home/app/conf`.
   existingSecret: ""
 
   ## extraEnvFrom injects additional envFrom sources (secrets or configmaps) into the API container.
@@ -203,6 +203,9 @@ topomojo-api:
   # Those most likely needing values are listed. For others,
   # see https://github.com/cmu-sei/TopoMojo/blob/master/src/TopoMojo.Api/appsettings.conf
   env:
+    ## By default we change ownership of the paths at and recursively below the root of the topomojo docs directory
+    ## to that of the running user and group, which are both 1654 per .NET conventions.
+    SKIP_VOL_PERMISSIONS: "false"
     # PathBase: ""
     # Oidc__Audience: topomojo-api
     # Oidc__Authority: http://localhost:5000
@@ -213,21 +216,40 @@ topomojo-api:
     # Oidc__UserRolesClaimMap__creator: Creator
     # Oidc__UserRolesClaimMap__observer: Observer
     # Oidc__UserRolesClaimMap__user: user
-    # Oidc__UserRolesClaimPath: realm_access.roles
+    # Oidc__UserRolesClaimPath = realm_access.roles
+
     # Database__Provider: InMemory
     # Database__ConnectionString: topomojo_db
     # Database__SeedFile: seed-data.json
     # Database__AdminId: ""
     # Database__AdminName: ""
+
     # Cache__RedisUrl: ""
     # Cache__Key: ""
     # Cache__SharedFolder: ""
+
     # OpenApi__Enabled: true
     # OpenApi__ApiName: TopoMojo
     # OpenApi__Client__ClientId: topomojo-swagger
-    # FileUpload__TopoRoot: tm
-    # FileUpload__IsoRoot: tm/isos
-    # FileUpload__DocRoot: tm/_docs
+
+    FileUpload__TopoRoot: /mnt/tm
+    ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
+    ## the NFS share your ESXi hosts also mount as a vSphere datastore.
+    FileUpload__IsoRoot: /mnt/tm/isos
+    ## DocRoot points at the chart's dedicated wwwroot/docs mount so uploaded
+    ## images are served by ASP.NET's static-file handler.
+    FileUpload__DocRoot: /home/app/wwwroot/docs
+    # FileUpload__MaxFileBytes: 21474836480  # 20GB
+
+    ## VMware Cloud API upload settings (when NFS mount unavailable).
+    ## TempRoot is set to a subdirectory of the existing topomojo
+    ## PVC mount; the vol-permissions init container creates and chowns it.
+    ## Override only if you have provisioned alternative storage yourself.
+    FileUpload__TempRoot: /mnt/tm/_iso-staging
+    # FileUpload__UseDatastoreApi: false
+    # FileUpload__UploadTimeoutMinutes: 180
+    # FileUpload__TempFileExpirationHours: 24
+
     # Core__DefaultGamespaceMinutes: 120
     # Core__DefaultGamespaceLimit: 2
     # Core__DefaultWorkspaceLimit: 0
@@ -240,6 +262,7 @@ topomojo-api:
     # Core__LaunchUrl: /lp
     # Core__DocPath: wwwroot/docs
     # Core__AllowUnprivilegedVmReconfigure: false
+
     # Pod__Url: ""
     # Pod__User: ""
     # Pod__Password: ""
@@ -260,9 +283,12 @@ topomojo-api:
     # Pod__Sddc__AuthUrl: ""
     # Pod__Sddc__CertificatePath: ""
     # Pod__Sddc__CertificatePassword: ""
+
     # Logging__Console__DisableColors: false
     # Logging__LogLevel__Default: Information
+
     # Ui__Branding__BackgroundImageUrl = theme/demo.png
+
     # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
     # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     # OTEL_SERVICE_NAME: topomojo-api
@@ -333,9 +359,8 @@ topomojo-ui:
 
   ingress:
     enabled: false
+    className: ""
     annotations: {}
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
     hosts:
       - host: chart-example.local
         paths:
@@ -384,7 +409,7 @@ topomojo-ui:
   settings: ""
 
   ## assets/settings.json content in yaml form. Takes precedence over settings: value when populated.
-  settingsYaml:
+  settingsYaml: {}
     # appname: TopoMojo
     # docsUrl: https://cmu-sei.github.io/crucible/topomojo
     # disableExternalLinks: true

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -192,7 +192,7 @@ topomojo-api:
     # Oidc__UserRolesClaimMap__creator: Creator
     # Oidc__UserRolesClaimMap__observer: Observer
     # Oidc__UserRolesClaimMap__user: user
-    # Oidc__UserRolesClaimPath = realm_access.roles
+    # Oidc__UserRolesClaimPath: realm_access.roles
 
     # Database__Provider: InMemory
     # Database__ConnectionString: topomojo_db
@@ -209,7 +209,7 @@ topomojo-api:
     # OpenApi__Client__ClientId: topomojo-swagger
 
     # FileUpload__TopoRoot: /mnt/tm
-    ## In NFS mode (UseDatastoreApi=false), override this to a path backed by
+    ## In NFS mode (UseDatastoreApi: false), override this to a path backed by
     ## the NFS share your ESXi hosts also mount as a vSphere datastore.
     # FileUpload__IsoRoot: /mnt/tm/isos
     ## DocRoot points at the chart's dedicated wwwroot/docs mount so uploaded
@@ -255,7 +255,7 @@ topomojo-api:
     # Pod__IsNsxNetwork: false
     # Pod__Sddc__ApiUrl: ""
     # Pod__Sddc__MetadataUrl: ""
-    # Pod__Sddc__SegmentApiPath = policy/api/v1/infra/tier-1s/cgw/segments
+    # Pod__Sddc__SegmentApiPath: policy/api/v1/infra/tier-1s/cgw/segments
     # Pod__Sddc__ApiKey: ""
     # Pod__Sddc__AuthUrl: ""
     # Pod__Sddc__CertificatePath: ""
@@ -264,7 +264,7 @@ topomojo-api:
     # Logging__Console__DisableColors: false
     # Logging__LogLevel__Default: Information
 
-    # Ui__Branding__BackgroundImageUrl = theme/demo.png
+    # Ui__Branding__BackgroundImageUrl: theme/demo.png
 
     # Open Telemetry
     # OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -63,7 +63,13 @@ topomojo-api:
   ingress:
     enabled: true
     className: ""
-    annotations: {}
+    # Default annotations target nginx-ingress. The use-regex flag is required
+    # for the regex-style ImplementationSpecific path below to actually match;
+    # without it, nginx treats the parens as literal characters.
+    annotations:
+      # nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+      # nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+      nginx.ingress.kubernetes.io/use-regex: "true"
     hosts:
       - host: chart-example.local
         paths:

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -227,9 +227,6 @@ topomojo-api:
     # FileUpload__UploadTimeoutMinutes: 180
     # FileUpload__TempFileExpirationHours: 24
 
-    # FileUpload__TopoRoot: tm
-    # FileUpload__IsoRoot: tm/isos
-    # FileUpload__DocRoot: tm/_docs
     # Core__DefaultGamespaceMinutes: 120
     # Core__DefaultGamespaceLimit: 2
     # Core__DefaultWorkspaceLimit: 0

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -117,7 +117,7 @@ topomojo-api:
           proxy_ssl_session_reuse on;
         }
     hosts:
-      - host: connect.example.com
+      - host: chart-example.local
         paths: []
     tls: []
     #  - secretName: chart-example-tls


### PR DESCRIPTION

## High-level summary

This PR is a wide-ranging cleanup of every Crucible app chart (alloy, blueprint, caster, cite, gallery, gameboard, player, steamfitter, topomojo). It does three things:

1. **Re-aligns parent `values.yaml` files with their subcharts.** Many subchart keys were missing from the parent values, which silently relied on subchart defaults. The parent now mirrors the full child schema so every override is discoverable in one file.
2. **Removes example/sample values from defaults.** URLs like `https://identity.example.com`, `https://X.example.com`, prebaked `kubernetes.io/ingress.class: nginx` annotations, sample CORS origins, dummy TLS secrets, and template Postgres connection strings are gone. Defaults are now empty (`""` / `[]` / `{}`) or commented-out placeholders, so a chart rendered with no overrides produces nothing surprising.
3. **Standardizes and expands READMEs.** All apps now share the same section structure (CORS, xAPI, OpenTelemetry), the same heading names (`### CORS Policy Settings`, `### xAPI Settings`), and the same OTel settings table. CITE / Blueprint / Gallery / Steamfitter gained full `XApiOptions__*` tables. Player, Caster, Steamfitter, Alloy, Blueprint, CITE, Gallery, Topomojo gained the `OpenTelemetry__*` settings table. Various typos and broken `master`-branch links were fixed.
4. Every modified chart receives a minor bump to account for changes to settings, values, and the readme.

---

## Changes by area

### 1. Parent / subchart values sync

For every parent `values.yaml`, the block under each subchart key (e.g., `alloy` → `alloy-api:`, `alloy-ui:`,) was made identical to the subchart's own `values.yaml`. This will allow a future PR to add automation ensuring parent/child chart values remain in sync, preventing a case where settings are added to / removed from parent/child charts without updating the other. It is rare that our apps would ever be deployed without using the parent chart, so that chart being the single source of truth simplifies operator experience.


### 2. README accuracy and standardization

All parent READMEs were re-audited against `values.yaml` and the upstream `appsettings.json`. Stale entries were removed, missing settings were added, and section structure was harmonized:

- **CORS section** — every chart now uses `### CORS Policy Settings` with the same column header (`Setting | Description | Example`), now includes the previously-undocumented `CorsPolicy__Origins__0` row, and ends with the same `**Note:** Additional origins can be added using the pattern CorsPolicy__Origins__1, ...` sentence. Gameboard has its own variant since it uses `Headers__Cors__*` — explicitly documented.
- **xAPI section** — added to **blueprint, cite, gallery, steamfitter** (12 settings each: `Enabled`, `Endpoint`, `Username`, `Password`, `IssuerUrl`, `ApiUrl`, `UiUrl`, `EmailDomain`, `Platform`, `RetentionDays`, `ProcessingTimeoutMinutes`, `ProcessingDelaySeconds`).
- **OpenTelemetry section** — restructured to a consistent shape across all charts: intro paragraph → YAML example → `OpenTelemetry__*` settings table (5 rows: `AddAlwaysOnTracingSampler`, `AddConsoleExporter`, `AddPrometheusExporter`, `IncludeDefaultActivitySources`, `IncludeDefaultMeters`) → "Default metrics from ServiceDefaults". Per-chart fixes:
- Several charts received edits to add missing sections or add additional documentation for settings that were previously undocumented.

---

## Default chart-value changes

These are the places a default that someone could observe in a rendered manifest actually changed. Cosmetic / whitespace / comment-only changes are not listed.

### Removed or zeroed-out example values (parent charts)

All of the following were previously hardcoded to sample/example values in parent `values.yaml` and now default to `""` or are commented out. **Why:** these are user-specific values that should never have shipped as live defaults — rendering a chart with no overrides was producing manifests that referenced `example.com`, sample identity URLs, and template Postgres connection strings. The new defaults make a no-override render produce empty strings instead of pointing at fake hosts.

| Setting | Old default | New default | Charts affected |
|---|---|---|---|
| `Authorization__Authority` | `https://identity.example.com` | `""` | alloy-api, blueprint-api, caster-api, cite-api, gallery-api, player-api, steamfitter-api, vm-api |
| `Authorization__AuthorizationUrl` | `https://identity.example.com/connect/authorize` | `""` | same as above |
| `Authorization__TokenUrl` | `https://identity.example.com/connect/token` | `""` | same as above |
| `ResourceOwnerAuthorization__Authority` | `https://identity.example.com` | `""` | alloy-api |
| `Client__TokenUrl` | `https://identity.example.com/connect/token` | `""` | caster-api |
| `IdentityClient__TokenUrl` | `https://identity.example.com/connect/token` | `""` | vm-api |
| `SEI_CRUCIBLE_AUTH_URL`, `SEI_CRUCIBLE_TOK_URL`, `SEI_CRUCIBLE_VM_API_URL`, `SEI_CRUCIBLE_PLAYER_API_URL`, `SEI_IDENTITY_TOK_URL`, `SEI_IDENTITY_API_URL` | `https://identity.example.com/...`, `https://vm.example.com/...`, etc. | `""` | caster-api |
| `SEI_CRUCIBLE_CLIENT_ID` | `player.provider` | `""` | caster-api |
| `SEI_IDENTITY_CLIENT_ID` | `terraform-identity-provider` | `""` | caster-api |
| `Player__VmApiUrl`, `Player__VmConsoleUrl` | `https://vm.example.com`, `https://console.example.com/vm/{id}/console` | `""` | caster-api |
| `ConnectionStrings__PostgreSQL` | `"Server=postgres;Port=5432;Database=<app>_api;Username=<app>_dbu;Password=;"` | `""` | every API chart |
| `CorsPolicy__Origins__0` | sample URLs (e.g. `https://alloy.example.com`, `https://blueprint.example.com`, `https://cite.example.com`, `https://gallery.example.com`, `https://player.example.com`, `https://caster.example.com`) | commented out (`# CorsPolicy__Origins__0: ""`) | every API chart that previously hardcoded one |
| `CorsPolicy__Origins__1` / `__2` (player-api) | `https://vm.example.com`, `https://osticket.example.com` | commented out | player-api |
| `CorsPolicy__Origins__1` (vm-api) | `https://console.example.com` | commented out | vm-api |
| `CorsPolicy__Methods__0`, `CorsPolicy__Headers__0` | `""` (active) | commented out (`# ...`) | all API charts — Why: an empty value still emits a `CorsPolicy:Methods:0=""` env var, which the application sees as a configured-but-empty allow list. Commenting it out drops the env var entirely. |
| `VSPHERE_SERVER`, `VSPHERE_USER` | `vcenter.example.com`, `caster-account@vsphere.local` | `""` | caster-api |
| `Vsphere__Host`, `Vsphere__Username` | `vcenter.example.com`, `player-account@vsphere.local` | `""` | vm-api |
| `ClientSettings__urls__playerApi`, `__casterApi`, `__steamfitterApi` | sample URLs | `""` | alloy-api |
| `ClientSettings__urls__playerApi` | `https://player.example.com` | `""` | vm-api |
| `RewriteHost__RewriteHostUrl` | `connect.example.com` | `""` | vm-api |

### Ingress / TLS defaults

| Setting | Old default | New default | Why |
|---|---|---|---|
| `<*>.ingress.annotations` | `kubernetes.io/ingress.class: nginx` plus `nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"`, `proxy-send-timeout`, `use-regex: "true"`, etc. — for many `*-api` and `*-ui` parents | `{}` | Drops the assumption that the cluster runs ingress-nginx. Class is now selected via `className`, and any cluster-specific annotations are an explicit user choice. |
| `<*>.ingress.tls` | `[{secretName: "", hosts: ["example.com"]}]` (most parent ingresses) | `[]` (commented placeholder example only) | The old default emitted a TLS section pointing at an empty `secretName` / fake host, which produces a broken Ingress on render. |
| `topomojo-api.consoleIngress.tls` | `[{secretName: "", hosts: ["connect.example.com"]}]` | `[]` | Same reason as above. |
| `<api-subchart>.ingress.enabled` | `false` | **`true`** | Subcharts now match the parent expectation (parents had `enabled: true`). Affected: `alloy-api`, `alloy-ui`, `blueprint-api`, `blueprint-ui`, `caster-api`, `caster-ui`, `cite-api`, `cite-ui`, `gallery-api`, `gallery-ui`, `gameboard-api`, `gameboard-ui`, `steamfitter-api`, `steamfitter-ui`, `topomojo-api`, `topomojo-ui`. |
| `<api>.ingress.hosts[0].host` | various app-named example hostnames (e.g. `alloy.example.com`) in parents | `chart-example.local` | Conventional Helm placeholder; user must override. |
| `<api>.ingress.hosts[0].paths` | one path per route (e.g. `/api`, `/swagger`, `/hubs`, `/theme`, `/img`, `/docs`) | a single regex-consolidated path (`/(api|swagger|hubs)`, `/(api|hub|docs|theme)`, `/(api|hub|img|docs|supportfiles)`, etc.) | One Ingress rule with `nginx.ingress.kubernetes.io/use-regex: "true"` is simpler and matches what the parent README documents. Affected: alloy-api, blueprint-api, caster-api, cite-api, gallery-api, gameboard-api, player-api, steamfitter-api, topomojo-api, vm-api. |

### Subchart `service.port` harmonization

| Chart | Old | New |
|---|---|---|
| `blueprint-api` | `8080` | `80` |
| `cite-api` | `8080` | `80` |
| `gallery-api` | `8080` | `80` |

**Why:** every other chart already used port `80`. The Service is now uniform across the platform.

### `caster-api` subchart env defaults

| Setting | Old | New | Why |
|---|---|---|---|
| `Terraform__DefaultVersion` | `0.12.24` | `0.14.0` | Subchart was lagging the parent (parent already used `0.14.0`); brings them into sync. |
| `Terraform__GitlabGroupId` | `6` | `""` | The literal `6` was a leftover from a development environment; shipping it as a default was a data leak risk for anyone auto-rendering. |
| `CorsPolicy__Origins__0` | `http://localhost:4310` | commented out | Same rationale as the umbrella charts — local-dev value should not be a default. |
| `Authorization__Authority`, `__AuthorizationUrl`, `__TokenUrl`, `VSPHERE_SERVER`, `VSPHERE_USER`, `VSPHERE_PASSWORD` | bare `:` (effectively null) | `""` | Explicit empty-string is the YAML idiom and reads correctly on every consumer. |

### Topomojo new / changed env defaults

| Setting | Old | New | Why |
|---|---|---|---|
| `SKIP_VOL_PERMISSIONS` | (not present) | `"false"` | Adds an explicit toggle for the volume-permissions init container. False keeps existing behavior (chown to UID/GID 1654); true is the documented escape hatch for storage classes that handle ownership themselves. |
| `FileUpload__TopoRoot` | `/mnt/tm` (active) | commented out | Stale default that no longer matched the chart's mount. Now commented as documentation only. |
| `FileUpload__IsoRoot` | `/mnt/tm/isos` (active) | commented out | Same reason. |
| `FileUpload__DocRoot` | `/home/app/wwwroot/docs` (active) | commented out | Same reason. |
| `FileUpload__TempRoot` | `/mnt/tm/_iso-staging` (active) | commented out | Same reason. |
| `existingSecret` doc reference path | `/app/conf` | `/home/app/conf` | Comment fix to match current image layout. |
| `consoleIngress.tls` | `[{secretName: "", hosts: ["connect.example.com"]}]` | `[]` | Stops emitting a broken TLS block by default. |

### Gameboard ingress path consolidation (parent)

| Setting | Old | New | Why |
|---|---|---|---|
| `gameboard-api.ingress.hosts[0].paths` | five entries (`/gb/api`, `/gb/hub`, `/gb/img`, `/gb/docs`, `/gb/supportfiles`) | single regex (`/gb/(api\|hub\|img\|docs\|supportfiles)`) | Same regex consolidation as the other charts, plus the new `nginx.ingress.kubernetes.io/use-regex: "true"` annotation in the README example. |

### Player UI / VM UI / Console UI parent defaults

- `settings: "{}"` was previously an active default for `player-ui`, `vm-ui`, and `console-ui`. It has been removed; the same content is now provided as a commented JSON example block. **Why:** an active `settings: "{}"` collided with `settingsYaml`, which takes precedence — leaving it active served no purpose. The commented block is now documentation for users who prefer pre-serialized JSON over `settingsYaml`.
- `settingsYaml` example URLs were updated from `localhost:*` developer addresses to public `https://X.example.com` placeholders so they read correctly as documentation.
- `OIDCSettings.silent_redirect_uri` and `authority` example URIs gained the trailing slash (`identity.example.com/`) and `.html` suffix to match what the apps actually emit.
- `HeaderBarSettings.enabled` example was changed from `false` to `true` in `alloy-ui` and from `true` to `false` in `cite-ui` / `steamfitter-ui` examples — these are commented examples only, but the README rows for `HeaderBarSettings.enabled` were updated to reflect the canonical `false` default.
