### PR TITLE
Restore osticket mysql dependency to sync Chart.lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           version: "latest"
 
+      - name: Add dependency Helm repo
+        run: helm repo add crucible https://helm.cmusei.dev/charts
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,15 @@ jobs:
         with:
           version: "latest"
 
-      - name: Add dependency Helm repo
-        run: helm repo add sei https://helm.cmusei.dev/charts
+      - name: Add dependency Helm repos
+        run: |
+          helm repo add sei https://helm.cmusei.dev/charts
+          helm repo add kvaps https://kvaps.github.io/charts
+          helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+          helm repo add runix https://helm.runix.net
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           version: "latest"
 
       - name: Add dependency Helm repo
-        run: helm repo add crucible https://helm.cmusei.dev/charts
+        run: helm repo add sei https://helm.cmusei.dev/charts
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0

--- a/charts/osticket/Chart.yaml
+++ b/charts/osticket/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.17.6
+version: 1.17.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -23,8 +23,7 @@ version: 1.17.6
 # It is recommended to use it with quotes.
 appVersion: "1.17.5"
 dependencies:
-- name: mysql
-  version: "9.3.4"
-  repository: "https://charts.bitnami.com/bitnami"
-  condition: mysql.enabled
-
+  - name: mysql
+    version: "9.3.4"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: mysql.enabled

--- a/charts/osticket/Chart.yaml
+++ b/charts/osticket/Chart.yaml
@@ -22,4 +22,9 @@ version: 1.17.6
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "1.17.5"
+dependencies:
+- name: mysql
+  version: "9.3.4"
+  repository: "https://charts.bitnami.com/bitnami"
+  condition: mysql.enabled
 


### PR DESCRIPTION
Commit 6342951 accidentally removed the dependencies block from charts/osticket/Chart.yaml while leaving Chart.lock and the vendored charts/mysql/ subchart in place. Once #118 bumped the version to 1.17.6, chart-releaser tried to package osticket and failed with "the lock file (Chart.lock) is out of sync with the dependencies file".

Restores the exact mysql dependency block that generated the existing Chart.lock, so the digest matches. The chart still uses mysql (mysql.enabled: true in values.yaml).