### PR TITLE
Add FileUpload__SupportsSubfolders setting to TopoMojo Helm chart

### DIFF
--- a/charts/topomojo/Chart.yaml
+++ b/charts/topomojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: topomojo
 type: application
 description: TopoMojo is a simple lab builder and player.
-version: 0.8.1
+version: 0.8.2
 home: https://cmu-sei.github.io/crucible/topomojo
 sources:
   - https://github.com/cmu-sei/TopoMojo

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -133,6 +133,7 @@ Optional tuning knobs (defaults shown):
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `FileUpload__MaxFileBytes` | Max upload size in bytes (`0` for unlimited) | `0` |
+| `FileUpload__SupportsSubfolders` | Enable subdirectory organization for ISOs. Set to `false` for Proxmox with local ISO storage. | `true` |
 | `FileUpload__UploadTimeoutMinutes` | HTTP timeout for the datastore PUT | `120` |
 | `FileUpload__TempFileExpirationHours` | Stale temp file cleanup threshold | `24` |
 
@@ -249,8 +250,8 @@ See the [TopoMojo documentation](https://github.com/cmu-sei/TopoMojo/blob/main/d
 | `Pod__Vlan__ResetDebounceDuration` | (Optional) Number of milliseconds to wait after a virtual network operation is initiated before reloading Proxmox's SDN. | `2000` |
 | `Pod__Vlan__ResetDebounceMaxDuration` | (Optional) Maximum number of milliseconds TopoMojo will debounce before it reloads Proxmox's SDN following a network operation. | `5000` |
 | `Pod__IsoStore` | Datastore for ISO files | `iso` |
-| `FileUpload_IsoRoot` | Path mounted to the container that ISOs uploaded through TopoMojo will be saved to - should map to the same storage as `Pod__IsoStore`. **For Proxmox deployments, this path must end with `/template/iso`.** | `/mnt/isos/template/iso` |
-| `FileUpload_SupportsSubFolders` | Set to `false` for Proxmox deployments because Proxmox does not allow sub folders in ISO stores | `false` |
+| `FileUpload__IsoRoot` | Path mounted to the container that ISOs uploaded through TopoMojo will be saved to - should map to the same storage as `Pod__IsoStore`. **For Proxmox deployments, this path must end with `/template/iso`.** | `/mnt/isos/template/iso` |
+| `FileUpload__SupportsSubfolders` | Set to `false` for Proxmox deployments because Proxmox does not allow sub folders in ISO stores | `false` |
 
 
 ### Helm Deployment Configuration

--- a/charts/topomojo/charts/topomojo-api/Chart.yaml
+++ b/charts/topomojo/charts/topomojo-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: topomojo-api
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: 2.8.0

--- a/charts/topomojo/charts/topomojo-api/values.yaml
+++ b/charts/topomojo/charts/topomojo-api/values.yaml
@@ -255,6 +255,7 @@ env:
   ## Override only if you have provisioned alternative storage yourself.
   FileUpload__TempRoot: /mnt/tm/_iso-staging
   # FileUpload__UseDatastoreApi: false
+  # FileUpload__SupportsSubfolders: true  # Set false for Proxmox with local ISO storage
   # FileUpload__UploadTimeoutMinutes: 180
   # FileUpload__TempFileExpirationHours: 24
 

--- a/charts/topomojo/values.yaml
+++ b/charts/topomojo/values.yaml
@@ -228,6 +228,7 @@ topomojo-api:
     # FileUpload__TopoRoot: tm
     # FileUpload__IsoRoot: tm/isos
     # FileUpload__DocRoot: tm/_docs
+    # FileUpload__SupportsSubfolders: false  # Set false for Proxmox with local ISO storage
     # Core__DefaultGamespaceMinutes: 120
     # Core__DefaultGamespaceLimit: 2
     # Core__DefaultWorkspaceLimit: 0


### PR DESCRIPTION
- Document SupportsSubfolders configuration option in values.yaml
- Recommend false for Proxmox with local ISO storage
- Bump chart version to 0.8.2