### PR TITLE
Update repo url

### DIFF
--- a/.github/scripts/check-chart-versions.sh
+++ b/.github/scripts/check-chart-versions.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # This script checks that chart versions are incremented when chart files are modified.
 # It compares the current branch against the base branch and fails if any chart has
+# changes without a corresponding version bump in its Chart.yaml.
+#
+# README.md changes are ignored: docs-only updates don't require a version bump.
+# A chart whose only changed file is its README.md is therefore not flagged.
 #
 # When a sub-chart is modified (e.g., charts/alloy/charts/alloy-api),
 # the parent chart (charts/alloy) must also have its version incremented.
@@ -74,6 +78,11 @@ has_charts=false
 while IFS= read -r file; do
     # Only process files under charts/ directory
     if [[ "$file" =~ ^charts/ ]]; then
+        # Docs-only changes don't require a version bump. Skip README.md
+        # anywhere in a chart tree, and the moodle chart's migrate.md.
+        if [[ "$file" =~ /README\.md$ || "$file" == "charts/moodle/migrate.md" ]]; then
+            continue
+        fi
         if chart_dir=$(find_chart_dir "$file"); then
             modified_charts["$chart_dir"]=1
             has_charts=true

--- a/.github/scripts/update-crucible-umbrella.sh
+++ b/.github/scripts/update-crucible-umbrella.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Update all cmusei repository dependencies to their latest versions
-# Updates the Chart.yaml with the latest versions from https://helm.cmusei.dev/charts
+# Updates the Chart.yaml with the latest versions from https://cmu-sei.github.io/helm-charts
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHART_DIR="$SCRIPT_DIR/../../charts/crucible-apps"
 CHART_FILE="$CHART_DIR/Chart.yaml"
-cmusei_REPO="https://helm.cmusei.dev/charts"
+cmusei_REPO="https://cmu-sei.github.io/helm-charts"
 REPO_NAME="cmusei"
 
 # Color output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Add dependency Helm repos
         run: |
-          helm repo add sei https://helm.cmusei.dev/charts
+          helm repo add sei https://cmu-sei.github.io/helm-charts
           helm repo add kvaps https://kvaps.github.io/charts
           helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
           helm repo add runix https://helm.runix.net

--- a/.github/workflows/update-crucible-umbrella.yaml
+++ b/.github/workflows/update-crucible-umbrella.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Add Helm repositories
         run: |
-          helm repo add cmusei https://helm.cmusei.dev/charts
+          helm repo add cmusei https://cmu-sei.github.io/helm-charts
           helm repo update
 
       - name: Run update script

--- a/Readme.md
+++ b/Readme.md
@@ -7,9 +7,11 @@ Helm charts for deploying CMU Software Engineering Institute applications to Kub
 Add this Helm repository:
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm repo update
 ```
+
+> **Note:** The previous repository URL `https://helm.cmusei.dev/charts` is deprecated and will be taken down in the future. Please update any existing configurations to use the new URL above.
 
 ## Quick Start
 

