### PR TITLE
Register bitnami Helm repo in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add cloudnative-pg https://cloudnative-pg.github.io/charts
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
## Problem

The `Release Charts` workflow fails packaging `charts/osticket`:

```
Error: no repository definition for https://charts.bitnami.com/bitnami
```

`chart-releaser` runs `helm dependency build` for osticket, which pulls the **mysql 9.3.4** subchart from `https://charts.bitnami.com/bitnami`. The workflow's "Add dependency Helm repos" step registers every other dependency repo (sei, kvaps, ingress-nginx, runix, prometheus-community, grafana, cloudnative-pg) but **not** bitnami, so the build can't resolve the repository.

## Fix

Add `helm repo add bitnami https://charts.bitnami.com/bitnami` alongside the other dependency repos. The osticket chart is unchanged — it continues to pull mysql from Bitnami's chart repo.

## Verification

- Confirmed `bitnami/mysql 9.3.4` is still served by the classic bitnami index and the tarball **actually downloads** (not just indexed).
- Ran `helm dependency build` + `helm package` for osticket against the committed `Chart.lock` with the bitnami repo registered — both succeed.

## Note

Bitnami has been deprecating their public chart catalog; 9.3.4 is still served today. This unblocks the release now. If Bitnami later removes the asset, vendoring the subchart locally would be the durable fallback.