### PR TITLE
Support Proxmox VM API and ISO settings in the player chart

### DIFF
--- a/charts/crucible-apps/Chart.yaml
+++ b/charts/crucible-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: crucible-apps
 description: Crucible framework application deployment - A comprehensive cybersecurity training and exercise platform with Keycloak, Player, Caster, Alloy, Blueprint, CITE, Gallery, Gameboard, Steamfitter, TopoMojo, and Moodle
 type: application
-version: 0.3.4
+version: 0.3.5
 home: https://cmu-sei.github.io/crucible/
 
 dependencies:

--- a/charts/crucible-apps/README.md
+++ b/charts/crucible-apps/README.md
@@ -573,10 +573,10 @@ player:
       Proxmox__StateRefreshIntervalSeconds: 5
       # ISO uploads (optional): name a PVE storage that accepts ISO images, then either
       # mount its template/iso directory and point IsoRoot at the mount (as below), or
-      # push through the PVE API instead with Proxmox__UploadViaApi: true
+      # push through the PVE API instead with Proxmox__IsoUploadViaApi: true
       Proxmox__IsoStorage: "nfs-isos"
       Proxmox__IsoRoot: "/app/isos/proxmox"
-      Proxmox__UploadViaApi: false
+      Proxmox__IsoUploadViaApi: false
 
     # The NFS export behind nfs-isos/template/iso
     iso:

--- a/charts/crucible-apps/README.md
+++ b/charts/crucible-apps/README.md
@@ -569,7 +569,8 @@ player:
       Proxmox__Host: "proxmox.example.com"
       Proxmox__Port: 8006 # Default Proxmox port, use 443 if behind reverse proxy
       Proxmox__Token: "PVEAPIToken=player@pve!tokenid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-      Proxmox__StateRefreshIntervalSeconds: 60
+      Proxmox__ValidateCertificate: true
+      Proxmox__StateRefreshIntervalSeconds: 5
 ```
 
 **Requirements:**
@@ -577,8 +578,9 @@ player:
 - Proxmox VE API token with appropriate permissions
 - Network access from Kubernetes cluster to Proxmox host
 - Token format: `PVEAPIToken=USER@REALM!TOKENID=UUID`
+- A PVE host serving its stock self-signed certificate needs either a trusted CA bundle (via `player.vm-api.certificateMap`) or `Proxmox__ValidateCertificate: false`
 
-**Note:** Player VM API can be configured for either vSphere OR Proxmox, not both simultaneously.
+**Note:** vSphere and Proxmox can both be enabled on the same Player VM API instance — each VM is routed to the backend matching its provider type. See the [Player chart documentation](https://github.com/cmu-sei/helm-charts/blob/main/charts/player/README.md) for the full list of Proxmox settings.
 
 #### Caster - vSphere Configuration
 

--- a/charts/crucible-apps/README.md
+++ b/charts/crucible-apps/README.md
@@ -571,6 +571,19 @@ player:
       Proxmox__Token: "PVEAPIToken=player@pve!tokenid=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       Proxmox__ValidateCertificate: true
       Proxmox__StateRefreshIntervalSeconds: 5
+      # ISO uploads (optional): name a PVE storage that accepts ISO images, then either
+      # mount its template/iso directory and point IsoRoot at the mount (as below), or
+      # push through the PVE API instead with Proxmox__UploadViaApi: true
+      Proxmox__IsoStorage: "nfs-isos"
+      Proxmox__IsoRoot: "/app/isos/proxmox"
+      Proxmox__UploadViaApi: false
+
+    # The NFS export behind nfs-isos/template/iso
+    iso:
+      enabled: true
+      server: "pve-nfs.example.com"
+      path: "/exports/pve-isos/template/iso"
+      mountPath: "/app/isos/proxmox"
 ```
 
 **Requirements:**

--- a/charts/crucible-apps/values.yaml
+++ b/charts/crucible-apps/values.yaml
@@ -804,6 +804,14 @@ player:
       # Proxmox__Token: ""  # API token in format: PVEAPIToken=USER@REALM!TOKENID=UUID
       # Proxmox__ValidateCertificate: true  # Set false for a PVE host serving its stock self-signed certificate
       # Proxmox__StateRefreshIntervalSeconds: 5
+      # Proxmox ISO uploads (optional). IsoStorage names a PVE storage that accepts ISO images;
+      # setting it turns Proxmox ISO support on. Then either mount that storage's template/iso
+      # directory and point IsoRoot at the mount (see player.vm-api.iso), or set UploadViaApi true
+      # to push each ISO through the PVE API instead.
+      # Proxmox__IsoStorage: ""
+      # Proxmox__UploadViaApi: false
+      # Proxmox__IsoRoot: ""
+      # Proxmox__IsoScopeSeparator: "__"
   vm-ui:
     ingress:
       className: ""

--- a/charts/crucible-apps/values.yaml
+++ b/charts/crucible-apps/values.yaml
@@ -802,7 +802,8 @@ player:
       # Proxmox__Host: "proxmox.example.com"
       # Proxmox__Port: 8006  # Default Proxmox port. Change to 443 if using reverse proxy
       # Proxmox__Token: ""  # API token in format: PVEAPIToken=USER@REALM!TOKENID=UUID
-      # Proxmox__StateRefreshIntervalSeconds: 60
+      # Proxmox__ValidateCertificate: true  # Set false for a PVE host serving its stock self-signed certificate
+      # Proxmox__StateRefreshIntervalSeconds: 5
   vm-ui:
     ingress:
       className: ""

--- a/charts/crucible-apps/values.yaml
+++ b/charts/crucible-apps/values.yaml
@@ -806,10 +806,10 @@ player:
       # Proxmox__StateRefreshIntervalSeconds: 5
       # Proxmox ISO uploads (optional). IsoStorage names a PVE storage that accepts ISO images;
       # setting it turns Proxmox ISO support on. Then either mount that storage's template/iso
-      # directory and point IsoRoot at the mount (see player.vm-api.iso), or set UploadViaApi true
+      # directory and point IsoRoot at the mount (see player.vm-api.iso), or set IsoUploadViaApi true
       # to push each ISO through the PVE API instead.
       # Proxmox__IsoStorage: ""
-      # Proxmox__UploadViaApi: false
+      # Proxmox__IsoUploadViaApi: false
       # Proxmox__IsoRoot: ""
       # Proxmox__IsoScopeSeparator: "__"
   vm-ui:

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.11.0
+version: 1.11.1
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/Chart.yaml
+++ b/charts/player/Chart.yaml
@@ -3,7 +3,7 @@ name: player
 description: Player is a window into virtual environments - enabling assignment of
   team membership and customization of responsive, browser-based user interfaces.
 type: application
-version: 1.11.1
+version: 1.12.0
 home: https://cmu-sei.github.io/crucible/player
 sources:
 - https://github.com/cmu-sei/Player.Api

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -428,8 +428,8 @@ VM API supports connection to multiple vSphere instances. Use the following sett
 | `Vsphere__Hosts__*__Address` | vCenter hostname or IP address | `vcenter.example.com` |
 | `Vsphere__Hosts__*__Username` | vCenter username | `player-account@vsphere.local` |
 | `Vsphere__Hosts__*__Password` | vCenter password | `password` |