--- a/charts/alloy/README.md
+++ b/charts/alloy/README.md
@@ -15,7 +15,7 @@ This Helm chart deploys Alloy with both [API](https://github.com/cmu-sei/Alloy.A
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install alloy sei/alloy -f values.yaml
 ```
 

--- a/charts/blueprint/README.md
+++ b/charts/blueprint/README.md
@@ -14,7 +14,7 @@ This Helm chart deploys Blueprint with both [API](https://github.com/cmu-sei/Blu
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install blueprint sei/blueprint -f values.yaml
 ```
 

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -19,7 +19,7 @@ VMware vSphere, Proxmox, or AWS/Azure cloud infrastructure are all supported opt
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install caster sei/caster -f values.yaml
 ```
 

--- a/charts/cite/README.md
+++ b/charts/cite/README.md
@@ -14,7 +14,7 @@ This Helm chart deploys CITE with both [API](https://github.com/cmu-sei/CITE.Api
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install cite sei/cite -f values.yaml
 ```
 

--- a/charts/crucible-apps/Chart.lock
+++ b/charts/crucible-apps/Chart.lock
@@ -1,33 +1,33 @@
 dependencies:
 - name: alloy
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.7.8
 - name: blueprint
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.9.3
 - name: caster
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.8.9
 - name: cite
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.9.7
 - name: gallery
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.9.7
 - name: gameboard
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 0.5.14
 - name: player
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.9.13
 - name: steamfitter
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 1.7.7
 - name: topomojo
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 0.7.1
 - name: moodle
-  repository: https://helm.cmusei.dev/charts
+  repository: https://cmu-sei.github.io/helm-charts
   version: 0.2.7
-digest: sha256:8ccf05d336638888bf6573a9731371c1cfd6aef199d96b154f1ec148edb97b27
-generated: "2026-05-15T15:45:37.562945035Z"
+digest: sha256:9c0daf8233ae0e3553a6197b9ac43dce42fe565307ff70326e7e0fff7ec7d2e3
+generated: "2026-06-04T14:29:01.59431072Z"

--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: crucible-apps
 description: Crucible framework application deployment - A comprehensive cybersecurity training and exercise platform with Keycloak, Player, Caster, Alloy, Blueprint, CITE, Gallery, Gameboard, Steamfitter, TopoMojo, and Moodle
 type: application
-version: 0.2.3
+version: 0.3.0
 home: https://cmu-sei.github.io/crucible/
 
 dependencies:

--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -8,52 +8,52 @@ home: https://cmu-sei.github.io/crucible/
 dependencies:
   # Crucible Applications
   - name: alloy
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.7.8
     condition: alloy.enabled
 
   - name: blueprint
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.9.3
     condition: blueprint.enabled
 
   - name: caster
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.8.9
     condition: caster.enabled
 
   - name: cite
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.9.7
     condition: cite.enabled
 
   - name: gallery
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.9.7
     condition: gallery.enabled
 
   - name: gameboard
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 0.5.14
     condition: gameboard.enabled
 
   - name: player
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.9.13
     condition: player.enabled
 
   - name: steamfitter
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 1.7.7
     condition: steamfitter.enabled
 
   - name: topomojo
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 0.7.1
     condition: topomojo.enabled
 
   # Moodle LMS
   - name: moodle
-    repository: https://helm.cmusei.dev/charts
+    repository: https://cmu-sei.github.io/helm-charts
     version: 0.2.7
     condition: moodle.enabled

--- a/charts/crucible-infra/README.md
+++ b/charts/crucible-infra/README.md
@@ -29,7 +29,7 @@ Chart components are enabled by default, but can be disabled via the values file
 ### 1. Add the Helm Repository
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm repo update
 ```
 

--- a/charts/gallery/README.md
+++ b/charts/gallery/README.md
@@ -14,7 +14,7 @@ This Helm chart deploys Gallery with both [API](https://github.com/cmu-sei/Galle
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install gallery sei/gallery -f values.yaml
 ```
 

--- a/charts/gameboard/README.md
+++ b/charts/gameboard/README.md
@@ -15,7 +15,7 @@ This Helm chart deploys Gameboard with both [API](https://github.com/cmu-sei/gam
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install gameboard sei/gameboard -f values.yaml
 ```
 

--- a/charts/moodle/README.md
+++ b/charts/moodle/README.md
@@ -18,7 +18,7 @@ If you are currently using the Bitnami Moodle Helm chart and want to migrate to 
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install moodle sei/moodle -f values.yaml
 ```
 

--- a/charts/moodle/migrate.md
+++ b/charts/moodle/migrate.md
@@ -302,7 +302,7 @@ ingress:
 If you have not already added the SEI Helm repository:
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm repo update
 ```
 
@@ -536,5 +536,5 @@ kubectl rollout restart deployment -n <namespace> moodle
 - [Moodle Site backup](https://docs.moodle.org/500/en/Site_backup)
 - [Moodle Upgrading](https://docs.moodle.org/en/Upgrading)
 - [Alpine Moodle Image](https://github.com/erseco/alpine-moodle)
-- [SEI Moodle Helm Chart](https://helm.cmusei.dev/charts)
+- [SEI Moodle Helm Chart](https://cmu-sei.github.io/helm-charts)
 - [Bitnami Legacy Notice](https://community.broadcom.com/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon)

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -21,7 +21,7 @@ This Helm chart deploys the full Player stack of integrated components:
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install player sei/player -f values.yaml
 ```
 

--- a/charts/steamfitter/README.md
+++ b/charts/steamfitter/README.md
@@ -22,7 +22,7 @@ This Helm chart deploys Steamfitter with both [API](https://github.com/cmu-sei/s
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install steamfitter sei/steamfitter -f values.yaml
 ```
 

--- a/charts/topomojo/README.md
+++ b/charts/topomojo/README.md
@@ -16,7 +16,7 @@ This Helm chart deploys TopoMojo with both [API](https://github.com/cmu-sei/Topo
 ## Installation
 
 ```bash
-helm repo add sei https://helm.cmusei.dev/charts
+helm repo add sei https://cmu-sei.github.io/helm-charts
 helm install topomojo sei/topomojo -f values.yaml
 ```
 


### PR DESCRIPTION
Update repo URLs to the new GitHub Pages URL in: 

1. Main Readme
2. Chart Readme installation instructions
3. Umbrella Chart dependencies
4. CI workflows

Also updates the check-chart-versions.sh logic to ignore readme-only changes when flagging if a chart needs a version bump.