### PR TITLE
Update Player applications

### DIFF
--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.10.11
+version: 1.11.0
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -485,6 +485,23 @@ vm-api:
 |-----------|-------------|---------|
 | `IsoUpload__BasePath` | ISO upload base path | `"/app/isos/player"` |
 | `IsoUpload_MaxFileSize` | ISO upload max file size | `6000000000` |
+| `IsoUpload__UploadToDatastore` | Push uploaded ISOs straight to the vSphere datastore instead of writing them to `BasePath` | `false` |
+| `IsoUpload__TempStagingPath` | Directory used to stage the ISO before it streams to the datastore. Empty uses the system temp path. Only applies when `UploadToDatastore` is `true` | `""` |
+| `IsoUpload__UploadTimeoutMinutes` | Timeout in minutes for the ISO upload to the datastore. Values of `0` or less fall back to 60. Only applies when `UploadToDatastore` is `true` | `60` |
+
+**Datastore upload mode:** setting `IsoUpload__UploadToDatastore: true` streams uploaded ISOs to the vSphere datastore rather than writing them under `BasePath`. This is intended for VMware Cloud on AWS SDDC environments, which only support vSAN and offer no NFS datastore. The default of `false` leaves existing NFS deployments unchanged. `BasePath` is not read in this mode, so the `iso.enabled` NFS mount is not required.
+
+In datastore mode the ISO is first staged as a local file (the upload is streamed to each host, which needs a seekable file), so the staging directory needs room for a full copy of the largest ISO you expect. The NFS path writes straight through and stages nothing, which is why `TempStagingPath` applies only to datastore mode. Uploads and deletes fan out across all enabled, connected hosts; if some hosts fail the operation still reports success along with a failed-host count.
+
+**ISO deletion:** the VM UI Files tab can now delete and list ISOs, not just upload them. Deletion is gated by three permissions Player API adds in 3.6.0, seeded by database migration and each covering a different scope:
+
+| Permission | Scope | Allows deleting |
+|---|---|---|
+| `DeleteIsos` | System | Any ISO in any View or team, including ones the user is not a member of |
+| `DeleteViewIsos` | View | View-wide ISOs and any team's ISOs within that View |
+| `DeleteTeamIsos` | Team | ISOs belonging to that specific team |
+
+Grant at least one to a role before the delete actions appear. The matching `UploadViewIsos` and `UploadTeamIsos` permissions already existed and are unchanged. Note that the Files tab listing follows the user's active (primary) team, so switching the active team narrows what is shown.
 
 #### CORS Policy Settings
 
@@ -733,6 +750,9 @@ player-ui:
 - Verify NFS mount is accessible if using `iso.enabled`
 - Ensure vCenter datastore has sufficient space
 - Check file permissions on datastore
+- In datastore upload mode (`IsoUpload__UploadToDatastore: true`), raise `IsoUpload__UploadTimeoutMinutes` for large ISOs on slow links, and confirm `IsoUpload__TempStagingPath` has room for a full copy of the ISO
+- A "failed on N of M hosts" message means the ISO reached some hosts but not others; check the VM API logs for which hosts failed
+- Missing delete buttons in the Files tab usually mean the user's role lacks `DeleteIsos`, `DeleteViewIsos`, or `DeleteTeamIsos`
 
 ## References
 

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.9.3
-appVersion: 3.4.6
+version: 1.9.4
+appVersion: 3.4.7

--- a/charts/player/charts/player-api/Chart.yaml
+++ b/charts/player/charts/player-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-api
 type: application
-version: 1.9.4
-appVersion: 3.5.12
+version: 1.10.0
+appVersion: 3.6.0

--- a/charts/player/charts/player-ui/Chart.yaml
+++ b/charts/player/charts/player-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: player-ui
 type: application
-version: 1.9.4
-appVersion: 3.4.9
+version: 1.10.0
+appVersion: 3.5.0

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.8.2
-appVersion: 3.8.11
+version: 1.9.0
+appVersion: 3.9.0

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -191,6 +191,9 @@ env:
 
   IsoUpload__BasePath: "/app/isos/player"
   IsoUpload_MaxFileSize: 6000000000
+  IsoUpload__UploadToDatastore: false
+  IsoUpload__TempStagingPath: ""
+  IsoUpload__UploadTimeoutMinutes: 60
 
   IdentityClient__TokenUrl: ""
   IdentityClient__ClientId: "player-vm-admin"

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.9.4
-appVersion: 3.6.10
+version: 1.10.0
+appVersion: 3.7.0

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -582,6 +582,9 @@ vm-api:
 
     IsoUpload__BasePath: "/app/isos/player"
     IsoUpload_MaxFileSize: 6000000000
+    IsoUpload__UploadToDatastore: false
+    IsoUpload__TempStagingPath: ""
+    IsoUpload__UploadTimeoutMinutes: 60
 
     IdentityClient__TokenUrl: ""
     IdentityClient__ClientId: "player-vm-admin"


### PR DESCRIPTION
## Summary

Combine the overlapping automated Player application updates into one Player chart release.

- [Player API 3.6.0](https://github.com/cmu-sei/Player.Api/releases/tag/3.6.0)
- [Player UI 3.5.0](https://github.com/cmu-sei/Player.Ui/releases/tag/3.5.0)
- [Player VM API 3.9.0](https://github.com/cmu-sei/Vm.Api/releases/tag/3.9.0)
- [Player VM UI 3.7.0](https://github.com/cmu-sei/Vm.Ui/releases/tag/3.7.0)
- [Player Console UI 3.4.7](https://github.com/cmu-sei/Console.Ui/releases/tag/3.4.7)

VM API values and documentation now expose the three ISO upload settings introduced in 3.9.0 using the application defaults.

These five releases are interdependent and need to ship together. VM UI 3.7.0 adds the Files tab for ISO upload, delete, and listing, which calls `GET api/views/{viewId}/isos`, `GET api/isos`, and `DELETE api/views/{viewId}/isos` — endpoints that first appear in VM API 3.9.0. The delete actions are in turn gated by permissions seeded by Player API 3.6.0. 

## Chart versions

| Chart | version | appVersion |
|---|---|---|
| `player` (parent) | 1.10.11 → 1.11.0 | — |
| `player-api` | 1.9.4 → 1.10.0 | 3.5.12 → 3.6.0 |
| `player-ui` | 1.9.4 → 1.10.0 | 3.4.9 → 3.5.0 |
| `vm-api` | 1.8.2 → 1.9.0 | 3.8.11 → 3.9.0 |
| `vm-ui` | 1.9.4 → 1.10.0 | 3.6.10 → 3.7.0 |
| `console-ui` | 1.9.3 → 1.9.4 | 3.4.6 → 3.4.7 |

Supersedes #478, #479, #480, #481, #482.