-| `Vsphere__Hosts__*__DsName` | Datastore name for file storage | `nfs-player` |
-| `Vsphere__Hosts__*__BaseFolder` | Folder within datastore | `player` |
+| `Vsphere__Hosts__*__DsName` | Datastore name for file storage. Also the datastore ISOs are written to and browsed on — see [ISO Upload](#iso-upload) | `nfs-player` |
+| `Vsphere__Hosts__*__BaseFolder` | Folder within datastore. Also the root of the ISO layout — see [ISO Upload](#iso-upload) | `player` |
 | `Vsphere__Timeout` | vSphere timeout | `30` |
 | `Vsphere__ConnectionRetryIntervalSeconds` | vSphere connection retry interval | `60` |
 | `Vsphere__ConnectionRefreshIntervalMinutes` | vSphere connection refresh interval | `20` |
@@ -449,9 +449,9 @@ VM API supports connection to multiple vSphere instances. Use the following sett
 **Important:**
 - Requires a privileged vCenter user for file operations
 - Datastore should be NFS for ease of access
-- Format: `<DATASTORE>/player/` (if BaseFolder is provided)
+- Files live under `[<DsName>] <BaseFolder>/` on each host's own datastore
 
-vSphere ISO support is configured separately — see [ISO Upload](#iso-upload) for `Vsphere__IsoRoot` and `Vsphere__UploadViaApi`.
+vSphere ISO support is configured separately — see [ISO Upload](#iso-upload) for `Vsphere__IsoRoot` and `Vsphere__IsoUploadViaApi`.
 
 #### Console Proxy (Optional)
 
@@ -500,7 +500,7 @@ Every ISO upload runs through the same pipeline before it reaches a hypervisor:
 > | Old | New |
 > |---|---|
 > | `IsoUpload__BasePath` | `Vsphere__IsoRoot` |
-> | `IsoUpload__UploadToDatastore` | `Vsphere__UploadViaApi` |
+> | `IsoUpload__UploadToDatastore` | `Vsphere__IsoUploadViaApi` |
 >
 > The old names are **ignored, not mapped forward**. An override still using them leaves ISO upload
 > misconfigured on a pod that otherwise starts and serves traffic normally; the API logs an error at
@@ -509,14 +509,14 @@ Every ISO upload runs through the same pipeline before it reaches a hypervisor:
 > `MaxFileSize`.
 
 **Where the bytes go — directory mode vs API mode.** Each hypervisor has its own `IsoRoot` and its own
-`UploadViaApi` flag:
+`IsoUploadViaApi` flag:
 
 *vSphere:*
 
 | Setting | Description | Example |
 |-----------|-------------|---------|
-| `Vsphere__IsoRoot` | Directory ISOs are written to. Must be on an export that is also a vCenter NFS datastore | `"/app/isos/player"` |
-| `Vsphere__UploadViaApi` | Stream ISOs to the datastore through vSphere instead of writing to `IsoRoot` | `false` |
+| `Vsphere__IsoRoot` | Directory ISOs are written to. Must be an export that is also a vCenter NFS datastore **and** whose contents surface at exactly `[<DsName>] <BaseFolder>` — see below | `"/app/isos/player"` |
+| `Vsphere__IsoUploadViaApi` | Stream ISOs to the datastore through vSphere instead of writing to `IsoRoot` | `false` |
 
 *Proxmox:*
 
@@ -524,17 +524,35 @@ Every ISO upload runs through the same pipeline before it reaches a hypervisor:
 |-----------|-------------|---------|
 | `Proxmox__IsoStorage` | PVE storage id that holds Player-managed ISOs. Setting it turns Proxmox ISO support on; clearing it turns it off | `"nfs-isos"` |
 | `Proxmox__IsoRoot` | Directory ISOs are written to. Must be a mount of `IsoStorage`'s **`template/iso`** directory — the layout PVE imposes on every storage that accepts ISO images | `"/app/isos/proxmox"` |
-| `Proxmox__UploadViaApi` | Push ISOs through the PVE storage API instead of writing to `IsoRoot` | `false` |
+| `Proxmox__IsoUploadViaApi` | Push ISOs through the PVE storage API instead of writing to `IsoRoot` | `false` |
 | `Proxmox__IsoScopeSeparator` | Separator that keeps one View's or team's ISOs distinct from another's inside the storage | `"__"` |
 
-**Directory mode** (`UploadViaApi: false`, the default) writes straight through to a share the hypervisor
+**Directory mode** (`IsoUploadViaApi: false`, the default) writes straight through to a share the hypervisor
 also reads, and stages nothing. It needs an NFS mount, which is what the `iso` volume below provides.
 
-**API mode** (`UploadViaApi: true`) needs no share. On vSphere it is intended for VMware Cloud on AWS
+**API mode** (`IsoUploadViaApi: true`) needs no share. On vSphere it is intended for VMware Cloud on AWS
 SDDC environments, which only support vSAN and offer no NFS datastore; on Proxmox it pushes each ISO
 through the PVE storage API. Either way the ISO is first staged as a complete local file — the upload is
 streamed and needs a seekable source — so `IsoUpload__TempStagingPath` must have room for the largest ISO
 you accept. Left empty it stages in the pod's writable layer, which `resources` does not limit by default.
+
+**Where a vSphere ISO ends up.** Both modes use the same datastore layout, and only differ in how the
+bytes get there:
+
+```
+[<Vsphere__Hosts__*__DsName>] <Vsphere__Hosts__*__BaseFolder>/<viewId>/<scopeId>/<filename>.iso
+```
+
+In API mode the ISO is pushed to **every enabled, connected host**, each through its own `DsName` and
+`BaseFolder`, and the destination folder is created if it does not exist. In directory mode the same tree
+is written locally under `Vsphere__IsoRoot`.
+
+This matters for directory mode because listing an ISO — and the VM console's ISO mount picker — always
+browses the vCenter datastore, in **both** modes. A `Vsphere__IsoRoot` that is on a datastore but at some
+other path within it will accept uploads that then never appear in Player. So it is not enough for
+`Vsphere__IsoRoot` to be *a* datastore export: mounting the export behind `[<DsName>]` at
+`/app/isos` and setting `Vsphere__IsoRoot: "/app/isos/player"` is correct when `BaseFolder` is `player`,
+because the two then name the same directory.
 
 Proxmox storage is a flat namespace, so an ISO's View or team is encoded into its filename using
 `Proxmox__IsoScopeSeparator`. Changing that value hides ISOs uploaded under the previous one.
@@ -636,8 +654,8 @@ vm-api:
       mountPath: /app/iso-staging
   env:
     IsoUpload__TempStagingPath: "/app/iso-staging"
-    Vsphere__UploadViaApi: true
-    Proxmox__UploadViaApi: true
+    Vsphere__IsoUploadViaApi: true
+    Proxmox__IsoUploadViaApi: true
     Proxmox__IsoStorage: "vsan-isos"
 ```
 
@@ -684,7 +702,7 @@ VM API supports Proxmox VE as an alternative to vSphere. Authentication uses a P
 | `Proxmox__GuestProcessPollMs` | Guest process status polling interval in milliseconds | `500` |
 | `Proxmox__GuestProcessDefaultTimeoutSeconds` | Default guest process timeout in seconds | `300` |
 
-Proxmox ISO support is configured separately — see [ISO Upload](#iso-upload) for `Proxmox__IsoStorage`, `Proxmox__IsoRoot`, `Proxmox__UploadViaApi` and `Proxmox__IsoScopeSeparator`, and [ISO Storage](#iso-storage-optional) for the volume each mode needs.
+Proxmox ISO support is configured separately — see [ISO Upload](#iso-upload) for `Proxmox__IsoStorage`, `Proxmox__IsoRoot`, `Proxmox__IsoUploadViaApi` and `Proxmox__IsoScopeSeparator`, and [ISO Storage](#iso-storage-optional) for the volume each mode needs.
 
 **TLS verification (upgrade note):** `Proxmox__ValidateCertificate` defaults to `true`. Earlier VM API versions did not verify the Proxmox certificate at all, so a PVE host serving its stock self-signed certificate worked without any configuration. It no longer does. Either trust the PVE certificate authority by pointing `vm-api.certificateMap` at a ConfigMap containing the CA bundle (see the VM API *Certificate Trust* section above), or set `Proxmox__ValidateCertificate: false` to keep the previous behavior.
 
@@ -924,10 +942,11 @@ player-ui:
 - Check `proxy-body-size` annotation is set depending on your ISO size needs
 - Verify NFS mount is accessible if using `iso.enabled`, and that `iso.mountPath` agrees with the `IsoRoot` of each hypervisor using it
 - If an override still sets `IsoUpload__BasePath` or `IsoUpload__UploadToDatastore`, it is being ignored — see the renamed keys under *ISO Upload* above. The VM API logs an error at startup naming the variable to set
-- "Proxmox:IsoRoot is required" means directory mode is on with no mount configured. Point `Proxmox__IsoRoot` at a mount of `<Proxmox__IsoStorage>`'s `template/iso` directory, or set `Proxmox__UploadViaApi: true`
+- A vSphere upload that reports success but lists no ISOs means `Vsphere__IsoRoot` is not the directory that surfaces at `[<Vsphere__Hosts__*__DsName>] <Vsphere__Hosts__*__BaseFolder>` — listing browses the datastore in both modes, so the two have to name the same place
+- "Proxmox:IsoRoot is required" means directory mode is on with no mount configured. Point `Proxmox__IsoRoot` at a mount of `<Proxmox__IsoStorage>`'s `template/iso` directory, or set `Proxmox__IsoUploadViaApi: true`
 - Ensure the vCenter datastore or PVE storage has sufficient space
 - Check file permissions on the datastore or export
-- In API mode (`UploadViaApi: true`), raise `IsoUpload__UploadTimeoutMinutes` for large ISOs on slow links, and confirm `IsoUpload__TempStagingPath` has room for a full copy of the ISO
+- In API mode (`IsoUploadViaApi: true`), raise `IsoUpload__UploadTimeoutMinutes` for large ISOs on slow links, and confirm `IsoUpload__TempStagingPath` has room for a full copy of the ISO
 - A "failed on N of M hosts" message means the ISO reached some hosts but not others; check the VM API logs for which hosts failed
 - Missing delete buttons in the Files tab usually mean the user's role lacks `DeleteIsos`, `DeleteViewIsos`, or `DeleteTeamIsos`
 

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -495,7 +495,7 @@ Every ISO upload runs through the same pipeline before it reaches a hypervisor:
 | `IsoUpload__UploadTimeoutMinutes` | Timeout in minutes for an API-mode upload. Values of `0` or less fall back to 60 | `60` |
 
 > [!IMPORTANT]
-> **Renamed in VM API 3.9.0.** Where an ISO ends up is now a per-hypervisor setting, so two keys moved:
+> **Renamed in VM API 3.10.0.** Where an ISO ends up is now a per-hypervisor setting, so two keys moved:
 >
 > | Old | New |
 > |---|---|

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -520,11 +520,30 @@ Grant at least one to a role before the delete actions appear. The matching `Upl
 
 ### Proxmox Configuration
 
+VM API supports Proxmox VE as an alternative to vSphere. Authentication uses a Proxmox API token.
+
 | Setting | Description | Example |
 |-----------|-------------|---------|
+| `Proxmox__Enabled` | Enable the Proxmox VE backend | `false` |
+| `Proxmox__Host` | Proxmox node hostname or IP address | `proxmox.example.com` |
+| `Proxmox__Port` | Proxmox API port. Use `443` when going through a reverse proxy | `8006` |
+| `Proxmox__Token` | API token, in the format `PVEAPIToken=USER@REALM!TOKENID=UUID` | `""` |
+| `Proxmox__ValidateCertificate` | Validate the Proxmox host's TLS certificate | `true` |
+| `Proxmox__StateRefreshIntervalSeconds` | How often VM power state is reconciled from Proxmox cluster resources. Values below `1` are clamped to `1` | `5` |
+| `Proxmox__CheckTaskProgressIntervalMilliseconds` | Cluster task poll interval while no task is pending | `5000` |
+| `Proxmox__ReCheckTaskProgressIntervalMilliseconds` | Cluster task poll interval while a task is still running | `1000` |
 | `Proxmox__FileUploadMaxBytes` | Maximum guest file upload payload in bytes | `61440` |
 | `Proxmox__GuestProcessPollMs` | Guest process status polling interval in milliseconds | `500` |
 | `Proxmox__GuestProcessDefaultTimeoutSeconds` | Default guest process timeout in seconds | `300` |
+
+**TLS verification (upgrade note):** `Proxmox__ValidateCertificate` defaults to `true`. Earlier VM API versions did not verify the Proxmox certificate at all, so a PVE host serving its stock self-signed certificate worked without any configuration. It no longer does. Either trust the PVE certificate authority by pointing `vm-api.certificateMap` at a ConfigMap containing the CA bundle (see the VM API *Certificate Trust* section above), or set `Proxmox__ValidateCertificate: false` to keep the previous behavior.
+
+**Note:** vSphere and Proxmox can both be enabled on the same VM API instance — each VM is routed to the backend matching its provider type. Leave `Proxmox__Enabled: false` on vSphere-only deployments.
+
+**Requirements:**
+
+- Proxmox VE API token with permissions to read cluster resources and perform VM power operations
+- Network access from the Kubernetes cluster to the Proxmox host on `Proxmox__Port`
 
 ### Health Probes
 
@@ -726,6 +745,12 @@ player-ui:
 - Check vCenter credentials have appropriate permissions
 - Ensure datastore exists and is accessible
 - For self-signed certs, consider trust configuration
+
+### Proxmox Connection Failures
+- TLS or certificate errors in the VM API log after an upgrade point at `Proxmox__ValidateCertificate`, which now defaults to `true`. Trust the PVE CA via `certificateMap`, or set it to `false`
+- Verify the Proxmox host is reachable from the VM API pod on `Proxmox__Port` (`8006` direct, `443` behind a reverse proxy)
+- Check the API token format: `PVEAPIToken=USER@REALM!TOKENID=UUID`
+- A warning that `StateRefreshIntervalSeconds` "would busy-loop" means the value is unset or below `1`; set `Proxmox__StateRefreshIntervalSeconds`
 
 ### Authentication Issues
 - Verify all OAuth clients are registered in identity provider

--- a/charts/player/README.md
+++ b/charts/player/README.md
@@ -386,6 +386,22 @@ vm-api:
 
 Each entry follows the standard Kubernetes [`envFrom`](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables) spec and supports both `secretRef` and `configMapRef`.
 
+### Extra Volumes
+
+`extraVolumes` and `extraVolumeMounts` are stringified YAML appended to the VM API pod's volumes and the container's volume mounts, for anything the chart does not create itself. See [ISO Storage](#iso-storage-optional) for the two cases that need them: a second NFS export when vSphere and Proxmox write to different shares, and scratch space for API-mode ISO staging.
+
+```yaml
+vm-api:
+  extraVolumes: |
+    - name: "my-vol"
+      nfs:
+        server: "nfs.example.com"
+        path: "/exports/example"
+  extraVolumeMounts: |
+    - name: "my-vol"
+      mountPath: /app/example
+```
+
 ### Player API Integration
 
 VM API needs to communicate to the Crucible [VM API](https://github.com/cmu-sei/vm.Api) application via a Resource Owner OAuth Flow for API-to-API communication using a service account. Use the following settings to configure the Resource Owner flow.
@@ -435,6 +451,8 @@ VM API supports connection to multiple vSphere instances. Use the following sett
 - Datastore should be NFS for ease of access
 - Format: `<DATASTORE>/player/` (if BaseFolder is provided)
 
+vSphere ISO support is configured separately — see [ISO Upload](#iso-upload) for `Vsphere__IsoRoot` and `Vsphere__UploadViaApi`.
+
 #### Console Proxy (Optional)
 
 For proxying VM console connections through nginx ingress:
@@ -466,9 +484,70 @@ vm-api:
 - Additional security layer for consoles
 - Centralized TLS termination
 
+#### ISO Upload
+
+Every ISO upload runs through the same pipeline before it reaches a hypervisor:
+
+| Setting | Description | Example |
+|-----------|-------------|---------|
+| `IsoUpload__MaxFileSize` | Largest ISO accepted, in bytes | `6000000000` |
+| `IsoUpload__TempStagingPath` | Where a local copy of the ISO is staged in *API mode* (see below). Empty uses the system temp path, which is the pod's own filesystem | `""` |
+| `IsoUpload__UploadTimeoutMinutes` | Timeout in minutes for an API-mode upload. Values of `0` or less fall back to 60 | `60` |
+
+> [!IMPORTANT]
+> **Renamed in VM API 3.9.0.** Where an ISO ends up is now a per-hypervisor setting, so two keys moved:
+>
+> | Old | New |
+> |---|---|
+> | `IsoUpload__BasePath` | `Vsphere__IsoRoot` |
+> | `IsoUpload__UploadToDatastore` | `Vsphere__UploadViaApi` |
+>
+> The old names are **ignored, not mapped forward**. An override still using them leaves ISO upload
+> misconfigured on a pod that otherwise starts and serves traffic normally; the API logs an error at
+> startup naming the variable to set. This chart also fixes a long-standing typo — `IsoUpload_MaxFileSize`
+> (one underscore) never reached the API, so any deployment that set it was silently running the default
+> `MaxFileSize`.
+
+**Where the bytes go — directory mode vs API mode.** Each hypervisor has its own `IsoRoot` and its own
+`UploadViaApi` flag:
+
+*vSphere:*
+
+| Setting | Description | Example |
+|-----------|-------------|---------|
+| `Vsphere__IsoRoot` | Directory ISOs are written to. Must be on an export that is also a vCenter NFS datastore | `"/app/isos/player"` |
+| `Vsphere__UploadViaApi` | Stream ISOs to the datastore through vSphere instead of writing to `IsoRoot` | `false` |
+
+*Proxmox:*
+
+| Setting | Description | Example |
+|-----------|-------------|---------|
+| `Proxmox__IsoStorage` | PVE storage id that holds Player-managed ISOs. Setting it turns Proxmox ISO support on; clearing it turns it off | `"nfs-isos"` |
+| `Proxmox__IsoRoot` | Directory ISOs are written to. Must be a mount of `IsoStorage`'s **`template/iso`** directory — the layout PVE imposes on every storage that accepts ISO images | `"/app/isos/proxmox"` |
+| `Proxmox__UploadViaApi` | Push ISOs through the PVE storage API instead of writing to `IsoRoot` | `false` |
+| `Proxmox__IsoScopeSeparator` | Separator that keeps one View's or team's ISOs distinct from another's inside the storage | `"__"` |
+
+**Directory mode** (`UploadViaApi: false`, the default) writes straight through to a share the hypervisor
+also reads, and stages nothing. It needs an NFS mount, which is what the `iso` volume below provides.
+
+**API mode** (`UploadViaApi: true`) needs no share. On vSphere it is intended for VMware Cloud on AWS
+SDDC environments, which only support vSAN and offer no NFS datastore; on Proxmox it pushes each ISO
+through the PVE storage API. Either way the ISO is first staged as a complete local file — the upload is
+streamed and needs a seekable source — so `IsoUpload__TempStagingPath` must have room for the largest ISO
+you accept. Left empty it stages in the pod's writable layer, which `resources` does not limit by default.
+
+Proxmox storage is a flat namespace, so an ISO's View or team is encoded into its filename using
+`Proxmox__IsoScopeSeparator`. Changing that value hides ISOs uploaded under the previous one.
+
+On vSphere, uploads and deletes fan out across all enabled, connected hosts; if some hosts fail the
+operation still reports success along with a failed-host count.
+
 #### ISO Storage (Optional)
 
-Mount NFS volume for ISO uploads:
+Directory mode needs an NFS volume the chart creates for you. `iso.mountPath` is where it lands in the
+pod, and each hypervisor's `IsoRoot` must point at, or under, that path.
+
+*vSphere only* — `path` is the export behind the vCenter NFS datastore:
 
 ```yaml
 vm-api:
@@ -477,21 +556,90 @@ vm-api:
     server: "nfs-server.example.com"
     path: "/exports/isos"
     size: "100Gi"
+    mountPath: "/app/isos/player" # the default
+  env:
+    Vsphere__IsoRoot: "/app/isos/player"
 ```
 
-#### ISO Upload
+*Proxmox only* — the same volume, repointed. `path` is the export behind `<IsoStorage>`'s `template/iso`
+directory, and `Proxmox__IsoRoot` matches `mountPath`. (`Vsphere__IsoRoot` keeps its default and is simply
+unused.)
 
-| Setting | Description | Example |
-|-----------|-------------|---------|
-| `IsoUpload__BasePath` | ISO upload base path | `"/app/isos/player"` |
-| `IsoUpload_MaxFileSize` | ISO upload max file size | `6000000000` |
-| `IsoUpload__UploadToDatastore` | Push uploaded ISOs straight to the vSphere datastore instead of writing them to `BasePath` | `false` |
-| `IsoUpload__TempStagingPath` | Directory used to stage the ISO before it streams to the datastore. Empty uses the system temp path. Only applies when `UploadToDatastore` is `true` | `""` |
-| `IsoUpload__UploadTimeoutMinutes` | Timeout in minutes for the ISO upload to the datastore. Values of `0` or less fall back to 60. Only applies when `UploadToDatastore` is `true` | `60` |
+```yaml
+vm-api:
+  iso:
+    enabled: true
+    server: "pve-nfs.example.com"
+    path: "/exports/pve-isos/template/iso"
+    size: "100Gi"
+    mountPath: "/app/isos/proxmox"
+  env:
+    Proxmox__IsoStorage: "nfs-isos"
+    Proxmox__IsoRoot: "/app/isos/proxmox"
+```
 
-**Datastore upload mode:** setting `IsoUpload__UploadToDatastore: true` streams uploaded ISOs to the vSphere datastore rather than writing them under `BasePath`. This is intended for VMware Cloud on AWS SDDC environments, which only support vSAN and offer no NFS datastore. The default of `false` leaves existing NFS deployments unchanged. `BasePath` is not read in this mode, so the `iso.enabled` NFS mount is not required.
+*Both, sharing one export* — possible when a single export is registered **both** as an NFS datastore in
+vCenter and as a storage in PVE. Mount its root and give each hypervisor a subpath; PVE ignores the
+`player/` subtree sitting beside its own `dump/`, `images/` and `template/`:
 
-In datastore mode the ISO is first staged as a local file (the upload is streamed to each host, which needs a seekable file), so the staging directory needs room for a full copy of the largest ISO you expect. The NFS path writes straight through and stages nothing, which is why `TempStagingPath` applies only to datastore mode. Uploads and deletes fan out across all enabled, connected hosts; if some hosts fail the operation still reports success along with a failed-host count.
+```yaml
+vm-api:
+  iso:
+    enabled: true
+    server: "nfs-server.example.com"
+    path: "/exports/isos"
+    size: "100Gi"
+    mountPath: "/app/isos"
+  env:
+    Vsphere__IsoRoot: "/app/isos/player"
+    Proxmox__IsoRoot: "/app/isos/template/iso"
+    Proxmox__IsoStorage: "nfs-isos"
+```
+
+*Both, on separate exports* — the `iso` volume serves one hypervisor and `extraVolumes` adds the second
+export for the other:
+
+```yaml
+vm-api:
+  iso:
+    enabled: true
+    server: "nfs-server.example.com"
+    path: "/exports/isos"
+    size: "100Gi"
+    mountPath: "/app/isos/player"
+  extraVolumes: |
+    - name: "pve-iso-vol"
+      nfs:
+        server: "pve-nfs.example.com"
+        path: "/exports/pve-isos/template/iso"
+  extraVolumeMounts: |
+    - name: "pve-iso-vol"
+      mountPath: /app/isos/proxmox
+  env:
+    Vsphere__IsoRoot: "/app/isos/player"
+    Proxmox__IsoStorage: "nfs-isos"
+    Proxmox__IsoRoot: "/app/isos/proxmox"
+```
+
+*API mode* — no ISO volume at all, but give the staged copy somewhere sized for it:
+
+```yaml
+vm-api:
+  iso:
+    enabled: false
+  extraVolumes: |
+    - name: "iso-staging-vol"
+      emptyDir:
+        sizeLimit: "8Gi"
+  extraVolumeMounts: |
+    - name: "iso-staging-vol"
+      mountPath: /app/iso-staging
+  env:
+    IsoUpload__TempStagingPath: "/app/iso-staging"
+    Vsphere__UploadViaApi: true
+    Proxmox__UploadViaApi: true
+    Proxmox__IsoStorage: "vsan-isos"
+```
 
 **ISO deletion:** the VM UI Files tab can now delete and list ISOs, not just upload them. Deletion is gated by three permissions Player API adds in 3.6.0, seeded by database migration and each covering a different scope:
 
@@ -535,6 +683,8 @@ VM API supports Proxmox VE as an alternative to vSphere. Authentication uses a P
 | `Proxmox__FileUploadMaxBytes` | Maximum guest file upload payload in bytes | `61440` |
 | `Proxmox__GuestProcessPollMs` | Guest process status polling interval in milliseconds | `500` |
 | `Proxmox__GuestProcessDefaultTimeoutSeconds` | Default guest process timeout in seconds | `300` |
+
+Proxmox ISO support is configured separately — see [ISO Upload](#iso-upload) for `Proxmox__IsoStorage`, `Proxmox__IsoRoot`, `Proxmox__UploadViaApi` and `Proxmox__IsoScopeSeparator`, and [ISO Storage](#iso-storage-optional) for the volume each mode needs.
 
 **TLS verification (upgrade note):** `Proxmox__ValidateCertificate` defaults to `true`. Earlier VM API versions did not verify the Proxmox certificate at all, so a PVE host serving its stock self-signed certificate worked without any configuration. It no longer does. Either trust the PVE certificate authority by pointing `vm-api.certificateMap` at a ConfigMap containing the CA bundle (see the VM API *Certificate Trust* section above), or set `Proxmox__ValidateCertificate: false` to keep the previous behavior.
 
@@ -772,10 +922,12 @@ player-ui:
 
 ### ISO Upload Failures
 - Check `proxy-body-size` annotation is set depending on your ISO size needs
-- Verify NFS mount is accessible if using `iso.enabled`
-- Ensure vCenter datastore has sufficient space
-- Check file permissions on datastore
-- In datastore upload mode (`IsoUpload__UploadToDatastore: true`), raise `IsoUpload__UploadTimeoutMinutes` for large ISOs on slow links, and confirm `IsoUpload__TempStagingPath` has room for a full copy of the ISO
+- Verify NFS mount is accessible if using `iso.enabled`, and that `iso.mountPath` agrees with the `IsoRoot` of each hypervisor using it
+- If an override still sets `IsoUpload__BasePath` or `IsoUpload__UploadToDatastore`, it is being ignored — see the renamed keys under *ISO Upload* above. The VM API logs an error at startup naming the variable to set
+- "Proxmox:IsoRoot is required" means directory mode is on with no mount configured. Point `Proxmox__IsoRoot` at a mount of `<Proxmox__IsoStorage>`'s `template/iso` directory, or set `Proxmox__UploadViaApi: true`
+- Ensure the vCenter datastore or PVE storage has sufficient space
+- Check file permissions on the datastore or export
+- In API mode (`UploadViaApi: true`), raise `IsoUpload__UploadTimeoutMinutes` for large ISOs on slow links, and confirm `IsoUpload__TempStagingPath` has room for a full copy of the ISO
 - A "failed on N of M hosts" message means the ISO reached some hosts but not others; check the VM API logs for which hosts failed
 - Missing delete buttons in the Files tab usually mean the user's role lacks `DeleteIsos`, `DeleteViewIsos`, or `DeleteTeamIsos`
 

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.9.4
-appVersion: 3.4.7
+version: 1.10.0
+appVersion: 3.5.0

--- a/charts/player/charts/console-ui/Chart.yaml
+++ b/charts/player/charts/console-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console-ui
 type: application
-version: 1.10.0
+version: 1.9.5
 appVersion: 3.5.0

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.9.1
+version: 1.10.0
 appVersion: 3.9.0

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: vm-api
 type: application
 version: 1.10.0
-appVersion: 3.9.0
+appVersion: 3.10.0

--- a/charts/player/charts/vm-api/Chart.yaml
+++ b/charts/player/charts/vm-api/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-api
 type: application
-version: 1.9.0
+version: 1.9.1
 appVersion: 3.9.0

--- a/charts/player/charts/vm-api/templates/_helpers.tpl
+++ b/charts/player/charts/vm-api/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolve extraVolumeMounts value
+*/}}
+{{- define "vm-api.extraVolumeMounts" -}}
+{{ tpl (default "" .Values.extraVolumeMounts) . }}
+{{- end -}}
+
+{{/*
+Resolve extraVolumes value
+*/}}
+{{- define "vm-api.extraVolumes" -}}
+{{ tpl (default "" .Values.extraVolumes) . }}
+{{- end -}}

--- a/charts/player/charts/vm-api/templates/deployment.yaml
+++ b/charts/player/charts/vm-api/templates/deployment.yaml
@@ -93,8 +93,9 @@ spec:
           {{- end }}
           {{ if .Values.iso.enabled }}
             - name: {{ include "vm-api.fullname" . }}-iso
-              mountPath: /app/isos/player
+              mountPath: {{ .Values.iso.mountPath }}
           {{- end }}
+          {{- include "vm-api.extraVolumeMounts" . | nindent 12 }}
 
       volumes:
       {{ if .Values.certificateMap }}
@@ -107,6 +108,7 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "vm-api.fullname" . }}-iso
       {{- end }}
+      {{- include "vm-api.extraVolumes" . | nindent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -189,9 +189,9 @@ env:
   ClaimsTransformation__EnableCaching: true
   ClaimsTransformation__CacheExpirationSeconds: 60
 
-  IsoUpload__BasePath: "/app/isos/player"
-  IsoUpload_MaxFileSize: 6000000000
-  IsoUpload__UploadToDatastore: false
+  # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
+  # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
+  IsoUpload__MaxFileSize: 6000000000
   IsoUpload__TempStagingPath: ""
   IsoUpload__UploadTimeoutMinutes: 60
 
@@ -207,6 +207,10 @@ env:
   ClientSettings__urls__playerApi: ""
 
   Vsphere__Host: ""
+  # Where vSphere ISOs are written. IsoRoot is the mount of the iso volume above; set UploadViaApi
+  # true instead where there is no NFS datastore to mount (VMware Cloud on AWS).
+  Vsphere__IsoRoot: "/app/isos/player"
+  Vsphere__UploadViaApi: false
   Vsphere__Username: ""
   Vsphere__Password: ""
   Vsphere__DsName: ""
@@ -258,3 +262,8 @@ env:
   Proxmox__FileUploadMaxBytes: 61440
   Proxmox__GuestProcessPollMs: 500
   Proxmox__GuestProcessDefaultTimeoutSeconds: 300
+  # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
+  Proxmox__IsoStorage: ""
+  Proxmox__UploadViaApi: false
+  Proxmox__IsoRoot: ""
+  Proxmox__IsoScopeSeparator: "__"

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -246,6 +246,15 @@ env:
   Vsphere__TaskInfoUnavailableTimeoutSeconds: 30
   Vsphere__GuestProcessTempPath: ""
   Vsphere__GuestProcessDefaultTimeoutSeconds: 300
+  # Proxmox VE. Can be configured alongside vSphere in the same instance.
+  Proxmox__Enabled: false
+  Proxmox__Host: ""
+  Proxmox__Port: 8006
+  Proxmox__Token: ""
+  Proxmox__ValidateCertificate: true
+  Proxmox__StateRefreshIntervalSeconds: 5
+  Proxmox__CheckTaskProgressIntervalMilliseconds: 5000
+  Proxmox__ReCheckTaskProgressIntervalMilliseconds: 1000
   Proxmox__FileUploadMaxBytes: 61440
   Proxmox__GuestProcessPollMs: 500
   Proxmox__GuestProcessDefaultTimeoutSeconds: 300

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -46,7 +46,7 @@ tolerations: []
 affinity: {}
 
 # iso - an NFS volume mount for ISO uploads, used when a hypervisor writes ISOs directly to a
-# share rather than pushing them through its API (Vsphere__UploadViaApi / Proxmox__UploadViaApi
+# share rather than pushing them through its API (Vsphere__IsoUploadViaApi / Proxmox__IsoUploadViaApi
 # false). Point mountPath at, or above, the ISO root(s) configured in env below:
 #   vSphere only  - mountPath /app/isos/player, path being the export behind the vCenter datastore
 #   Proxmox only  - mountPath /app/isos/proxmox, path being the export behind <IsoStorage>/template/iso,
@@ -156,7 +156,7 @@ certificateMap: ""
 #   - name: "pve-iso-vol"
 #     mountPath: /app/isos/proxmox
 #
-# Example use to give Vsphere__UploadViaApi / Proxmox__UploadViaApi somewhere to stage the
+# Example use to give Vsphere__IsoUploadViaApi / Proxmox__IsoUploadViaApi somewhere to stage the
 # local copy they make of each ISO. Size it for the largest ISO you expect to accept
 # (IsoUpload__MaxFileSize) and point IsoUpload__TempStagingPath at the mountPath, otherwise
 # that copy is written to the pod's filesystem:
@@ -232,9 +232,9 @@ env:
   ClaimsTransformation__CacheExpirationSeconds: 60
 
   # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
-  # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
+  # Vsphere__IsoUploadViaApi below, and Proxmox__IsoRoot / Proxmox__IsoUploadViaApi.
   IsoUpload__MaxFileSize: 6000000000
-  # Where UploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
+  # Where IsoUploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
   # which is the pod's own filesystem; see extraVolumes above for mounting scratch space instead.
   IsoUpload__TempStagingPath: ""
   IsoUpload__UploadTimeoutMinutes: 60
@@ -252,10 +252,15 @@ env:
 
   Vsphere__Host: ""
   # Where vSphere ISOs are written. IsoRoot is a path under the iso volume's mountPath above, on an
-  # export that is also a vCenter NFS datastore; set UploadViaApi true instead where there is no
+  # export that is also a vCenter NFS datastore; set IsoUploadViaApi true instead where there is no
   # such datastore to mount (VMware Cloud on AWS), and no iso volume is needed.
+  #
+  # Both modes use one datastore layout: "[<DsName>] <BaseFolder>/<viewId>/<scopeId>/<file>.iso", written
+  # to every enabled host in API mode. Listing browses the datastore in BOTH modes, so IsoRoot has to be
+  # the directory that surfaces at "[<DsName>] <BaseFolder>" or uploads succeed and then list empty.
+  # See the ISO Upload section of the player chart README.
   Vsphere__IsoRoot: "/app/isos/player"
-  Vsphere__UploadViaApi: false
+  Vsphere__IsoUploadViaApi: false
   Vsphere__Username: ""
   Vsphere__Password: ""
   Vsphere__DsName: ""
@@ -310,11 +315,11 @@ env:
   # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
   # It names a PVE storage that accepts ISO images, and IsoRoot must be a mount of that same storage's
   # template/iso directory - the layout PVE itself imposes, so an NFS export of it is mounted as e.g.
-  # /app/isos/proxmox via the iso volume above. Set UploadViaApi true to push each ISO through the PVE
+  # /app/isos/proxmox via the iso volume above. Set IsoUploadViaApi true to push each ISO through the PVE
   # API instead, which needs no mount but stages a local copy first (IsoUpload__TempStagingPath).
   # Proxmox storage is a flat namespace, so IsoScopeSeparator is what keeps one View or team's ISOs
   # distinct from another's within it; changing it hides ISOs uploaded under the previous value.
   Proxmox__IsoStorage: ""
-  Proxmox__UploadViaApi: false
+  Proxmox__IsoUploadViaApi: false
   Proxmox__IsoRoot: ""
   Proxmox__IsoScopeSeparator: "__"

--- a/charts/player/charts/vm-api/values.yaml
+++ b/charts/player/charts/vm-api/values.yaml
@@ -45,12 +45,21 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
-# iso - an NFS volume mount for ISO uploads
+# iso - an NFS volume mount for ISO uploads, used when a hypervisor writes ISOs directly to a
+# share rather than pushing them through its API (Vsphere__UploadViaApi / Proxmox__UploadViaApi
+# false). Point mountPath at, or above, the ISO root(s) configured in env below:
+#   vSphere only  - mountPath /app/isos/player, path being the export behind the vCenter datastore
+#   Proxmox only  - mountPath /app/isos/proxmox, path being the export behind <IsoStorage>/template/iso,
+#                   and set Proxmox__IsoRoot to the same mountPath
+#   both, one export registered in vCenter *and* PVE - mountPath /app/isos, with
+#                   Vsphere__IsoRoot /app/isos/player and Proxmox__IsoRoot /app/isos/template/iso
+# Two separate exports need a second volume; see extraVolumes below.
 iso:
   enabled: false
   size: ""
   server: ""
   path: ""
+  mountPath: "/app/isos/player"
 
 probes:
   livenessProbe:
@@ -133,6 +142,39 @@ consoleIngress:
 # the configMap name here
 certificateMap: ""
 
+## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
+# Example use to add a second ISO share, when vSphere and Proxmox write to different NFS
+# exports (the iso volume above serves the first one):
+#
+# extraVolumes: |
+#   - name: "pve-iso-vol"
+#     nfs:
+#       server: "pve-nfs.example.com"
+#       path: "/exports/pve-iso/template/iso"
+#
+# extraVolumeMounts: |
+#   - name: "pve-iso-vol"
+#     mountPath: /app/isos/proxmox
+#
+# Example use to give Vsphere__UploadViaApi / Proxmox__UploadViaApi somewhere to stage the
+# local copy they make of each ISO. Size it for the largest ISO you expect to accept
+# (IsoUpload__MaxFileSize) and point IsoUpload__TempStagingPath at the mountPath, otherwise
+# that copy is written to the pod's filesystem:
+#
+# extraVolumes: |
+#   - name: "iso-staging-vol"
+#     emptyDir:
+#       sizeLimit: "8Gi"
+#
+# extraVolumeMounts: |
+#   - name: "iso-staging-vol"
+#     mountPath: /app/iso-staging
+#
+# See kubernetes documentation for configuring your volumes:
+# https://kubernetes.io/docs/concepts/storage/volumes/
+extraVolumeMounts: ""
+extraVolumes: ""
+
 command: ["dotnet", "Player.Vm.Api.dll"]
 
 ## existingSecret references a secret already in k8s.
@@ -192,6 +234,8 @@ env:
   # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
   # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
   IsoUpload__MaxFileSize: 6000000000
+  # Where UploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
+  # which is the pod's own filesystem; see extraVolumes above for mounting scratch space instead.
   IsoUpload__TempStagingPath: ""
   IsoUpload__UploadTimeoutMinutes: 60
 
@@ -207,8 +251,9 @@ env:
   ClientSettings__urls__playerApi: ""
 
   Vsphere__Host: ""
-  # Where vSphere ISOs are written. IsoRoot is the mount of the iso volume above; set UploadViaApi
-  # true instead where there is no NFS datastore to mount (VMware Cloud on AWS).
+  # Where vSphere ISOs are written. IsoRoot is a path under the iso volume's mountPath above, on an
+  # export that is also a vCenter NFS datastore; set UploadViaApi true instead where there is no
+  # such datastore to mount (VMware Cloud on AWS), and no iso volume is needed.
   Vsphere__IsoRoot: "/app/isos/player"
   Vsphere__UploadViaApi: false
   Vsphere__Username: ""
@@ -263,6 +308,12 @@ env:
   Proxmox__GuestProcessPollMs: 500
   Proxmox__GuestProcessDefaultTimeoutSeconds: 300
   # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
+  # It names a PVE storage that accepts ISO images, and IsoRoot must be a mount of that same storage's
+  # template/iso directory - the layout PVE itself imposes, so an NFS export of it is mounted as e.g.
+  # /app/isos/proxmox via the iso volume above. Set UploadViaApi true to push each ISO through the PVE
+  # API instead, which needs no mount but stages a local copy first (IsoUpload__TempStagingPath).
+  # Proxmox storage is a flat namespace, so IsoScopeSeparator is what keeps one View or team's ISOs
+  # distinct from another's within it; changing it hides ISOs uploaded under the previous value.
   Proxmox__IsoStorage: ""
   Proxmox__UploadViaApi: false
   Proxmox__IsoRoot: ""

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.11.0
+version: 1.10.1
 appVersion: 3.8.0

--- a/charts/player/charts/vm-ui/Chart.yaml
+++ b/charts/player/charts/vm-ui/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: vm-ui
 type: application
-version: 1.10.0
-appVersion: 3.7.0
+version: 1.11.0
+appVersion: 3.8.0

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -649,7 +649,7 @@ vm-api:
     # Both modes use one datastore layout: "[<DsName>] <BaseFolder>/<viewId>/<scopeId>/<file>.iso", written
     # to every enabled host in API mode. Listing browses the datastore in BOTH modes, so IsoRoot has to be
     # the directory that surfaces at "[<DsName>] <BaseFolder>" or uploads succeed and then list empty.
-    # See the ISO Upload section of this chart's README.
+    # See the ISO Upload section of the player chart README.
     Vsphere__IsoRoot: "/app/isos/player"
     Vsphere__IsoUploadViaApi: false
     Vsphere__Username: ""

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -580,9 +580,9 @@ vm-api:
     ClaimsTransformation__EnableCaching: true
     ClaimsTransformation__CacheExpirationSeconds: 60
 
-    IsoUpload__BasePath: "/app/isos/player"
-    IsoUpload_MaxFileSize: 6000000000
-    IsoUpload__UploadToDatastore: false
+    # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
+    # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
+    IsoUpload__MaxFileSize: 6000000000
     IsoUpload__TempStagingPath: ""
     IsoUpload__UploadTimeoutMinutes: 60
 
@@ -598,6 +598,10 @@ vm-api:
     ClientSettings__urls__playerApi: ""
 
     Vsphere__Host: ""
+    # Where vSphere ISOs are written. IsoRoot is the mount of the iso volume above; set UploadViaApi
+    # true instead where there is no NFS datastore to mount (VMware Cloud on AWS).
+    Vsphere__IsoRoot: "/app/isos/player"
+    Vsphere__UploadViaApi: false
     Vsphere__Username: ""
     Vsphere__Password: ""
     Vsphere__DsName: ""
@@ -649,6 +653,11 @@ vm-api:
     Proxmox__FileUploadMaxBytes: 61440
     Proxmox__GuestProcessPollMs: 500
     Proxmox__GuestProcessDefaultTimeoutSeconds: 300
+    # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
+    Proxmox__IsoStorage: ""
+    Proxmox__UploadViaApi: false
+    Proxmox__IsoRoot: ""
+    Proxmox__IsoScopeSeparator: "__"
 vm-ui:
   image:
     repository: cmusei/vm-ui

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -436,12 +436,21 @@ vm-api:
   tolerations: []
   affinity: {}
 
-  # iso - an NFS volume mount for ISO uploads
+  # iso - an NFS volume mount for ISO uploads, used when a hypervisor writes ISOs directly to a
+  # share rather than pushing them through its API (Vsphere__UploadViaApi / Proxmox__UploadViaApi
+  # false). Point mountPath at, or above, the ISO root(s) configured in env below:
+  #   vSphere only  - mountPath /app/isos/player, path being the export behind the vCenter datastore
+  #   Proxmox only  - mountPath /app/isos/proxmox, path being the export behind <IsoStorage>/template/iso,
+  #                   and set Proxmox__IsoRoot to the same mountPath
+  #   both, one export registered in vCenter *and* PVE - mountPath /app/isos, with
+  #                   Vsphere__IsoRoot /app/isos/player and Proxmox__IsoRoot /app/isos/template/iso
+  # Two separate exports need a second volume; see extraVolumes below.
   iso:
     enabled: false
     size: ""
     server: ""
     path: ""
+    mountPath: "/app/isos/player"
 
   probes:
     livenessProbe:
@@ -524,6 +533,39 @@ vm-api:
   # the configMap name here
   certificateMap: ""
 
+  ## extraVolumeMounts and Volumes is stringified YAML of kubernetes volume definitions
+  # Example use to add a second ISO share, when vSphere and Proxmox write to different NFS
+  # exports (the iso volume above serves the first one):
+  #
+  # extraVolumes: |
+  #   - name: "pve-iso-vol"
+  #     nfs:
+  #       server: "pve-nfs.example.com"
+  #       path: "/exports/pve-iso/template/iso"
+  #
+  # extraVolumeMounts: |
+  #   - name: "pve-iso-vol"
+  #     mountPath: /app/isos/proxmox
+  #
+  # Example use to give Vsphere__UploadViaApi / Proxmox__UploadViaApi somewhere to stage the
+  # local copy they make of each ISO. Size it for the largest ISO you expect to accept
+  # (IsoUpload__MaxFileSize) and point IsoUpload__TempStagingPath at the mountPath, otherwise
+  # that copy is written to the pod's filesystem:
+  #
+  # extraVolumes: |
+  #   - name: "iso-staging-vol"
+  #     emptyDir:
+  #       sizeLimit: "8Gi"
+  #
+  # extraVolumeMounts: |
+  #   - name: "iso-staging-vol"
+  #     mountPath: /app/iso-staging
+  #
+  # See kubernetes documentation for configuring your volumes:
+  # https://kubernetes.io/docs/concepts/storage/volumes/
+  extraVolumeMounts: ""
+  extraVolumes: ""
+
   command: ["dotnet", "Player.Vm.Api.dll"]
 
   ## existingSecret references a secret already in k8s.
@@ -583,6 +625,8 @@ vm-api:
     # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
     # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
     IsoUpload__MaxFileSize: 6000000000
+    # Where UploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
+    # which is the pod's own filesystem; see extraVolumes above for mounting scratch space instead.
     IsoUpload__TempStagingPath: ""
     IsoUpload__UploadTimeoutMinutes: 60
 
@@ -598,8 +642,9 @@ vm-api:
     ClientSettings__urls__playerApi: ""
 
     Vsphere__Host: ""
-    # Where vSphere ISOs are written. IsoRoot is the mount of the iso volume above; set UploadViaApi
-    # true instead where there is no NFS datastore to mount (VMware Cloud on AWS).
+    # Where vSphere ISOs are written. IsoRoot is a path under the iso volume's mountPath above, on an
+    # export that is also a vCenter NFS datastore; set UploadViaApi true instead where there is no
+    # such datastore to mount (VMware Cloud on AWS), and no iso volume is needed.
     Vsphere__IsoRoot: "/app/isos/player"
     Vsphere__UploadViaApi: false
     Vsphere__Username: ""
@@ -654,10 +699,17 @@ vm-api:
     Proxmox__GuestProcessPollMs: 500
     Proxmox__GuestProcessDefaultTimeoutSeconds: 300
     # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
+    # It names a PVE storage that accepts ISO images, and IsoRoot must be a mount of that same storage's
+    # template/iso directory - the layout PVE itself imposes, so an NFS export of it is mounted as e.g.
+    # /app/isos/proxmox via the iso volume above. Set UploadViaApi true to push each ISO through the PVE
+    # API instead, which needs no mount but stages a local copy first (IsoUpload__TempStagingPath).
+    # Proxmox storage is a flat namespace, so IsoScopeSeparator is what keeps one View or team's ISOs
+    # distinct from another's within it; changing it hides ISOs uploaded under the previous value.
     Proxmox__IsoStorage: ""
     Proxmox__UploadViaApi: false
     Proxmox__IsoRoot: ""
     Proxmox__IsoScopeSeparator: "__"
+
 vm-ui:
   image:
     repository: cmusei/vm-ui

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -637,6 +637,15 @@ vm-api:
     Vsphere__TaskInfoUnavailableTimeoutSeconds: 30
     Vsphere__GuestProcessTempPath: ""
     Vsphere__GuestProcessDefaultTimeoutSeconds: 300
+    # Proxmox VE. Can be configured alongside vSphere in the same instance.
+    Proxmox__Enabled: false
+    Proxmox__Host: ""
+    Proxmox__Port: 8006
+    Proxmox__Token: ""
+    Proxmox__ValidateCertificate: true
+    Proxmox__StateRefreshIntervalSeconds: 5
+    Proxmox__CheckTaskProgressIntervalMilliseconds: 5000
+    Proxmox__ReCheckTaskProgressIntervalMilliseconds: 1000
     Proxmox__FileUploadMaxBytes: 61440
     Proxmox__GuestProcessPollMs: 500
     Proxmox__GuestProcessDefaultTimeoutSeconds: 300

--- a/charts/player/values.yaml
+++ b/charts/player/values.yaml
@@ -437,7 +437,7 @@ vm-api:
   affinity: {}
 
   # iso - an NFS volume mount for ISO uploads, used when a hypervisor writes ISOs directly to a
-  # share rather than pushing them through its API (Vsphere__UploadViaApi / Proxmox__UploadViaApi
+  # share rather than pushing them through its API (Vsphere__IsoUploadViaApi / Proxmox__IsoUploadViaApi
   # false). Point mountPath at, or above, the ISO root(s) configured in env below:
   #   vSphere only  - mountPath /app/isos/player, path being the export behind the vCenter datastore
   #   Proxmox only  - mountPath /app/isos/proxmox, path being the export behind <IsoStorage>/template/iso,
@@ -547,7 +547,7 @@ vm-api:
   #   - name: "pve-iso-vol"
   #     mountPath: /app/isos/proxmox
   #
-  # Example use to give Vsphere__UploadViaApi / Proxmox__UploadViaApi somewhere to stage the
+  # Example use to give Vsphere__IsoUploadViaApi / Proxmox__IsoUploadViaApi somewhere to stage the
   # local copy they make of each ISO. Size it for the largest ISO you expect to accept
   # (IsoUpload__MaxFileSize) and point IsoUpload__TempStagingPath at the mountPath, otherwise
   # that copy is written to the pod's filesystem:
@@ -623,9 +623,9 @@ vm-api:
     ClaimsTransformation__CacheExpirationSeconds: 60
 
     # The shared ISO upload pipeline. Where the bytes end up is per-provider: Vsphere__IsoRoot /
-    # Vsphere__UploadViaApi below, and Proxmox__IsoRoot / Proxmox__UploadViaApi.
+    # Vsphere__IsoUploadViaApi below, and Proxmox__IsoRoot / Proxmox__IsoUploadViaApi.
     IsoUpload__MaxFileSize: 6000000000
-    # Where UploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
+    # Where IsoUploadViaApi stages its local copy of each ISO. Empty means the system temp directory,
     # which is the pod's own filesystem; see extraVolumes above for mounting scratch space instead.
     IsoUpload__TempStagingPath: ""
     IsoUpload__UploadTimeoutMinutes: 60
@@ -643,10 +643,15 @@ vm-api:
 
     Vsphere__Host: ""
     # Where vSphere ISOs are written. IsoRoot is a path under the iso volume's mountPath above, on an
-    # export that is also a vCenter NFS datastore; set UploadViaApi true instead where there is no
+    # export that is also a vCenter NFS datastore; set IsoUploadViaApi true instead where there is no
     # such datastore to mount (VMware Cloud on AWS), and no iso volume is needed.
+    #
+    # Both modes use one datastore layout: "[<DsName>] <BaseFolder>/<viewId>/<scopeId>/<file>.iso", written
+    # to every enabled host in API mode. Listing browses the datastore in BOTH modes, so IsoRoot has to be
+    # the directory that surfaces at "[<DsName>] <BaseFolder>" or uploads succeed and then list empty.
+    # See the ISO Upload section of this chart's README.
     Vsphere__IsoRoot: "/app/isos/player"
-    Vsphere__UploadViaApi: false
+    Vsphere__IsoUploadViaApi: false
     Vsphere__Username: ""
     Vsphere__Password: ""
     Vsphere__DsName: ""
@@ -701,12 +706,12 @@ vm-api:
     # View/team-scoped ISO storage. Set IsoStorage to turn Proxmox ISO support on; clear it to turn it off.
     # It names a PVE storage that accepts ISO images, and IsoRoot must be a mount of that same storage's
     # template/iso directory - the layout PVE itself imposes, so an NFS export of it is mounted as e.g.
-    # /app/isos/proxmox via the iso volume above. Set UploadViaApi true to push each ISO through the PVE
+    # /app/isos/proxmox via the iso volume above. Set IsoUploadViaApi true to push each ISO through the PVE
     # API instead, which needs no mount but stages a local copy first (IsoUpload__TempStagingPath).
     # Proxmox storage is a flat namespace, so IsoScopeSeparator is what keeps one View or team's ISOs
     # distinct from another's within it; changing it hides ISOs uploaded under the previous value.
     Proxmox__IsoStorage: ""
-    Proxmox__UploadViaApi: false
+    Proxmox__IsoUploadViaApi: false
     Proxmox__IsoRoot: ""
     Proxmox__IsoScopeSeparator: "__"
 


### PR DESCRIPTION
> [!IMPORTANT]
> **Use this PR for the release instead of the automated "Player VM API to x.y.z" PRs.** Those PRs bump `appVersion` alone and would land the new image without the configuration and documentation it needs — a Proxmox deployment on a self-signed certificate would break with no knob exposed to fix it, and ISO upload would break on every deployment overriding the renamed keys below. Close any that open as superseded by this one.
>
> All three application releases are now cut and the `appVersion` fields are set (see [Release checklist](#release-checklist)). Merging to `main` publishes these charts immediately via `release.yml`.

The three application releases this chart release carries:

- [Player VM API 3.10.0](https://github.com/cmu-sei/Vm.Api/releases/tag/3.10.0)
- [Player VM UI 3.8.0](https://github.com/cmu-sei/Vm.Ui/releases/tag/3.8.0)
- [Player Console UI 3.5.0](https://github.com/cmu-sei/Console.Ui/releases/tag/3.5.0)

## ⚠️ Breaking change — ISO upload configuration

Where an ISO ends up is now a per-hypervisor setting, so two keys moved out of the shared `IsoUpload` block. Renamed in `charts/player/charts/vm-api/values.yaml` and `charts/player/values.yaml`:

| Before | After |
| --- | --- |
| `IsoUpload__BasePath: "/app/isos/player"` | `Vsphere__IsoRoot: "/app/isos/player"` |
| `IsoUpload__UploadToDatastore` | `Vsphere__IsoUploadViaApi` |

**Any downstream `values.yaml` overriding those keys must be renamed before upgrading.** The old keys are ignored by the API, not mapped forward, so an un-migrated override leaves ISO upload broken while the pod otherwise starts and serves traffic normally. The API logs an error at startup naming the environment variable to set — including when the renamed key is only holding the chart's default while the override sits on the old name, which is exactly what an un-migrated upgrade looks like. `Vsphere__IsoRoot` keeps pointing at the existing `iso:` NFS volume mount, so a deployment that renames the keys and changes nothing else behaves as before.

Also fixed here: the pre-existing typo `IsoUpload_MaxFileSize` (one underscore) → `IsoUpload__MaxFileSize`. That key was never reaching the API, so any deployment relying on it was silently running the default `MaxFileSize`. Anything overriding it should confirm the intended value is actually set now that it takes effect.

## ⚠️ Breaking change — self-signed Proxmox hosts

`Proxmox__ValidateCertificate` now defaults to `true`.

Earlier VM API versions did not verify the Proxmox certificate at all — and because the key did not exist, an absent value *silently* bound to `false`. A PVE host serving its stock self-signed certificate therefore worked with no configuration. It no longer will.

Two ways forward:

- **Preferred:** trust the PVE certificate authority by pointing `vm-api.certificateMap` at a ConfigMap holding the CA bundle (see the VM API *Certificate Trust* section of the Player chart README).
- **Opt out:** set `Proxmox__ValidateCertificate: false` to keep the previous behavior.

## Summary

Two things, both needed by the same VM API release:

1. **Proxmox connection settings.** The chart exposed only three of the eleven `Proxmox__*` settings the API reads. All of them are surfaced now, with defaults matching the application's own `appsettings.json`.
2. **Proxmox ISO uploads, in both write modes.** The chart could only support vSphere directory-mode uploads: its single NFS volume was mounted at a hardcoded `/app/isos/player`, with no way to repoint it, add a second export, or provide staging space.

This also fixes a problem independent of either: `Proxmox__StateRefreshIntervalSeconds` was never surfaced and its C# property has no default, so it bound to `0`. The API clamps that to a **one second** poll against the PVE cluster. Setting it to `5` here fixes that for current deployments.

## ISO upload

Each hypervisor now owns its own ISO destination and its own write mode. New in `vm-api.env`:

| Setting | Description | Default |
|---|---|---|
| `Proxmox__IsoStorage` | PVE storage id holding Player-managed ISOs. Setting it turns Proxmox ISO support on; clearing it turns it off | `""` |
| `Proxmox__IsoRoot` | Directory ISOs are written to in directory mode. Must be a mount of `IsoStorage`'s **`template/iso`** directory — the layout PVE imposes on every storage that accepts ISO images | `""` |
| `Proxmox__IsoUploadViaApi` | Push ISOs through the PVE storage API instead of writing to `IsoRoot` | `false` |
| `Proxmox__IsoScopeSeparator` | Separator that keeps one View's or team's ISOs distinct inside the storage, which is a flat namespace. Changing it hides ISOs uploaded under the previous value | `"__"` |

`Proxmox__IsoRoot` is deliberately left empty. There is no correct default now that the mount is a deployment choice, and blank produces the API's actionable *"Proxmox:IsoRoot is required when Proxmox:IsoUploadViaApi is false"* error rather than silently writing ISOs into the pod's own filesystem where PVE will never see them.

### New chart values

- **`iso.mountPath`** (default `/app/isos/player`, i.e. the value that was hardcoded, so existing renders are unchanged). The chart-created NFS volume can now serve Proxmox instead of vSphere, or both at once when a single export is registered as an NFS datastore in vCenter *and* as a storage in PVE.
- **`extraVolumes` / `extraVolumeMounts`** — the same stringified-YAML passthrough `vm-ui`, `console-ui` and `player-ui` already have, added to `vm-api`. It covers the two arrangements the single volume cannot: a second NFS export when the two hypervisors write to different shares, and an `emptyDir` for API-mode staging.

### Modes

**Directory mode** (`IsoUploadViaApi: false`, the default) writes straight through to a share the hypervisor also reads, and stages nothing.

**API mode** (`IsoUploadViaApi: true`) needs no share — on vSphere it targets a vSAN-only SDDC with no NFS datastore, on Proxmox it pushes through the PVE storage API — but it first stages a complete local copy of the ISO, because the upload is streamed and needs a seekable source. With `IsoUpload__MaxFileSize` at 6 GB and `resources: {}` setting no `ephemeral-storage` limit, that copy lands in the pod's writable layer unless `IsoUpload__TempStagingPath` points at a mounted volume. Hence the `emptyDir` example.

Five worked topologies are documented under *ISO Storage* in the Player chart README: vSphere only, Proxmox only, both sharing one export, both on separate exports, and API mode.

### Where a vSphere ISO ends up

Previously undocumented anywhere, and a real configuration trap, so the README now states it. Both modes use one datastore layout:

```
[<Vsphere__Hosts__*__DsName>] <Vsphere__Hosts__*__BaseFolder>/<viewId>/<scopeId>/<filename>.iso
```

In API mode the ISO is pushed to **every enabled, connected host**, each through its own `DsName` and `BaseFolder`. In directory mode the same tree is written locally under `Vsphere__IsoRoot` — and because listing (and the mount picker) browses the vCenter datastore in *both* modes, `Vsphere__IsoRoot` has to be the directory that surfaces at `[<DsName>] <BaseFolder>`. A `Vsphere__IsoRoot` on a datastore but at some other path within it accepts uploads that then never appear in Player. A troubleshooting entry covers that symptom.

## Proxmox connection settings

New in the `player` chart's `vm-api.env`:

| Setting | Description | Default |
|---|---|---|
| `Proxmox__Enabled` | Enable the Proxmox VE backend | `false` |
| `Proxmox__Host` | Proxmox node hostname or IP address | `""` |
| `Proxmox__Port` | Proxmox API port. Use `443` when going through a reverse proxy | `8006` |
| `Proxmox__Token` | API token, format `PVEAPIToken=USER@REALM!TOKENID=UUID` | `""` |
| `Proxmox__ValidateCertificate` | Validate the Proxmox host's TLS certificate | `true` |
| `Proxmox__StateRefreshIntervalSeconds` | How often VM power state is reconciled from cluster resources. Values below `1` are clamped to `1` | `5` |
| `Proxmox__CheckTaskProgressIntervalMilliseconds` | Cluster task poll interval while no task is pending | `5000` |
| `Proxmox__ReCheckTaskProgressIntervalMilliseconds` | Cluster task poll interval while a task is still running | `1000` |

The existing `Proxmox__FileUploadMaxBytes`, `Proxmox__GuestProcessPollMs`, and `Proxmox__GuestProcessDefaultTimeoutSeconds` are unchanged. All values match the application defaults in VM API's `appsettings.json`.

## Also fixed

- **Proxmox connection settings were never in the `player` chart.** `Enabled`, `Host`, `Port`, and `Token` existed only as a commented example in the `crucible-apps` umbrella, even though the vSphere equivalents (`Vsphere__Host`, `Vsphere__Username`, `Vsphere__Password`, …) are surfaced in the chart with empty defaults. That asymmetry is closed.
- **The Player chart README's ISO documentation was stale and, after the rename, wrong.** Its table documented `IsoUpload__BasePath`, `IsoUpload__UploadToDatastore` and the `IsoUpload_MaxFileSize` typo, none of the per-provider keys were documented anywhere, and the "Datastore upload mode" prose was written in the old key names. Rewritten as a shared-pipeline table, per-provider tables, the rename note, the mode explanation, and the five topologies — cross-referenced from the vSphere and Proxmox configuration sections, with the ISO troubleshooting list updated to match.
- **`template/iso` was documented nowhere an operator would look.** That `Proxmox__IsoRoot` must be a mount of the storage's `template/iso` directory appeared only in C# comments and a runtime error message; the one operator-facing mention, in the API's `appsettings.json`, repeated the vSphere wording and described the wrong thing. Fixed in the chart README, the chart values comments, and [Vm.Api#81](https://github.com/cmu-sei/Vm.Api/pull/81).
- **The `crucible-apps` Proxmox example was stale** — it still showed `Proxmox__StateRefreshIntervalSeconds: 60` and no `ValidateCertificate`. It now also shows the ISO keys and the volume they need.
- **`crucible-apps` incorrectly claimed VM API supports one hypervisor at a time.** It said *"Player VM API can be configured for either vSphere OR Proxmox, not both simultaneously."* Both providers register unconditionally and each VM is routed to its own backend by provider type. Replaced with a note that both can be enabled together. (The equivalent claim in the TopoMojo chart is correct, since TopoMojo has a single `Pod__HypervisorType`, and is left alone.)
- Added a **Proxmox Connection Failures** troubleshooting subsection to the Player chart README, alongside the existing vSphere one.

## Chart versions

Each chart's `version` follows what changed *in that chart*, not the bump size of its `appVersion`:

| Chart | version | appVersion | Why |
|---|---|---|---|
| `player` (parent) | 1.11.0 → **1.12.0** | — | minor: carries `vm-api`'s breaking values renames |
| `vm-api` | 1.9.0 → **1.10.0** | 3.9.0 → **3.10.0** | minor: new values, renamed keys, template changes |
| `vm-ui` | 1.10.0 → **1.10.1** | 3.7.0 → **3.8.0** | patch: `appVersion` only, no chart content change |
| `console-ui` | 1.9.4 → **1.9.5** | 3.4.7 → **3.5.0** | patch: `appVersion` only, no chart content change |
| `crucible-apps` | 0.3.4 → **0.3.5** | — | patch: commented example values and README only |

Neither UI changes any configuration key — their entire diff against `main` is the two `Chart.yaml` lines — so they take patch bumps even though both applications released a minor version. Repo history doesn't tie the two: across all charts, a minor `appVersion` bump has been paired with a minor chart bump 45 times and a patch chart bump 46 times.

`crucible-apps` touches only commented-out example keys, so nothing an installed release renders changes.

`Chart.lock` and the pinned `player` dependency version in `crucible-apps` are untouched, and cannot be updated here. `update-crucible-umbrella.sh` resolves each pin from the *published* repo index and then runs `helm dependency update`, so pinning `player` 1.12.0 is only possible once this PR has merged and `release.yml` has published it — the latest published `player` is 1.11.0 today, and a pin to a chart absent from the index fails the dependency update.

> [!NOTE]
> **Follow-up after merge:** dispatch the **Update Crucible Umbrella Chart** workflow (`patch`) to advance the `player` pin 1.11.0 → 1.12.0 and refresh `Chart.lock`. Until that runs, `crucible-apps` 0.3.5 ships the new commented Proxmox and ISO examples while still pinning `player` 1.11.0. That is inert rather than broken — the examples are all commented out, and 1.11.0 pulls the older `vm-api` chart and image, on which the new keys would do nothing — but the umbrella's documentation is ahead of the chart it pins until the pin moves.

### Release checklist

All three application PRs shipped together — the ISO API contract changes, and both UIs consume the regenerated client.

- [x] [Vm.Api#81](https://github.com/cmu-sei/Vm.Api/pull/81) merged and [VM API 3.10.0](https://github.com/cmu-sei/Vm.Api/releases/tag/3.10.0) tagged
- [x] [Vm.Ui#590](https://github.com/cmu-sei/Vm.Ui/pull/590) merged and [VM UI 3.8.0](https://github.com/cmu-sei/Vm.Ui/releases/tag/3.8.0) tagged
- [x] [Console.Ui#743](https://github.com/cmu-sei/Console.Ui/pull/743) merged and [Console UI 3.5.0](https://github.com/cmu-sei/Console.Ui/releases/tag/3.5.0) tagged
- [x] `charts/player/charts/vm-api/Chart.yaml` — `appVersion` 3.10.0
- [x] `charts/player/charts/vm-ui/Chart.yaml` — `appVersion` 3.8.0, `version` 1.10.1
- [x] `charts/player/charts/console-ui/Chart.yaml` — `appVersion` 3.5.0, `version` 1.9.5
- [x] Add the release links to this PR body, as in b3ccecc
- [x] Close any automated "Player VM API / VM UI / Console UI to x.y.z" PRs as superseded by this one — none opened
- [ ] Mark ready for review
- [ ] *After merge:* dispatch **Update Crucible Umbrella Chart** to move the `crucible-apps` `player` pin to 1.12.0

The chart and the image are now in step, which the renamed ISO keys require: **this chart must not be released ahead of the VM API image**, since on 3.9.0 the old `IsoUpload__BasePath` no longer being set is what would break ISO upload. 3.10.0 reads every key set here.

## Verification

- `check-chart-versions.sh origin/main` → `SUCCESS: All modified charts have updated versions.`
- `check-readme-sync.sh origin/main` → `SUCCESS: No README sync reminders to emit.`
- `check-values-sync.py --base-ref origin/main` → `SUCCESS: All parent/child values are in sync.` (My container's trimmed Python lacks `difflib`, which the script imports only for diff output, so it ran with a stub on `PYTHONPATH`. The comparison itself is the script's own.)
- `helm template charts/player` renders all eleven `Proxmox__*` keys and all six ISO keys into the vm-api Secret.
- `helm template charts/player` renders `cmusei/vm-api:3.10.0`, `cmusei/vm-ui:3.8.0` and `cmusei/vm-console-ui:3.5.0`; all three tags are published on Docker Hub.
- The `Proxmox__*` and `Vsphere__Iso*` defaults in this chart match `appsettings.json` as released in 3.10.0. The one deliberate divergence is `Proxmox__IsoRoot`, left empty here where the application defaults it to `player/isos`, for the reason given above.
- Each of the five documented ISO topologies renders as documented — the repointed `mountPath`, a second NFS volume through `extraVolumes`, and the `emptyDir` with its `sizeLimit`.
- With the default values, the rendered vm-api Deployment is identical to `origin/main`'s apart from the renamed env keys and one blank line from the new `extraVolumes` include (the same artifact the UI charts' includes produce).
- `helm lint charts/player charts/crucible-apps` — no new findings. (`charts/player` reports missing `Chart.yaml` dependencies on `main` as well.)

End-to-end validation is not possible in this repo — no VM API image containing #81 exists yet. The application-side behavior is covered by Vm.Api#81's suite (244 tests) and validated against the local Aspire AppHost, whose `appsettings.json` carries these same defaults; this change mirrors them into helm.


