### PR TITLE
Fix silent git-pull failure in mkdocs-material chart

### DIFF
--- a/charts/mkdocs-material/Chart.yaml
+++ b/charts/mkdocs-material/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.15
+version: 0.2.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mkdocs-material/templates/configmap-entry.yaml
+++ b/charts/mkdocs-material/templates/configmap-entry.yaml
@@ -48,6 +48,15 @@ data:
 
     update-ca-certificates
 
+    # HOME may be read-only, which breaks `git config --global`
+    # (credential storage lock error). Point it at a writable dir.
+    export HOME=/tmp
+    # The /git checkout can be owned by a different uid than this container
+    # runs as; without this, git's CVE-2022-24765 hardening aborts with
+    # "detected dubious ownership in repository at '/git'" and every pull
+    # fails silently, leaving the docs site permanently stale.
+    git config --global --add safe.directory /git
+
     if [ -n $DOCS_GIT_CRED_FILE ]; then
         execute_git_command "git config --global credential.helper \"store --file=/git-credentials/${DOCS_GIT_CRED_FILE}\""
     fi


### PR DESCRIPTION
The docs-build init container's git-pull.sh failed on every run when /git sits on a persistent or shared volume (EFS, reused PVC), because the /git checkout is owned by a different uid than the container runs as. Git's CVE-2022-24765 hardening then aborts 'git reset --hard' with 'detected dubious ownership in repository at /git'. The script's error handler exits 0 on failure, so the Job reports Complete and the site silently freezes at its first build.

Set HOME=/tmp (HOME may be read-only, breaking 'git config --global') and mark /git as a safe.directory immediately after update-ca-certificates.

Bump chart version to 0.2.16.