### PR TITLE
Stop marking chart releases as 'latest'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,5 +42,10 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
+        with:
+          # Releases are per-chart, so no single chart should carry the
+          # repo-wide "Latest" marker (it would otherwise land on whichever
+          # chart happens to publish last).
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Releases in this repo are per-chart, so set `mark_as_latest: false` on chart-releaser. This prevents whichever chart publishes last in a run from carrying GitHub's repo-wide "Latest" badge.