### PR TITLE
Update Player applications

### DIFF
--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.10.9
+version: 1.10.10
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -423,6 +423,12 @@ VM API supports connection to multiple vSphere instances. Use the following sett
 | `Vsphere__CheckTaskProgressIntervalMilliseconds` | Task progress check interval | `5000` |
 | `Vsphere__ReCheckTaskProgressIntervalMilliseconds` | Task progress recheck interval | `1000` |
 | `Vsphere__HealthAllowanceSeconds` | Health allowance seconds | `180` |
+| `Vsphere__SkipGuestFileCertificateValidation` | Skip TLS certificate validation for guest file transfers | `false` |
+| `Vsphere__GuestFileTransferTimeoutMinutes` | Guest file transfer timeout in minutes | `3` |
+| `Vsphere__TaskTimeoutMinutes` | vSphere task timeout in minutes | `10` |
+| `Vsphere__TaskInfoUnavailableTimeoutSeconds` | Time to wait for unavailable vSphere task information | `30` |
+| `Vsphere__GuestProcessTempPath` | Temporary directory used for guest process files | `""` |
+| `Vsphere__GuestProcessDefaultTimeoutSeconds` | Default guest process timeout in seconds | `300` |
 
 **Important:**
 - Requires a privileged vCenter user for file operations
@@ -494,6 +500,14 @@ vm-api:
 | `CorsPolicy__SupportsCredentials` | CORS supports credentials | `true` |
 
 **Note:** Additional origins can be added using the pattern `CorsPolicy__Origins__2`, `CorsPolicy__Origins__3`, etc.
+
+### Proxmox Configuration
+
+| Setting | Description | Example |
+|-----------|-------------|---------|
+| `Proxmox__FileUploadMaxBytes` | Maximum guest file upload payload in bytes | `61440` |
+| `Proxmox__GuestProcessPollMs` | Guest process status polling interval in milliseconds | `500` |
+| `Proxmox__GuestProcessDefaultTimeoutSeconds` | Default guest process timeout in seconds | `300` |
 
 ### Health Probes
 

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: console-ui
 type: application
 version: 1.9.3
-appVersion: 3.4.5
+appVersion: 3.4.6

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.9.2
-appVersion: 3.4.4
+version: 1.9.3
+appVersion: 3.4.5

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-api
 type: application
-version: 1.9.2
-appVersion: 3.5.9
+version: 1.9.3
+appVersion: 3.5.10

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: player-api
 type: application
 version: 1.9.3
-appVersion: 3.5.10
+appVersion: 3.5.11

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-ui
 type: application
-version: 1.9.2
-appVersion: 3.4.7
+version: 1.9.3
+appVersion: 3.4.8

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.8.1
-appVersion: 3.8.10
+version: 1.8.2
+appVersion: 3.8.11

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -236,3 +236,13 @@ env:
   # OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
   # Optional: override the service name reported to collectors
   # OTEL_SERVICE_NAME: vm-api
+
+  Vsphere__SkipGuestFileCertificateValidation: false
+  Vsphere__GuestFileTransferTimeoutMinutes: 3
+  Vsphere__TaskTimeoutMinutes: 10
+  Vsphere__TaskInfoUnavailableTimeoutSeconds: 30
+  Vsphere__GuestProcessTempPath: ""
+  Vsphere__GuestProcessDefaultTimeoutSeconds: 300
+  Proxmox__FileUploadMaxBytes: 61440
+  Proxmox__GuestProcessPollMs: 500
+  Proxmox__GuestProcessDefaultTimeoutSeconds: 300

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: vm-ui
 type: application
 version: 1.9.4
-appVersion: 3.6.9
+appVersion: 3.6.10

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.9.3
-appVersion: 3.6.8
+version: 1.9.4
+appVersion: 3.6.9

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -628,6 +628,15 @@ vm-api:
     # Optional: override the service name reported to collectors
     # OTEL_SERVICE_NAME: vm-api
 
+    Vsphere__SkipGuestFileCertificateValidation: false
+    Vsphere__GuestFileTransferTimeoutMinutes: 3
+    Vsphere__TaskTimeoutMinutes: 10
+    Vsphere__TaskInfoUnavailableTimeoutSeconds: 30
+    Vsphere__GuestProcessTempPath: ""
+    Vsphere__GuestProcessDefaultTimeoutSeconds: 300
+    Proxmox__FileUploadMaxBytes: 61440
+    Proxmox__GuestProcessPollMs: 500
+    Proxmox__GuestProcessDefaultTimeoutSeconds: 300
 vm-ui:
   image:
     repository: cmusei/vm-ui


### PR DESCRIPTION
## Summary

Combine the overlapping automated Player application updates into one Player chart release.

- [Player API 3.5.11](https://github.com/cmu-sei/Player.Api/releases/tag/3.5.11)
- [Player UI 3.4.8](https://github.com/cmu-sei/Player.Ui/releases/tag/3.4.8)
- [Player VM API 3.8.11](https://github.com/cmu-sei/Vm.Api/releases/tag/3.8.11)
- [Player VM UI 3.6.10](https://github.com/cmu-sei/Vm.Ui/releases/tag/3.6.10)
- [Player Console UI 3.4.6](https://github.com/cmu-sei/Console.Ui/releases/tag/3.4.6)

VM API values and documentation now expose the nine settings introduced in 3.8.11 using the application defaults.

Supersedes #456, #457, #458, #459, #460, #463.

## Validation

- Chart version validation
- Exact Player parent/child values comparison
- `helm lint` for all five child charts
- `helm template` for all five child charts
- `git diff --check`