### PR TITLE
Revert "Stop marking chart releases as 'latest'"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,5 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
-        with:
-          # Releases are per-chart, so no single chart should carry the
-          # repo-wide "Latest" marker (it would otherwise land on whichever
-          # chart happens to publish last).
-          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts #419. GitHub always designates one full release as "Latest", so the most recently published chart serving as the repo's latest release is acceptable—there's no need to suppress the badge.