### PR TITLE
Surface full KubernetesJobs config in caster chart values and docs

### DIFF
--- a/charts/caster/Chart.yaml
+++ b/charts/caster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: caster
 description: Caster enables the coded design and deployment of cyber topologies.
 type: application
-version: 1.9.1
+version: 1.9.2
 home: https://cmu-sei.github.io/crucible/caster/
 sources:
 - https://github.com/cmu-sei/Caster.Api/

--- a/charts/caster/README.md
+++ b/charts/caster/README.md
@@ -151,9 +151,30 @@ The preferred way to integrate Caster with [Player](https://cmu-sei.github.io/cr
 | `Terraform__KubernetesJobs__RootWorkingDirectory` | K8s jobs root working directory | `"/terraform/root"` |
 | `Terraform__KubernetesJobs__ImageRegistry` | K8s jobs image registry | `"https://registry-1.docker.io/"` |
 | `Terraform__KubernetesJobs__ImageName` | K8s jobs image name | `"hashicorp/terraform"` |
+| `Terraform__KubernetesJobs__ImageTags__0` | Explicit image tag(s); indexed list. Optional — set when not querying tags | `"1.14"` |
 | `Terraform__KubernetesJobs__QueryImageTags` | Query image tags | `"true"` |
 | `Terraform__KubernetesJobs__QueryImageTagsRegex` | Image tags regex filter | `"^([0-9]\\d*\\.\\d+\\.\\d+)$"` |
 | `Terraform__KubernetesJobs__QueryImageTagsMinutes` | Image tags query interval | `"720"` |
+| `Terraform__KubernetesJobs__PodReadyTimeoutSeconds` | Max seconds to wait for a job pod to become ready | `"120"` |
+
+The following are optional. By default the chart manages the job volume via a
+PersistentVolumeClaim and sets the `PersistentVolumeClaimName`, `VolumeMountPath`,
+and `VolumeMountSubPath` values automatically when `Enabled` is `"true"`; override
+them only when you need to. Use `UseHostVolume`/`HostVolumePath` instead to back the
+job volume with a host path, and `JobTemplateFile`/`JobTemplateYaml` to supply a
+custom V1Job spec.
+
+| Setting | Description | Example |
+|-----------|-------------|---------|
+| `Terraform__KubernetesJobs__UseHostVolume` | Use a hostPath volume instead of the chart-managed PVC | `"false"` |
+| `Terraform__KubernetesJobs__HostVolumePath` | Host path mounted when `UseHostVolume` is `"true"` | `"/mnt/data/terraform"` |
+| `Terraform__KubernetesJobs__PersistentVolumeClaimName` | PVC name for job storage. Set by chart; override if necessary | `"caster-terraform-data-pvc"` |
+| `Terraform__KubernetesJobs__VolumeMountPath` | Mount path inside the job pod. Set by chart; override if necessary | `"/terraform"` |
+| `Terraform__KubernetesJobs__VolumeMountSubPath` | Sub-path within the volume. Set by chart; override if necessary | `""` |
+| `Terraform__KubernetesJobs__ConfigMaps__0__Name` | Name of a ConfigMap to mount into the job; indexed list | `"caster-certs"` |
+| `Terraform__KubernetesJobs__ConfigMaps__0__MountPath` | Mount path for the indexed ConfigMap | `"/usr/local/share/ca-certificates/"` |
+| `Terraform__KubernetesJobs__JobTemplateFile` | Path to a V1Job YAML file to use as the job template | `""` |
+| `Terraform__KubernetesJobs__JobTemplateYaml` | Inline V1Job YAML string to use as the job template | `""` |
 
 > **GitLab prerequisites:** create a dedicated group for Caster projects, generate a token with `api` scope, and confirm the token has access to the group.
 

--- a/charts/caster/charts/caster-api/Chart.yaml
+++ b/charts/caster/charts/caster-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: caster-api
 type: application
-version: 1.7.1
+version: 1.7.2
 appVersion: 3.6.9

--- a/charts/caster/charts/caster-api/values.yaml
+++ b/charts/caster/charts/caster-api/values.yaml
@@ -265,6 +265,18 @@ env:
   Terraform__KubernetesJobs__QueryImageTags: "true"
   Terraform__KubernetesJobs__QueryImageTagsRegex: "^([0-9]\\d*\\.\\d+\\.\\d+)$"
   Terraform__KubernetesJobs__QueryImageTagsMinutes: "720"
+  # Max seconds to wait for a job pod to become ready
+  Terraform__KubernetesJobs__PodReadyTimeoutSeconds: "120"
+
+  # Use a hostPath volume instead of the chart-managed PersistentVolumeClaim.
+  # When enabled, HostVolumePath is mounted instead of the PVC settings below.
+  # Terraform__KubernetesJobs__UseHostVolume: "false"
+  # Terraform__KubernetesJobs__HostVolumePath: "/mnt/data/terraform"
+
+  # Optionally override the job pod spec with a V1Job template.
+  # Set a path to a YAML file (JobTemplateFile) or provide inline YAML (JobTemplateYaml).
+  # Terraform__KubernetesJobs__JobTemplateFile: ""
+  # Terraform__KubernetesJobs__JobTemplateYaml: ""
 
   # Set by chart, can override if necessary
   # Terraform__KubernetesJobs__PersistentVolumeClaimName: "caster-terraform-data-pvc"

--- a/charts/caster/values.yaml
+++ b/charts/caster/values.yaml
@@ -266,6 +266,18 @@ caster-api:
     Terraform__KubernetesJobs__QueryImageTags: "true"
     Terraform__KubernetesJobs__QueryImageTagsRegex: "^([0-9]\\d*\\.\\d+\\.\\d+)$"
     Terraform__KubernetesJobs__QueryImageTagsMinutes: "720"
+    # Max seconds to wait for a job pod to become ready
+    Terraform__KubernetesJobs__PodReadyTimeoutSeconds: "120"
+
+    # Use a hostPath volume instead of the chart-managed PersistentVolumeClaim.
+    # When enabled, HostVolumePath is mounted instead of the PVC settings below.
+    # Terraform__KubernetesJobs__UseHostVolume: "false"
+    # Terraform__KubernetesJobs__HostVolumePath: "/mnt/data/terraform"
+
+    # Optionally override the job pod spec with a V1Job template.
+    # Set a path to a YAML file (JobTemplateFile) or provide inline YAML (JobTemplateYaml).
+    # Terraform__KubernetesJobs__JobTemplateFile: ""
+    # Terraform__KubernetesJobs__JobTemplateYaml: ""
 
     # Set by chart, can override if necessary
     # Terraform__KubernetesJobs__PersistentVolumeClaimName: "caster-terraform-data-pvc"


### PR DESCRIPTION
## Summary

The Caster API binds a `Terraform:KubernetesJobs` configuration section (`KubernetesJobOptions`) with 18 settings, but the caster Helm chart only surfaced 9 of them in `values.yaml`. This PR brings the chart and its README fully in line with the app's `appsettings.json`.

### Changes
- **`caster-api/values.yaml`** — added the missing settings: `PodReadyTimeoutSeconds` (active default), and commented entries for `UseHostVolume`, `HostVolumePath`, `JobTemplateFile`, and `JobTemplateYaml`.
- **`caster/values.yaml`** (umbrella) — applied the same additions so the parent/child `caster-api.env` blocks stay in sync.
- **`caster/README.md`** — expanded the Kubernetes Jobs section to document all 18 settings, including the chart-managed volume keys and indexed `ConfigMaps`/`ImageTags` entries.
- **Version bumps** — `caster-api` `1.7.1 → 1.7.2`, `caster` (umbrella) `1.9.1 → 1.9.2`.

### Why
The five missing settings were settable only as undocumented passthrough env vars. Surfacing them in values.yaml and the README makes the chart fully represent the configurable surface of the app.

## Validation
Ran the repo's `validate-charts.yaml` checks locally against `origin/main`:
- ✅ Chart Version Check (both charts bumped; parent-bump-on-subchart-change satisfied)
- ✅ Parent/Child Values Sync
- ✅ README sync reminder clears (no warnings)

## Notes
- `UseHostVolume`/`HostVolumePath` are left commented because they are mutually exclusive with the chart's auto-managed PVC volume logic in `secret.yaml`.